### PR TITLE
⚡ Bolt: optimize builder target selection

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -21,3 +21,7 @@
 ## 2026-04-07 - Unique Cache Tick Keys for Modular Systems
 **Learning:** Using a generic `_cacheTick` property to guard multiple different cached results on the Room object leads to brittle logic and potential runtime errors. If one system (e.g., Dashboard) updates the generic tick but not all cached properties, other systems (e.g., Medic) might skip their required `room.find` calls, resulting in undefined access.
 **Action:** Always use specific, unique tick keys (e.g., `_myCreepsTick`, `_injuredCreepsTick`) for each cached dataset to ensure modular safety and prevent cross-system cache collisions.
+
+## 2026-04-14 - Heuristic Target Selection and ID Caching
+**Learning:** Repeatedly calling `findClosestByPath` in high-frequency creep roles is extremely expensive ($O(N \cdot \text{Pathfinding})$). Replacing it with `findClosestByRange` ($O(N)$) and caching the resulting target ID in `creep.memory` allows the creep to reuse the target until it is completed or invalid, reducing the search frequency from every tick to once per target lifecycle.
+**Action:** Always prefer `findClosestByRange` for heuristic target selection and implement ID caching in `creep.memory` to minimize spatial search overhead in role logic.

--- a/role.builder.js
+++ b/role.builder.js
@@ -19,12 +19,25 @@ const roleBuilder = {
             const targets = creep.room._constructionSites;
 
             if (targets.length > 0) {
-                // 最も近い建設サイトへ
-                const target = creep.pos.findClosestByPath(targets);
+                // ⚡ PERFORMANCE: Cache target ID to avoid re-searching every tick
+                let target = Game.getObjectById(creep.memory.buildTargetId);
+
+                // If target is invalid or no longer exists in construction sites, find a new one
+                if (!target || !targets.some((t) => t.id === target.id)) {
+                    // ⚡ PERFORMANCE: Use findClosestByRange (O(N)) instead of findClosestByPath (O(N*Pathfinding))
+                    target = creep.pos.findClosestByRange(targets);
+                    if (target) {
+                        creep.memory.buildTargetId = target.id;
+                    } else {
+                        delete creep.memory.buildTargetId;
+                    }
+                }
+
                 if (target && creep.build(target) === ERR_NOT_IN_RANGE) {
                     creep.moveTo(target, { visualizePathStyle: { stroke: '#0000ff' } });
                 }
             } else {
+                delete creep.memory.buildTargetId;
                 // 建設サイトがなければアップグレードモードに
                 if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
                     creep.moveTo(creep.room.controller, {

--- a/tests/role.builder.test.js
+++ b/tests/role.builder.test.js
@@ -2,7 +2,7 @@
  * role.builder.js のユニットテスト
  */
 
-global.Game = { time: 10 };
+global.Game = { time: 10, getObjectById: jest.fn() };
 global.Memory = {};
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
@@ -74,14 +74,16 @@ describe('role.builder', () => {
 
   test('buildingモードで建設サイトがあるときbuildを呼ぶ', () => {
     const mockSite = { id: 'site1', pos: { x: 10, y: 10 } };
+    global.Game.getObjectById.mockReturnValue(null);
+
     const creep = {
-      memory: { building: true },
+      memory: { building: true, buildTargetId: undefined },
       store: { [global.RESOURCE_ENERGY]: 50, getFreeCapacity: jest.fn().mockReturnValue(0) },
       say: jest.fn(),
       build: jest.fn().mockReturnValue(global.OK),
       upgradeController: jest.fn(),
       moveTo: jest.fn(),
-      pos: { findClosestByPath: jest.fn().mockReturnValue(mockSite) },
+      pos: { findClosestByRange: jest.fn().mockReturnValue(mockSite) },
       room: {
         _constructionSitesTick: undefined,
         _constructionSites: [mockSite],
@@ -92,6 +94,32 @@ describe('role.builder', () => {
 
     roleBuilder.run(creep);
     expect(creep.build).toHaveBeenCalled();
+    expect(creep.memory.buildTargetId).toBe('site1');
+  });
+
+  test('buildingモードでキャッシュされたターゲットを使用する', () => {
+    const mockSite = { id: 'site1', pos: { x: 10, y: 10 } };
+    global.Game.getObjectById.mockReturnValue(mockSite);
+
+    const creep = {
+      memory: { building: true, buildTargetId: 'site1' },
+      store: { [global.RESOURCE_ENERGY]: 50, getFreeCapacity: jest.fn().mockReturnValue(0) },
+      say: jest.fn(),
+      build: jest.fn().mockReturnValue(global.OK),
+      upgradeController: jest.fn(),
+      moveTo: jest.fn(),
+      pos: { findClosestByRange: jest.fn() },
+      room: {
+        _constructionSitesTick: 10,
+        _constructionSites: [mockSite],
+        find: jest.fn(),
+        controller: { pos: { x: 5, y: 5 } },
+      },
+    };
+
+    roleBuilder.run(creep);
+    expect(creep.build).toHaveBeenCalledWith(mockSite);
+    expect(creep.pos.findClosestByRange).not.toHaveBeenCalled();
   });
 
   test('buildingモードで建設サイトがないときupgradeControllerを呼ぶ', () => {


### PR DESCRIPTION
💡 What: Replaced `findClosestByPath` with `findClosestByRange` and implemented target ID caching in `creep.memory.buildTargetId` within `role.builder.js`.

🎯 Why: `findClosestByPath` is an $O(N \cdot \text{Pathfinding})$ operation that was running every tick for every builder. Pathfinding is extremely CPU-intensive in Screeps.

📊 Impact: Significantly reduces CPU usage for builders by replacing expensive pathfinding with linear distance checks and caching targets until they are no longer valid.

🔬 Measurement: Verified with updated unit tests in `tests/role.builder.test.js` which now cover both initial selection and cache usage. Syntax verified with `node -c`.

---
*PR created automatically by Jules for task [7934930936813304846](https://jules.google.com/task/7934930936813304846) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/122" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Builder creeps now cache their target construction sites, reducing unnecessary target re-selection calculations each tick.

* **Tests**
  * Added comprehensive test coverage for the new cached target selection workflow, including validation and fallback behaviors when targets become unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->