### PR TITLE
fix(security): implement stack trace sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-01 - Stack Trace Sanitization
+**Vulnerability:** Information leakage through full error stack traces.
+**Learning:** Screeps environments often log full error stacks which include absolute file paths. This reveals internal server directory structures.
+**Prevention:** Use a regex-based sanitizer like `getSafeStack` to strip absolute paths, keeping only filenames and line numbers for debugging without exposing sensitive infrastructure details.

--- a/main.js
+++ b/main.js
@@ -333,7 +333,9 @@ module.exports.loop = function () {
     } catch (e) {
         console.log('❌ CRITICAL ERROR: ' + e.message);
         if (e.stack) {
-            console.log(e.stack);
+            // Sanitize stack trace locally to avoid module dependencies in critical path
+            const safeStack = e.stack.replace(/(\/|\\)(?:.*[\/\\\\])?([^\/\\ ]+:\d+:\d+)/g, '$2');
+            console.log(safeStack);
         }
     }
 };

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -54,12 +54,20 @@ module.exports = {
         this.log('debug', message);
     },
 
+    // Sanitize stack trace to prevent path leakage
+    getSafeStack: function (stack) {
+        if (!stack) return '';
+        // Strip absolute paths, keep filename:line:column
+        return stack.replace(/(\/|\\)(?:.*[\/\\\\])?([^\/\\ ]+:\d+:\d+)/g, '$2');
+    },
+
     // Wrap function with error catching
     tryCatch: function (fn, context) {
         try {
             return fn();
         } catch (e) {
-            this.error(`Exception in ${context}: ${e.message}\n${e.stack}`);
+            const safeStack = this.getSafeStack(e.stack);
+            this.error(`Exception in ${context}: ${e.message}\n${safeStack}`);
             return null;
         }
     },


### PR DESCRIPTION
🛡️ Sentinel: implement stack trace sanitization to prevent information leakage of internal file paths via error logs.

This change ensures that when errors are caught and logged (either in the main loop or via the logging utility), the reported stack traces are sanitized to remove absolute directory paths from the host environment, while preserving filenames and line numbers for debugging.

---
*PR created automatically by Jules for task [14377655304109864519](https://jules.google.com/task/14377655304109864519) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/33" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
