### PR TITLE
🛡️ Sentinel: [security improvement] enhance stack trace sanitization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-26 - Robust Stack Trace Sanitization
+**Vulnerability:** Internal directory structure leakage via unsanitized stack traces.
+**Learning:** Simple regex patterns like `/(\/|\\)([\w.-]+\.js:)/g` often fail to remove the entire absolute path, instead only removing individual separators. Cross-platform path formats (Unix vs. Windows) and characters like spaces must be explicitly handled.
+**Prevention:** Use a more robust pattern like `/(?:[a-zA-Z]:)?(\/|\\)(?:.*[\/\\\\])?([^\/\\?%*:|"<>]+:\d+:\d+)/g` to capture and remove the entire absolute path from the root down to the filename.

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -60,9 +60,12 @@ module.exports = {
      */
     getSafeStack: function (stack) {
         if (!stack) return '';
+        // Robust regex to correctly handle both Unix and Windows absolute paths
+        // (including those with spaces) while preserving filename:line:column format.
+        const regex = /(?:[a-zA-Z]:)?(\/|\\)(?:.*[\/\\\\])?([^\/\\?%*:|"<>]+:\d+:\d+)/g;
         return stack
             .split('\n')
-            .map((line) => line.replace(/(\/|\\)([\w.-]+\.js:)/g, '$2'))
+            .map((line) => line.replace(regex, '$2'))
             .join('\n');
     },
 


### PR DESCRIPTION
### 🛡️ Sentinel Security Improvement

**Severity:** MEDIUM (Defense in Depth)

**💡 Vulnerability:** Internal directory structure leakage via stack traces. The previous sanitization logic was fragile and often left parts of the absolute path visible.

**🎯 Impact:** Exposure of internal server paths, which can aid an attacker in mapping the environment or exploiting path-related vulnerabilities.

**🔧 Fix:** Replaced the fragile regex with a robust pattern `/(?:[a-zA-Z]:)?(\/|\\)(?:.*[\/\\\\])?([^\/\\?%*:|"<>]+:\d+:\d+)/g` that correctly handles:
- Unix absolute paths
- Windows absolute paths (including drive letters)
- Paths containing spaces
- Proper reduction to `filename:line:column` format.

**✅ Verification:**
- Created and ran a test script covering Unix, Windows (simple), and Windows (with spaces) path formats.
- Verified syntax with `node -c utils.logging.js`.
- Ensured no regressions by reviewing usage in `main.js`.

---
*PR created automatically by Jules for task [12292968395879976797](https://jules.google.com/task/12292968395879976797) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a vulnerability where error stack traces could expose internal directory structures. Stack traces are now properly sanitized across Unix and Windows systems.

* **Documentation**
  * Added documentation covering stack trace sanitization best practices and cross-platform path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->