### PR TITLE
⚡ Bolt: Implement per-tick room-level caching for expensive find operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,11 @@
 ## 2026-03-24 - Cross-Role Per-Tick Room Caching
 **Learning:** Attaching search results (like FIND_SOURCES_ACTIVE) to the volatile Room object using a `_cacheKey` and `_cacheKeyTick` pattern allows multiple creeps of different roles to share the same expensive find operation within a single tick. This is significantly faster than per-creep caching in memory.
 **Action:** Implement unified room-level caching for shared search targets (sources, construction sites) to provide global CPU savings across all active roles.
+
+## 2026-03-31 - Dashboard as a Cache Warmer for Global Systems
+**Learning:** The room dashboard often performs comprehensive  calls to gather stats for the UI. By attaching these results to the volatile Room object (e.g., `room._myCreeps`), subsequent heavy systems like Defense or AI can skip their own expensive searches and use simple JS filters on the cached arrays. This turn-based caching provides a massive reduction in per-tick `room.find` calls.
+**Action:** When implementing dashboards or global status checks, always cache the raw search results on the room object to "warm" the cache for downstream logic.
+
+## 2026-03-31 - Dashboard as a Cache Warmer for Global Systems
+**Learning:** The room dashboard often performs comprehensive `room.find` calls to gather stats for the UI. By attaching these results to the volatile Room object (e.g., `room._myCreeps`), subsequent heavy systems like Defense or AI can skip their own expensive searches and use simple JS filters on the cached arrays. This turn-based caching provides a massive reduction in per-tick `room.find` calls.
+**Action:** When implementing dashboards or global status checks, always cache the raw search results on the room object to "warm" the cache for downstream logic.

--- a/defense.manager.js
+++ b/defense.manager.js
@@ -11,19 +11,21 @@ const defenseManager = {
 
     // タワー自動制御
     manageTowers: function (room) {
-        const towers = room.find(FIND_MY_STRUCTURES, {
-            filter: (s) => s.structureType === STRUCTURE_TOWER,
-        });
+        // ⚡ PERFORMANCE: Reuse cached room structures and creeps if available (populated by dashboard)
+        const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+        const towers = myStructures.filter((s) => s.structureType === STRUCTURE_TOWER);
 
         if (towers.length === 0) {
             return;
         }
 
         // 脅威の優先順位付け
-        const hostiles = room.find(FIND_HOSTILE_CREEPS);
-        const damagedCreeps = room.find(FIND_MY_CREEPS, {
-            filter: (c) => c.hits < c.hitsMax,
-        });
+        const hostiles = room._hostileCreeps || room.find(FIND_HOSTILE_CREEPS);
+        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+
+        const damagedCreeps = myCreeps.filter((c) => c.hits < c.hitsMax);
+
+        // FIND_STRUCTURES (including non-my) is not cached yet, but we can filter from myStructures if it's mostly our structures
         const damagedStructures = room.find(FIND_STRUCTURES, {
             filter: (s) => s.hits < s.hitsMax && s.structureType !== STRUCTURE_WALL,
         });
@@ -61,7 +63,8 @@ const defenseManager = {
 
     // 脅威レベル評価
     checkThreats: function (room) {
-        const hostiles = room.find(FIND_HOSTILE_CREEPS);
+        // ⚡ PERFORMANCE: Reuse cached hostile creeps
+        const hostiles = room._hostileCreeps || room.find(FIND_HOSTILE_CREEPS);
 
         if (hostiles.length === 0) {
             if (Memory.defenseLevel) {
@@ -95,19 +98,21 @@ const defenseManager = {
     // 防衛creep管理
     manageDefenders: function (room) {
         const threatLevel = Memory.defenseLevel || 0;
-        const defenders = _.filter(
-            Game.creeps,
-            (c) => c.memory.role === 'defender' && c.room.name === room.name
-        );
+
+        // ⚡ PERFORMANCE: Use cached room creeps to find defenders instead of global filter
+        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+        const defenders = myCreeps.filter((c) => c.memory.role === 'defender');
 
         // 脅威に応じて必要な防衛creep数を決定
         const requiredDefenders = Math.min(Math.ceil(threatLevel / 3), 4);
 
         if (defenders.length < requiredDefenders && threatLevel > 0) {
             // スポーン準備
-            const spawns = room.find(FIND_MY_SPAWNS, {
-                filter: (s) => !s.spawning,
-            });
+            // ⚡ PERFORMANCE: Use cached room structures to find spawns
+            const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+            const spawns = myStructures.filter(
+                (s) => s.structureType === STRUCTURE_SPAWN && !s.spawning
+            );
 
             if (spawns.length > 0) {
                 this.spawnDefender(spawns[0], threatLevel);
@@ -171,7 +176,9 @@ const defenseManager = {
 
     // Defender creepの行動制御
     runDefender: function (creep) {
-        const hostile = creep.pos.findClosestByRange(FIND_HOSTILE_CREEPS);
+        // ⚡ PERFORMANCE: Use cached hostile creeps
+        const hostiles = creep.room._hostileCreeps || creep.room.find(FIND_HOSTILE_CREEPS);
+        const hostile = creep.pos.findClosestByRange(hostiles);
 
         if (hostile) {
             // 敵を発見
@@ -212,14 +219,12 @@ const defenseManager = {
 
     // 統計情報表示
     showStats: function (room) {
-        const towers = room.find(FIND_MY_STRUCTURES, {
-            filter: (s) => s.structureType === STRUCTURE_TOWER,
-        }).length;
+        // ⚡ PERFORMANCE: Use cached room objects
+        const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+        const towers = myStructures.filter((s) => s.structureType === STRUCTURE_TOWER).length;
 
-        const defenders = _.filter(
-            Game.creeps,
-            (c) => c.memory.role === 'defender' && c.room.name === room.name
-        ).length;
+        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+        const defenders = myCreeps.filter((c) => c.memory.role === 'defender').length;
 
         const threatLevel = Memory.defenseLevel || 0;
 

--- a/utils.dashboard.js
+++ b/utils.dashboard.js
@@ -15,9 +15,18 @@ function formatNumber(num) {
 
 const DashboardRenderer = {
     renderRoomDashboard(room) {
-        const creeps = room.find(FIND_MY_CREEPS);
-        const structures = room.find(FIND_MY_STRUCTURES);
-        const hostiles = room.find(FIND_HOSTILE_CREEPS);
+        // ⚡ PERFORMANCE OPTIMIZATION: Per-tick caching of common searches on the Room object.
+        // This allows other systems (like defense.manager) to reuse these results.
+        if (room._cacheTick !== Game.time) {
+            room._myCreeps = room.find(FIND_MY_CREEPS);
+            room._myStructures = room.find(FIND_MY_STRUCTURES);
+            room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
+            room._cacheTick = Game.time;
+        }
+
+        const creeps = room._myCreeps;
+        const structures = room._myStructures;
+        const hostiles = room._hostileCreeps;
 
         // ⚡ PERFORMANCE OPTIMIZATION: Use a single loop to count roles instead of multiple filters.
         const roleCount = {


### PR DESCRIPTION
💡 **What**: Implemented a per-tick caching pattern on the volatile `Room` object for the most common and expensive search operations (`FIND_MY_CREEPS`, `FIND_MY_STRUCTURES`, and `FIND_HOSTILE_CREEPS`). The `DashboardRenderer` now "warms" this cache during its routine stats collection, and `defense.manager.js` was updated to reuse these cached arrays using native JS `.filter()` instead of re-calling the engine's `room.find()` API.

🎯 **Why**: In Screeps, `room.find()` is a computationally expensive operation. The previous implementation called it multiple times across different modules (Dashboard, Defense Manager, etc.) for the same data within the same tick. Centralizing this data on the `Room` object for the duration of a tick avoids redundant processing.

📊 **Impact**: Reduces total `room.find()` calls by approximately 4-6 per tick per room. In a typical colony setup, this results in a measurable CPU savings (estimated 0.2-0.5 CPU per tick), especially when hostiles are present or defensive systems are active.

🔬 **Measurement**: Verified that all colony logic remains functional via `pnpm test` (39/39 passing). Performance gains can be observed in the in-game CPU stats by comparing CPU usage before and after the change in a room with multiple active structures and creeps.

---
*PR created automatically by Jules for task [6748403739245266328](https://jules.google.com/task/6748403739245266328) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/113" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
