### PR TITLE
🛡️ Sentinel: [security improvement] Hardening gamification combo system against DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -27,3 +27,8 @@
 **Vulnerability:** Denial of Service (DoS) via accumulation of non-essential metadata across multiple systems.
 **Learning:** In memory-constrained environments, simply clearing one or two large structures may not be enough if many small but cumulative data points (diaries, emotion history, visual trails) are scattered across the `Memory` object. A centralized emergency cleanup must be comprehensive and target all known "heavy" or "volatile" properties.
 **Prevention:** Implement a centralized `emergencyCleanup` that not only deletes large root-level structures but also performs a deep pass to prune non-essential metadata from persistent entities like creeps and rooms.
+
+## 2026-03-20 - Hardening Gamification Combo System
+**Vulnerability:** Prototype Pollution and Memory Denial of Service (DoS) via unsanitized combo types.
+**Learning:** Even internal-looking systems like gamification tracking can be vulnerable if they use external or dynamic strings as object keys. In Screeps, where Memory is limited to 2MB, unbounded object growth is a viable DoS vector.
+**Prevention:** Always validate keys with `isSafeKey`, truncate string lengths, and enforce a strict cap on the number of unique keys allowed in a collection.

--- a/gamification.js
+++ b/gamification.js
@@ -3,6 +3,7 @@
  */
 
 const vfx = require('visual.effects');
+const utilsMemory = require('utils.memory');
 
 const gamification = {
     /**
@@ -88,14 +89,24 @@ const gamification = {
     addCombo: function (type) {
         this.init();
 
-        if (!Memory.gamification.combos[type]) {
-            Memory.gamification.combos[type] = {
+        // Security: Validate and truncate type to prevent Prototype Pollution and Memory DoS
+        if (!utilsMemory.isSafeKey(type)) {
+            return 0;
+        }
+        const sanitizedType = String(type).substring(0, 32);
+
+        if (!Memory.gamification.combos[sanitizedType]) {
+            // Security: Cap the number of combo types to prevent Memory DoS
+            if (Object.keys(Memory.gamification.combos).length >= 10) {
+                return 0;
+            }
+            Memory.gamification.combos[sanitizedType] = {
                 count: 0,
                 lastTick: 0,
             };
         }
 
-        const combo = Memory.gamification.combos[type];
+        const combo = Memory.gamification.combos[sanitizedType];
 
         if (Game.time - combo.lastTick <= 10) {
             combo.count++;
@@ -107,7 +118,7 @@ const gamification = {
 
         if (combo.count >= 3) {
             const bonusXP = combo.count * 2;
-            this.addXP(bonusXP, combo.count + 'x ' + type + ' combo!');
+            this.addXP(bonusXP, combo.count + 'x ' + sanitizedType + ' combo!');
         }
 
         return combo.count;
@@ -264,7 +275,7 @@ const gamification = {
             case 'harvest': {
                 this.addXP(1, 'harvest');
                 const harvestCombo = this.addCombo('harvest');
-                if (harvestCombo >= 5) {
+                if (harvestCombo && harvestCombo >= 5) {
                     vfx.combo(creep.pos, harvestCombo);
                 }
                 break;
@@ -277,7 +288,7 @@ const gamification = {
             case 'upgrade': {
                 this.addXP(2, 'upgrade');
                 const upgradeCombo = this.addCombo('upgrade');
-                if (upgradeCombo >= 3) {
+                if (upgradeCombo && upgradeCombo >= 3) {
                     vfx.combo(creep.pos, upgradeCombo);
                 }
                 break;

--- a/tests/security.gamification.test.js
+++ b/tests/security.gamification.test.js
@@ -1,0 +1,63 @@
+/**
+ * Security: Gamification Combo System Tests
+ */
+
+const gamification = require('../gamification');
+
+describe('Security: Gamification Combo System', () => {
+    beforeEach(() => {
+        global.Game = {
+            time: 100,
+            spawns: {}
+        };
+        global.Memory = {
+            gamification: {
+                combos: {}
+            }
+        };
+        // Mock console.log to avoid cluttering test output
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('addCombo should reject unsafe keys (Prototype Pollution protection)', () => {
+        const result = gamification.addCombo('__proto__');
+        expect(result).toBe(0);
+        // Should not be an OWN property
+        expect(Object.prototype.hasOwnProperty.call(Memory.gamification.combos, '__proto__')).toBe(false);
+    });
+
+    test('addCombo should truncate long keys (Memory DoS protection)', () => {
+        const longKey = 'a'.repeat(100);
+        const expectedKey = 'a'.repeat(32);
+
+        gamification.addCombo(longKey);
+
+        expect(Memory.gamification.combos[expectedKey]).toBeDefined();
+        expect(Memory.gamification.combos[longKey]).toBeUndefined();
+    });
+
+    test('addCombo should respect maximum combo types limit (Memory DoS protection)', () => {
+        // Fill up to the limit (10)
+        for (let i = 0; i < 10; i++) {
+            gamification.addCombo(`type_${i}`);
+        }
+        expect(Object.keys(Memory.gamification.combos).length).toBe(10);
+
+        // Try to add one more
+        const result = gamification.addCombo('one_too_many');
+        expect(result).toBe(0);
+        expect(Object.keys(Memory.gamification.combos).length).toBe(10);
+        expect(Memory.gamification.combos['one_too_many']).toBeUndefined();
+    });
+
+    test('addCombo should still work for normal keys', () => {
+        const result = gamification.addCombo('harvest');
+        expect(result).toBe(1);
+        expect(Memory.gamification.combos['harvest']).toBeDefined();
+        expect(Memory.gamification.combos['harvest'].count).toBe(1);
+    });
+});


### PR DESCRIPTION
### 🛡️ Sentinel Security Improvement

**💡 Vulnerability:**
The `addCombo` function in the gamification system was susceptible to **Prototype Pollution** and **Memory Denial of Service (DoS)**. It allowed creating an unbounded number of unique properties on the persistent `Memory` object using unsanitized `type` strings, and did not validate those strings against dangerous keys like `__proto__`.

**🎯 Impact:**
In the 2MB-limited Screeps environment, an exploit or bug could lead to:
1.  **Memory Exhaustion:** Crashing the AI by exceeding the 2MB memory limit mid-tick.
2.  **Prototype Pollution:** Overwriting `Object.prototype` properties, potentially leading to remote code execution or logic bypasses in the global Screeps environment.

**🔧 Fix:**
-   Integrated `utils.memory.isSafeKey` to validate combo types before use as keys.
-   Added string truncation to 32 characters for all combo type keys.
-   Enforced a strict limit of **10** unique combo types in `Memory.gamification.combos`.
-   Added defensive null-checks to `trackAction` to handle rejected combo attempts gracefully.
-   Followed the repository's convention for flat module requires.

**✅ Verification:**
-   Created `tests/security.gamification.test.js` covering Prototype Pollution, key truncation, and the volume cap.
-   Ran `pnpm jest` and confirmed all **43 tests** pass (100% success rate).
-   Verified the fix manually via `read_file` to ensure it fits the <50 line constraint for Sentinel.

**Reflections:**
Recorded learnings in `.jules/sentinel.md` regarding the importance of hardening even "fun" internal systems that manipulate persistent global memory.

---
*PR created automatically by Jules for task [3486162614420384802](https://jules.google.com/task/3486162614420384802) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
