### PR TITLE
⚡ Bolt: Standardized per-tick caching and repairer optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-04-14 - Heuristic Target Selection and ID Caching
 **Learning:** Repeatedly calling `findClosestByPath` in high-frequency creep roles is extremely expensive ($O(N \cdot \text{Pathfinding})$). Replacing it with `findClosestByRange` ($O(N)$) and caching the resulting target ID in `creep.memory` allows the creep to reuse the target until it is completed or invalid, reducing the search frequency from every tick to once per target lifecycle.
 **Action:** Always prefer `findClosestByRange` for heuristic target selection and implement ID caching in `creep.memory` to minimize spatial search overhead in role logic.
+
+## 2026-05-12 - Standardized Tick-Gated Caching and Sticky Repair Targets
+**Learning:** Shared per-tick caching (like FIND_MY_CREEPS) only works reliably across modular systems if every consumer uses unique, standardized tick keys (e.g., `_myCreepsTick`). Using a generic key or failing to check the tick leads to redundant searches or stale data. Furthermore, implementing target ID caching for Repairers significantly reduces per-tick O(N) scans.
+**Action:** Standardize per-tick cache keys on the Room object across all modules and implement sticky target ID caching for all repair and build-heavy roles.

--- a/defense.manager.js
+++ b/defense.manager.js
@@ -12,7 +12,11 @@ const defenseManager = {
     // タワー自動制御
     manageTowers: function (room) {
         // ⚡ PERFORMANCE: Reuse cached room structures and creeps if available (populated by dashboard)
-        const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+        if (room._myStructuresTick !== Game.time) {
+            room._myStructures = room.find(FIND_MY_STRUCTURES);
+            room._myStructuresTick = Game.time;
+        }
+        const myStructures = room._myStructures;
         const towers = myStructures.filter((s) => s.structureType === STRUCTURE_TOWER);
 
         if (towers.length === 0) {
@@ -20,15 +24,28 @@ const defenseManager = {
         }
 
         // 脅威の優先順位付け
-        const hostiles = room._hostileCreeps || room.find(FIND_HOSTILE_CREEPS);
-        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+        if (room._hostileCreepsTick !== Game.time) {
+            room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
+            room._hostileCreepsTick = Game.time;
+        }
+        const hostiles = room._hostileCreeps;
+
+        if (room._myCreepsTick !== Game.time) {
+            room._myCreeps = room.find(FIND_MY_CREEPS);
+            room._myCreepsTick = Game.time;
+        }
+        const myCreeps = room._myCreeps;
 
         const damagedCreeps = myCreeps.filter((c) => c.hits < c.hitsMax);
 
-        // FIND_STRUCTURES (including non-my) is not cached yet, but we can filter from myStructures if it's mostly our structures
-        const damagedStructures = room.find(FIND_STRUCTURES, {
-            filter: (s) => s.hits < s.hitsMax && s.structureType !== STRUCTURE_WALL,
-        });
+        // ⚡ PERFORMANCE: Shared per-tick caching for damaged structures
+        if (room._damagedStructuresTick !== Game.time) {
+            room._damagedStructures = room.find(FIND_STRUCTURES, {
+                filter: (s) => s.hits < s.hitsMax && s.structureType !== STRUCTURE_WALL,
+            });
+            room._damagedStructuresTick = Game.time;
+        }
+        const damagedStructures = room._damagedStructures;
 
         towers.forEach((tower) => {
             // 優先度1: 敵creepへの攻撃
@@ -64,7 +81,11 @@ const defenseManager = {
     // 脅威レベル評価
     checkThreats: function (room) {
         // ⚡ PERFORMANCE: Reuse cached hostile creeps
-        const hostiles = room._hostileCreeps || room.find(FIND_HOSTILE_CREEPS);
+        if (room._hostileCreepsTick !== Game.time) {
+            room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
+            room._hostileCreepsTick = Game.time;
+        }
+        const hostiles = room._hostileCreeps;
 
         if (hostiles.length === 0) {
             if (Memory.defenseLevel) {
@@ -100,7 +121,11 @@ const defenseManager = {
         const threatLevel = Memory.defenseLevel || 0;
 
         // ⚡ PERFORMANCE: Use cached room creeps to find defenders instead of global filter
-        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+        if (room._myCreepsTick !== Game.time) {
+            room._myCreeps = room.find(FIND_MY_CREEPS);
+            room._myCreepsTick = Game.time;
+        }
+        const myCreeps = room._myCreeps;
         const defenders = myCreeps.filter((c) => c.memory.role === 'defender');
 
         // 脅威に応じて必要な防衛creep数を決定
@@ -109,7 +134,11 @@ const defenseManager = {
         if (defenders.length < requiredDefenders && threatLevel > 0) {
             // スポーン準備
             // ⚡ PERFORMANCE: Use cached room structures to find spawns
-            const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+            if (room._myStructuresTick !== Game.time) {
+                room._myStructures = room.find(FIND_MY_STRUCTURES);
+                room._myStructuresTick = Game.time;
+            }
+            const myStructures = room._myStructures;
             const spawns = myStructures.filter(
                 (s) => s.structureType === STRUCTURE_SPAWN && !s.spawning
             );
@@ -177,7 +206,11 @@ const defenseManager = {
     // Defender creepの行動制御
     runDefender: function (creep) {
         // ⚡ PERFORMANCE: Use cached hostile creeps
-        const hostiles = creep.room._hostileCreeps || creep.room.find(FIND_HOSTILE_CREEPS);
+        if (creep.room._hostileCreepsTick !== Game.time) {
+            creep.room._hostileCreeps = creep.room.find(FIND_HOSTILE_CREEPS);
+            creep.room._hostileCreepsTick = Game.time;
+        }
+        const hostiles = creep.room._hostileCreeps;
         const hostile = creep.pos.findClosestByRange(hostiles);
 
         if (hostile) {
@@ -220,10 +253,18 @@ const defenseManager = {
     // 統計情報表示
     showStats: function (room) {
         // ⚡ PERFORMANCE: Use cached room objects
-        const myStructures = room._myStructures || room.find(FIND_MY_STRUCTURES);
+        if (room._myStructuresTick !== Game.time) {
+            room._myStructures = room.find(FIND_MY_STRUCTURES);
+            room._myStructuresTick = Game.time;
+        }
+        const myStructures = room._myStructures;
         const towers = myStructures.filter((s) => s.structureType === STRUCTURE_TOWER).length;
 
-        const myCreeps = room._myCreeps || room.find(FIND_MY_CREEPS);
+        if (room._myCreepsTick !== Game.time) {
+            room._myCreeps = room.find(FIND_MY_CREEPS);
+            room._myCreepsTick = Game.time;
+        }
+        const myCreeps = room._myCreeps;
         const defenders = myCreeps.filter((c) => c.memory.role === 'defender').length;
 
         const threatLevel = Memory.defenseLevel || 0;

--- a/role.repairer.js
+++ b/role.repairer.js
@@ -10,32 +10,44 @@ const roleRepairer = {
         }
 
         if (creep.memory.repairing) {
-            // ⚡ PERFORMANCE: Per-tick caching of damaged structures
+            // ⚡ PERFORMANCE: Per-tick caching of damaged structures (Shared across roles)
             if (creep.room._damagedStructuresTick !== Game.time) {
                 creep.room._damagedStructures = creep.room.find(FIND_STRUCTURES, {
                     filter: (s) => s.hits < s.hitsMax && s.structureType !== STRUCTURE_WALL,
                 });
                 creep.room._damagedStructuresTick = Game.time;
             }
-
             const targets = creep.room._damagedStructures;
 
             if (targets && targets.length > 0) {
-                // ⚡ PERFORMANCE: Find target with minimum hits in O(N)
-                let target = targets[0];
-                let minHits = target.hits;
+                // ⚡ PERFORMANCE: Cache target ID to avoid redundant O(N) scans every tick
+                let target = Game.getObjectById(creep.memory.repairTargetId);
 
-                for (let i = 1; i < targets.length; i++) {
-                    if (targets[i].hits < minHits) {
-                        target = targets[i];
-                        minHits = target.hits;
+                // If target is invalid or fully repaired, find a new one
+                if (!target || target.hits === target.hitsMax) {
+                    // ⚡ PERFORMANCE: Find target with minimum hits in O(N)
+                    target = targets[0];
+                    let minHits = target.hits;
+
+                    for (let i = 1; i < targets.length; i++) {
+                        if (targets[i].hits < minHits) {
+                            target = targets[i];
+                            minHits = target.hits;
+                        }
+                    }
+
+                    if (target) {
+                        creep.memory.repairTargetId = target.id;
+                    } else {
+                        delete creep.memory.repairTargetId;
                     }
                 }
 
-                if (creep.repair(target) === ERR_NOT_IN_RANGE) {
+                if (target && creep.repair(target) === ERR_NOT_IN_RANGE) {
                     creep.moveTo(target, { visualizePathStyle: { stroke: '#ffff00' } });
                 }
             } else {
+                delete creep.memory.repairTargetId;
                 // 修理対象がない場合はアップグレード
                 if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
                     creep.moveTo(creep.room.controller, {

--- a/tests/defense.manager.test.js
+++ b/tests/defense.manager.test.js
@@ -54,8 +54,11 @@ describe('defense.manager', () => {
     
     mockRoom = {
       _myStructures: [mockTower],
+      _myStructuresTick: Game.time,
       _hostileCreeps: [],
+      _hostileCreepsTick: Game.time,
       _myCreeps: [],
+      _myCreepsTick: Game.time,
       find: jest.fn().mockImplementation((type) => {
         if (type === FIND_MY_STRUCTURES) return [mockTower];
         if (type === FIND_HOSTILE_CREEPS) return [];
@@ -127,8 +130,15 @@ describe('defense.manager', () => {
   test('runDefenderがhostilesがいるとき攻撃する', () => {
     const mockHostile = { pos: { getRangeTo: jest.fn().mockReturnValue(1) } };
     const mockDefender = {
-      room: { _hostileCreeps: [mockHostile], find: jest.fn().mockReturnValue([mockHostile]) },
-      pos: { findClosestByRange: jest.fn().mockReturnValue(mockHostile), getRangeTo: jest.fn().mockReturnValue(1) },
+      room: {
+        _hostileCreeps: [mockHostile],
+        _hostileCreepsTick: Game.time,
+        find: jest.fn().mockReturnValue([mockHostile]),
+      },
+      pos: {
+        findClosestByRange: jest.fn().mockReturnValue(mockHostile),
+        getRangeTo: jest.fn().mockReturnValue(1),
+      },
       attack: jest.fn().mockReturnValue(OK),
       rangedAttack: jest.fn(),
       heal: jest.fn(),

--- a/tests/role.repairer.test.js
+++ b/tests/role.repairer.test.js
@@ -2,7 +2,10 @@
  * role.repairer.js のユニットテスト
  */
 
-global.Game = { time: 10 };
+global.Game = {
+  time: 10,
+  getObjectById: jest.fn(),
+};
 global.Memory = {};
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;

--- a/utils.dashboard.js
+++ b/utils.dashboard.js
@@ -17,11 +17,18 @@ const DashboardRenderer = {
     renderRoomDashboard(room) {
         // ⚡ PERFORMANCE OPTIMIZATION: Per-tick caching of common searches on the Room object.
         // This allows other systems (like defense.manager) to reuse these results.
-        if (room._cacheTick !== Game.time) {
+        // Using unique tick keys prevents accidental cache collisions between modules.
+        if (room._myCreepsTick !== Game.time) {
             room._myCreeps = room.find(FIND_MY_CREEPS);
+            room._myCreepsTick = Game.time;
+        }
+        if (room._myStructuresTick !== Game.time) {
             room._myStructures = room.find(FIND_MY_STRUCTURES);
+            room._myStructuresTick = Game.time;
+        }
+        if (room._hostileCreepsTick !== Game.time) {
             room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
-            room._cacheTick = Game.time;
+            room._hostileCreepsTick = Game.time;
         }
 
         const creeps = room._myCreeps;


### PR DESCRIPTION
This PR implements a high-impact performance optimization by standardizing the per-tick caching pattern across the codebase and optimizing the Repairer role.

Key improvements:
1. **Standardized Caching:** Unifies cache keys (e.g., `_myCreepsTick`) on the volatile `Room` object. This ensures that the Dashboard, Defense Manager, and Role logic share the same search results within a single tick, eliminating redundant engine calls.
2. **Repairer Optimization:** Adds `repairTargetId` caching to the Repairer role. Instead of searching for the most damaged structure every tick (O(N)), the creep now uses `Game.getObjectById` (O(1)) for its current target until it is fully repaired or the creep's energy is exhausted.
3. **Robustness:** Using unique keys per data type (rather than a generic `_cacheTick`) prevents accidental cache collisions and ensures data integrity even when modules are toggled by the Adaptive System.

All tests passed, and syntax has been verified.

---
*PR created automatically by Jules for task [875676825676797436](https://jules.google.com/task/875676825676797436) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/137" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced sticky repair targeting to reduce repeated target searches per tick.

* **Bug Fixes**
  * Implemented tick-gated cache invalidation to prevent stale room data usage.

* **Tests**
  * Updated test fixtures to support new per-tick caching validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->