### PR TITLE
🎨 Palette: Enhance dashboard glanceability and visual rewards

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -37,3 +37,7 @@
 ## 2025-06-26 - [Accessibility in Small-Scale Text]
 **Learning:** For very small informational text (e.g., font size 0.4 for CPU/Bucket stats), semantic colors like Green or Yellow can suffer from poor contrast against a 50% opacity black background. Forcing these labels to White (#ffffff) ensures maximum readability and WCAG compliance for small-scale UI elements, while relying on adjacent progress bars to convey status through color.
 **Action:** Prioritize high-contrast white text for sub-0.5 font sizes on transparent backgrounds, even if it replaces semantic status colors.
+
+## 2025-06-30 - [Visual Rewards for Completion]
+**Learning:** In a gamified UI, reaching 100% on a progress bar should feel distinct from "near completion". Using a unique "Gold" (#FFD700) color specifically for the 100% state provides a clear, satisfying visual reward that distinguishes completed tasks from those still in progress, providing immediate positive reinforcement.
+**Action:** Always implement a dedicated "completed" color state (like Gold) for progress bars in gamified systems to differentiate the "Finished" state from "High Progress".

--- a/tests/utils.dashboard.test.js
+++ b/tests/utils.dashboard.test.js
@@ -79,12 +79,20 @@ describe('DashboardRenderer', () => {
             expect.objectContaining({ font: 0.4 })
         );
 
-        // Verify storage percent is displayed
+        // Verify GCL color is blue
+        expect(mockRoom.visual.text).toHaveBeenCalledWith(
+            expect.stringContaining('GCL: 3 (50%)'),
+            expect.any(Number),
+            expect.any(Number),
+            expect.objectContaining({ color: '#00aaff' })
+        );
+
+        // Verify storage percent is displayed with warning color (50%)
         expect(mockRoom.visual.text).toHaveBeenCalledWith(
             expect.stringContaining('Storage: 500.0K (50%)'),
             expect.any(Number),
             expect.any(Number),
-            expect.objectContaining({ color: '#ffffff' })
+            expect.objectContaining({ color: '#ffff00' })
         );
     });
 });

--- a/utils.dashboard.js
+++ b/utils.dashboard.js
@@ -146,7 +146,7 @@ const DashboardRenderer = {
         // 🌐 GCL info
         room.visual.text(`🌐 GCL: ${info.gcl.level} (${info.gcl.percent}%)`, x, y, {
             font: 0.7,
-            color: '#ffffff',
+            color: '#00aaff',
             align: 'left',
             stroke: '#000000',
             strokeWidth: 0.05,
@@ -163,7 +163,7 @@ const DashboardRenderer = {
             strokeWidth: 0.02,
         });
         room.visual.rect(x, y - 0.1, gclBarWidth * gclProgress, gclBarHeight, {
-            fill: '#ffffff',
+            fill: '#00aaff',
             opacity: 0.8,
         });
         y += 0.6;
@@ -232,9 +232,16 @@ const DashboardRenderer = {
         y += 0.6;
 
         // 📦 Storage info
+        let storageColor = '#00ffff'; // Cyan (Healthy)
+        if (info.storagePercent < 30) {
+            storageColor = '#ff0000'; // Red (Critical)
+        } else if (info.storagePercent < 70) {
+            storageColor = '#ffff00'; // Yellow (Warning)
+        }
+
         room.visual.text(`📦 Storage: ${info.storage} (${info.storagePercent}%)`, x, y, {
             font: 0.7,
-            color: '#ffffff',
+            color: storageColor,
             align: 'left',
             stroke: '#000000',
             strokeWidth: 0.05,
@@ -251,7 +258,7 @@ const DashboardRenderer = {
             strokeWidth: 0.02,
         });
         room.visual.rect(x, y - 0.1, storageBarWidth * storageProgress, storageBarHeight, {
-            fill: '#ffffff',
+            fill: storageColor,
             opacity: 0.8,
         });
         y += 0.8;

--- a/visual.effects.js
+++ b/visual.effects.js
@@ -214,12 +214,14 @@ const visualEffects = {
 
         // プログレス
         let color;
-        if (progress >= 0.8) {
-            color = '#00FF00';
+        if (progress >= 1.0) {
+            color = '#FFD700'; // Gold (Completed)
+        } else if (progress >= 0.8) {
+            color = '#00FF00'; // Green (Near Completion)
         } else if (progress >= 0.5) {
-            color = '#FFFF00';
+            color = '#FFFF00'; // Yellow (Midway)
         } else {
-            color = '#FF0000';
+            color = '#FF0000'; // Red (Just Started)
         }
 
         visual.rect(pos.x - width / 2, pos.y - height / 2, width * progress, height, {


### PR DESCRIPTION
This PR introduces several micro-UX improvements focused on glanceability and visual rewards in the room dashboard and VFX systems.

### 💡 What
- **GCL Differentiation:** Changed GCL text and progress bar from White to Blue (#00aaff), making it easily distinguishable from other metrics.
- **Semantic Storage Status:** Added Red (<30%), Yellow (<70%), and Cyan (>=70%) coloring to the Storage info text and bar, allowing users to assess resource health at a glance.
- **Completion Reward:** Updated the `vfx.progressBar` helper to use a Gold (#FFD700) color exactly when progress reaches 100%, providing a satisfying visual cue for finished tasks (like Daily Challenges).
- **Test Alignment:** Updated `tests/utils.dashboard.test.js` to reflect the new color logic.

### 🎯 Why
- The previous dashboard used white for multiple different types of data, requiring more cognitive effort to parse.
- A "near completion" green bar looked too similar to a "finished" bar; the new Gold state provides immediate positive reinforcement for completed tasks.

### ♿ Accessibility
- Synchronized text colors with their respective progress bars to reinforce visual association.
- Used high-contrast colors (Blue, Cyan, Yellow, Red, Gold) against the dark dashboard background to ensure readability.
- Maintained white for multi-part creep role counts to avoid visual clutter and maintain baseline contrast.

---
*PR created automatically by Jules for task [17074648571497596317](https://jules.google.com/task/17074648571497596317) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
