### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
 name: Deploy to Screeps PTR
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tadanobutubutu/screeps/security/code-scanning/1](https://github.com/tadanobutubutu/screeps/security/code-scanning/1)

In general, the fix is to explicitly declare the `permissions` for the `GITHUB_TOKEN` in the workflow, restricting them to the minimum required. Since this workflow only checks out code and runs a Node script with an external Screeps token, a sensible starting point is `contents: read` at the workflow root, which applies to all jobs unless overridden. If later the deploy script needs more GitHub privileges, they can be explicitly added.

The best minimal, non-breaking fix is to add a `permissions` section at the top level of `.github/workflows/deploy.yml`, just under the `name:` (and before `on:`), setting `contents: read`. This documents the required access and ensures the token will not accidentally have write permissions if organization defaults are broad or later changed. No imports or additional methods are needed because this is purely a YAML configuration change.

Concretely: edit `.github/workflows/deploy.yml` to insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Deploy to Screeps PTR`). All existing functionality (checkout, node setup, and `node deploy.js` with `SCREEPS_TOKEN`) will remain the same, while the `GITHUB_TOKEN` used by `actions/checkout` will be restricted to read-only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
