### PR TITLE
Potential fix for code scanning alert no. 14: Server-side request forgery

### DIFF
--- a/dashboard/app/api/screeps/route.ts
+++ b/dashboard/app/api/screeps/route.ts
@@ -4,12 +4,20 @@ const SCREEPS_API = "https://screeps.com/api";
 const TOKEN = process.env.SCREEPS_TOKEN ?? "";
 const USERNAME = process.env.SCREEPS_USERNAME ?? "";
 
+// Allow-list of supported Screeps API endpoints. Query values are mapped to concrete paths.
+const ALLOWED_ENDPOINTS: Record<string, string> = {
+  overview: "user/overview",
+  // add more allowed endpoints here as needed, e.g.:
+  // "stats": "user/stats",
+};
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const endpoint = searchParams.get("endpoint") ?? "user/overview";
+  const endpointKey = searchParams.get("endpoint") ?? "overview";
+  const resolvedEndpoint = ALLOWED_ENDPOINTS[endpointKey] ?? ALLOWED_ENDPOINTS["overview"];
 
   try {
-    const res = await fetch(`${SCREEPS_API}/${endpoint}`, {
+    const res = await fetch(`${SCREEPS_API}/${resolvedEndpoint}`, {
       headers: {
         "X-Token": TOKEN,
         "X-Username": USERNAME,


### PR DESCRIPTION
Potential fix for [https://github.com/tadanobutubutu/screeps/security/code-scanning/14](https://github.com/tadanobutubutu/screeps/security/code-scanning/14)

In general, to fix SSRF issues you must ensure user input cannot arbitrarily influence the destination of outgoing HTTP requests. The hostname should typically come from a fixed configuration or an allow-list, and any user-controlled path segments must be validated against an allow-list of expected values or at least normalized and restricted (no `..`, no scheme changes, etc.).

For this specific code, the safest and least intrusive fix is to restrict `endpoint` to a known set of Screeps API endpoints that this route is intended to support. Instead of using the raw `endpoint` query parameter, we map a small set of allowed query values to concrete path strings. For example, we might support `endpoint=overview`, `endpoint=stats`, etc., mapping them to `user/overview`, `user/stats`, and default to `user/overview` if the provided value is missing or invalid. This preserves the existing default behavior (`"user/overview"`) while preventing arbitrary paths. If you truly need flexible paths, a secondary option is to validate `endpoint` against a strict regular expression (e.g., only letters, digits, slashes, and dashes, and no `..`), but an allow-list is more robust.

Concretely, inside `dashboard/app/api/screeps/route.ts`:

- Introduce a small `ALLOWED_ENDPOINTS` mapping object that maps simple keys from the query string to specific Screeps API paths.
- Replace the direct `endpoint = searchParams.get("endpoint") ?? "user/overview"` with logic that:
  - Reads `endpoint` from the query.
  - Looks it up in `ALLOWED_ENDPOINTS`.
  - Falls back to the default `"user/overview"` when the provided key is missing or not recognized.
- Use the resulting, server-controlled `resolvedEndpoint` when constructing the `fetch` URL.

This requires only local code changes within this file; no new imports or external libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced API endpoint security by restricting access to a predefined set of allowed endpoints, providing safer default behavior for unrecognized requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->