### PR TITLE
fix(workflows): normalize GitHub Actions versions and update validator rules

### DIFF
--- a/.github/workflows/ai-code-improvement.yml
+++ b/.github/workflows/ai-code-improvement.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Analyze Code Quality
         id: analyze

--- a/.github/workflows/ai-powered-auto-fix.yml
+++ b/.github/workflows/ai-powered-auto-fix.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Check for Errors
         id: check

--- a/.github/workflows/ai-strategy-analyzer.yml
+++ b/.github/workflows/ai-strategy-analyzer.yml
@@ -14,10 +14,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: 🧠 AI Strategy Analysis
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const focusAreas = ['defense', 'expansion', 'harvesting', 'upgrading', 'exploration'];

--- a/.github/workflows/auto-assign-jules.yml
+++ b/.github/workflows/auto-assign-jules.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Check if Jules should be notified
         id: check
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;
@@ -65,7 +65,7 @@ jobs:
 
       - name: Mention Jules in comment
         if: steps.check.outputs.should_mention == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const issue = context.payload.issue;

--- a/.github/workflows/auto-create-roles.yml
+++ b/.github/workflows/auto-create-roles.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       

--- a/.github/workflows/auto-fix-errors.yml
+++ b/.github/workflows/auto-fix-errors.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Check for Errors
         id: check

--- a/.github/workflows/auto-fix-issues.yml
+++ b/.github/workflows/auto-fix-issues.yml
@@ -34,7 +34,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Get Issue Details
         id: issue

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
       

--- a/.github/workflows/auto-improve.yml
+++ b/.github/workflows/auto-improve.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -17,7 +17,7 @@ jobs:
       startsWith(github.head_ref, 'renovate/')
     steps:
       - name: Auto merge bot PRs only
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-update-docs.yml
+++ b/.github/workflows/auto-update-docs.yml
@@ -23,10 +23,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       

--- a/.github/workflows/auto-zenodo-release.yml
+++ b/.github/workflows/auto-zenodo-release.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create Zenodo snapshot release
         if: steps.check_changes.outputs.changed == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
       

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,10 +18,10 @@ jobs:
       github.actor != 'google-labs-jules[bot]'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Create Jules Issue for low coverage files
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/daily-leaderboard.yml
+++ b/.github/workflows/daily-leaderboard.yml
@@ -14,10 +14,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: 🏆 Generate Daily Achievements
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const achievements = [

--- a/.github/workflows/daily-quest.yml
+++ b/.github/workflows/daily-quest.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Generate Quest
         id: quest

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/discussion-auto-implement.yml
+++ b/.github/workflows/discussion-auto-implement.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Analyze Discussion
         id: analyze

--- a/.github/workflows/discussion-bot.yml
+++ b/.github/workflows/discussion-bot.yml
@@ -22,7 +22,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Generate Bot Personality
         id: personality

--- a/.github/workflows/emergency-api-restore.yml
+++ b/.github/workflows/emergency-api-restore.yml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Check API Token
         id: check
@@ -61,8 +61,8 @@ jobs:
             monitor:
               runs-on: ubuntu-latest
               steps:
-                - uses: actions/checkout@v6
-                - uses: actions/setup-node@v6
+                - uses: actions/checkout@v4
+                - uses: actions/setup-node@v4
                   with:
                     node-version: '20'
                 

--- a/.github/workflows/error-threshold-monitor.yml
+++ b/.github/workflows/error-threshold-monitor.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Analyze Recent Errors
         id: analyze

--- a/.github/workflows/fix-undici-lockfile.yml
+++ b/.github/workflows/fix-undici-lockfile.yml
@@ -10,12 +10,12 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/game-monitor-15min.yml
+++ b/.github/workflows/game-monitor-15min.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
       

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Sync Labels
         uses: micnncim/action-label-syncer@v1

--- a/.github/workflows/multi-bot-system.yml
+++ b/.github/workflows/multi-bot-system.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event.inputs.bot_name == 'code-reviewer-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Code Reviewer Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Review Code Quality
         run: |
@@ -67,7 +67,7 @@ jobs:
     if: github.event.inputs.bot_name == 'documentation-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Documentation Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Update Documentation
         run: |
@@ -106,7 +106,7 @@ jobs:
     if: github.event.inputs.bot_name == 'performance-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Performance Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Analyze Performance
         run: |
@@ -143,7 +143,7 @@ jobs:
     if: github.event.inputs.bot_name == 'security-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Security Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Security Scan
         run: |
@@ -180,7 +180,7 @@ jobs:
     if: github.event.inputs.bot_name == 'test-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Test Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Generate Test Report
         run: |
@@ -218,7 +218,7 @@ jobs:
     if: github.event.inputs.bot_name == 'refactor-bot' || github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Refactor Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Suggest Refactoring
         run: |
@@ -256,7 +256,7 @@ jobs:
     if: github.event.inputs.bot_name == 'all' || github.event.schedule
     name: Stats Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Generate Statistics
         run: |

--- a/.github/workflows/openrouter-auto-fix.yml
+++ b/.github/workflows/openrouter-auto-fix.yml
@@ -28,16 +28,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 
       - name: Get Issue Content
         id: issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             let issueNumber;
@@ -255,7 +255,7 @@ jobs:
 
       - name: Create Branch and PR
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Label PR
         uses: actions/labeler@v6

--- a/.github/workflows/prevent-null-errors.yml
+++ b/.github/workflows/prevent-null-errors.yml
@@ -19,7 +19,7 @@ jobs:
     name: Check Null Safety
     
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Scan for Common Null/Undefined Issues
         run: |

--- a/.github/workflows/project-gamification.yml
+++ b/.github/workflows/project-gamification.yml
@@ -20,7 +20,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Calculate Stats
         id: stats

--- a/.github/workflows/protect-package-json.yml
+++ b/.github/workflows/protect-package-json.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           echo "$CHANGED_FILES"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/random-experiment.yml
+++ b/.github/workflows/random-experiment.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       

--- a/.github/workflows/rule-based-improve.yml
+++ b/.github/workflows/rule-based-improve.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
       

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -14,7 +14,7 @@ jobs:
   secret-scanning:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-monitor.yml
+++ b/.github/workflows/security-monitor.yml
@@ -24,12 +24,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for better analysis
       
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
       
@@ -227,7 +227,7 @@ jobs:
       
       # 6. Upload Security Report as Artifact
       - name: 📤 Upload Security Report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: security-report-${{ github.run_number }}
           path: SECURITY_REPORT.md

--- a/.github/workflows/setup-labels.yml
+++ b/.github/workflows/setup-labels.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create sonarcloud label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,12 +19,12 @@ jobs:
       github.actor != 'google-labs-jules[bot]'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 
@@ -47,7 +47,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Fetch SonarCloud issues and create Jules Issue
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}

--- a/.github/workflows/specialized-bots.yml
+++ b/.github/workflows/specialized-bots.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Changelog Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Metrics Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Collect Metrics
         run: |
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Dependency Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Check Dependencies
         run: |
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Cleanup Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Code Cleanup
         run: |
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Backup Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Verify Backups
         run: |
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Test Integration
         run: |
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     name: QA Bot
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       
       - name: Quality Assurance
         run: |

--- a/.github/workflows/supabase-keepalive.yml
+++ b/.github/workflows/supabase-keepalive.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/update-wiki.yml
+++ b/.github/workflows/update-wiki.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
       - name: Checkout Main Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Checkout Wiki Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki-repo

--- a/.github/workflows/usage-monitor.yml
+++ b/.github/workflows/usage-monitor.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Check GitHub Actions Usage
         id: usage

--- a/.github/workflows/validate-action-versions.yml
+++ b/.github/workflows/validate-action-versions.yml
@@ -17,17 +17,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           token: ${{ github.token }}
 
       - name: Scan for invalid action versions
         id: scan
         run: |
-          echo "🔍 Scanning .github/workflows/ for invalid action versions (v5+)..."
+          echo "🔍 Scanning .github/workflows/ for invalid action versions..."
 
-          INVALID=$(grep -rn 'uses:.*actions/.*@v[5-9][0-9]*' .github/workflows/ \
+          INVALID=$(grep -Ern \
+            -e 'uses:\s*actions/checkout@v([5-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/setup-node@v([5-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/setup-python@v([6-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/upload-artifact@v([5-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/download-artifact@v([5-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/cache@v([5-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*actions/github-script@v([8-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*peter-evans/create-pull-request@v([8-9]|[1-9][0-9]+)' \
+            -e 'uses:\s*stefanzweifel/git-auto-commit-action@v([6-9]|[1-9][0-9]+)' \
+            .github/workflows/ \
             --include='*.yml' \
+            --include='*.yaml' \
             --exclude='validate-action-versions.yml' 2>/dev/null || true)
 
           if [ -n "$INVALID" ]; then
@@ -39,20 +50,23 @@ jobs:
             echo "✅ All action versions are valid!"
           fi
 
-      - name: Auto-fix to v4
+      - name: Auto-fix to stable versions
         if: steps.scan.outputs.found == 'true'
         run: |
-          echo "🔧 Fixing invalid versions to @v4..."
+          echo "🔧 Fixing invalid versions to stable versions..."
 
-          find .github/workflows/ -name '*.yml' \
+          find .github/workflows/ \( -name '*.yml' -o -name '*.yaml' \) \
             ! -name 'validate-action-versions.yml' | while read f; do
             sed -i \
               -e 's|actions/checkout@v[5-9][0-9]*|actions/checkout@v4|g' \
               -e 's|actions/setup-node@v[5-9][0-9]*|actions/setup-node@v4|g' \
+              -e 's|actions/setup-python@v[6-9][0-9]*|actions/setup-python@v5|g' \
               -e 's|actions/upload-artifact@v[5-9][0-9]*|actions/upload-artifact@v4|g' \
               -e 's|actions/download-artifact@v[5-9][0-9]*|actions/download-artifact@v4|g' \
               -e 's|actions/cache@v[5-9][0-9]*|actions/cache@v4|g' \
-              -e 's|actions/github-script@v[5-9][0-9]*|actions/github-script@v6|g' \
+              -e 's|actions/github-script@v[8-9][0-9]*|actions/github-script@v7|g' \
+              -e 's|peter-evans/create-pull-request@v[8-9][0-9]*|peter-evans/create-pull-request@v7|g' \
+              -e 's|stefanzweifel/git-auto-commit-action@v[6-9][0-9]*|stefanzweifel/git-auto-commit-action@v5|g' \
               "$f"
           done
 

--- a/.github/workflows/validate-package-versions.yml
+++ b/.github/workflows/validate-package-versions.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 
@@ -132,10 +132,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
 

--- a/.github/workflows/workflow-health-monitor.yml
+++ b/.github/workflows/workflow-health-monitor.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
       
       - name: Ensure Labels Exist
         run: |


### PR DESCRIPTION
### Motivation

- ワークフロー内で存在しない・許容外のアクションバージョンが混在しており安定性・再現性を損なっていたため、アクションバージョンを安定版へ正規化する変更を行いました。 
- 自動検出ロジックが曖昧な正規表現で広く`v5+`を検出していたため、アクション別に不正バージョンを検出するようにバリデータを精緻化しました。 
- ワークフロー由来のループや誤ったバージョン自動適用を防ぎ、既存の運用ルール（`.github/JULES_INSTRUCTIONS.md`の制約）に従う形に整えました。

### Description

- `.github/workflows/*` の多数のワークフローで `actions/checkout@v6` → `@v4`、`actions/setup-node@v6` → `@v4`、`actions/github-script@v8` → `@v7`、`actions/upload-artifact@v7` → `@v4` 等へバージョンを正規化しました。 
- `.github/workflows/validate-action-versions.yml` を改良し、アクション別の検出パターン（`checkout`, `setup-node`, `setup-python`, `upload-artifact`, `github-script`, `peter-evans/create-pull-request`, `git-auto-commit-action` など）を明示的にスキャンするようにし、`.yml` と `.yaml` の両方を対象にしました。 
- バリデータの自動修正ルールを更新して、`github-script` を `@v7`、`setup-python` を `@v5`、`peter-evans/create-pull-request` を `@v7`、`stefanzweifel/git-auto-commit-action` を `@v5` など想定される安定版に置き換える `sed` 置換を追加しました。 
- ワークフローファイル群をスキャン・修正した上で変更を反映しています（多数のワークフローで `uses:` 行を置換）。

### Testing

- `npm test -- --runInBand` を実行し、テストスイートが `41` 件のスイート、`384` 件のテストすべて成功で完了しました。 
- 変更後にリポジトリを `rg` で検査して `uses: actions/checkout@v6|actions/setup-node@v6|actions/github-script@v8|actions/upload-artifact@v7` の残存を確認し、該当する不正なバージョンが検出されないことを確認しました。 
- リポジトリ外の GitHub Issue の自動クローズは環境からの API アクセス/認証が不可能なため（HTTP `000` 応答）、この実行環境では実行できず失敗したことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3a290633c832ab4af091f3fef8497)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/158" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
