### PR TITLE
🎨 Palette: Add interactivity and accessibility to Web Dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ yarn-error.log*
 dist/
 build/
 *.tgz
+**/.next/
 
 # Test results
 junit.xml

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -45,3 +45,7 @@
 ## 2026-03-05 - [Critical Defense Visibility]
 **Learning:** For critical survival mechanics like Safe Mode, simply showing RCL progress is insufficient. Integrating a dedicated shield icon (🛡️) with a countdown (for active states) or a remaining count (for inactive states) directly into the primary status line provides essential security awareness without requiring the user to open secondary menus.
 **Action:** Always include high-priority defensive cooldowns or counts (like Safe Mode or Nuke timers) in the main room status block using distinct, recognizable icons.
+
+## 2026-03-10 - [Layout-Stable Feedback & Manual Refresh]
+**Learning:** In data-driven dashboards, especially those fetching from external APIs with potential latency or caching (like the Screeps API), showing a "Last sync" timestamp and providing a manual "Refresh" button significantly improves the user's sense of control and confidence in the data freshness. Furthermore, refactoring components to maintain the dashboard structure (headers, containers) during loading/error states—rather than replacing the entire view—prevents jarring layout shifts and provides a more professional, stable user experience.
+**Action:** Always provide manual refresh controls with "last updated" timestamps for external data views, and ensure the UI structure remains stable during async state transitions.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 
 type ScreepsStats = {
   power?: number;
@@ -13,27 +13,78 @@ export default function Dashboard() {
   const [stats, setStats] = useState<ScreepsStats | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
-  useEffect(() => {
-    fetch("/api/screeps?endpoint=overview")
-      .then((r) => r.json())
-      .then((data) => {
-        setStats(data);
-        setLoading(false);
-      })
-      .catch((e) => {
-        setError(String(e));
-        setLoading(false);
-      });
+  const fetchStats = useCallback(async (isManual = false) => {
+    if (isManual) setIsRefreshing(true);
+    else setLoading(true);
+
+    try {
+      const r = await fetch("/api/screeps?endpoint=overview");
+      if (!r.ok) throw new Error(`API error: ${r.status}`);
+      const data = await r.json();
+      setStats(data);
+      setLastUpdated(new Date());
+      setError(null);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setLoading(false);
+      setIsRefreshing(false);
+    }
   }, []);
 
-  if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error: {error}</p>;
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
 
   return (
     <main style={{ fontFamily: "monospace", padding: "2rem" }}>
-      <h1>🐛 Screeps Dashboard</h1>
-      <pre>{JSON.stringify(stats, null, 2)}</pre>
+      <header style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "1rem" }}>
+        <h1 style={{ margin: 0 }}>🐛 Screeps Dashboard</h1>
+        <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+          {lastUpdated && (
+            <span style={{ fontSize: "0.8rem", color: "#666" }}>
+              Last sync: {lastUpdated.toLocaleTimeString()}
+            </span>
+          )}
+          <button
+            onClick={() => fetchStats(true)}
+            disabled={loading || isRefreshing}
+            aria-label="Refresh stats"
+            style={{
+              cursor: (loading || isRefreshing) ? "not-allowed" : "pointer",
+              padding: "0.5rem 1rem",
+              background: "#eee",
+              border: "1px solid #ccc",
+              borderRadius: "4px"
+            }}
+          >
+            {isRefreshing ? "Refreshing..." : "🔄 Refresh"}
+          </button>
+        </div>
+      </header>
+
+      <div aria-live="polite">
+        {loading && <p>Loading initial stats...</p>}
+      </div>
+
+      {error && (
+        <div role="alert" style={{ color: "red", padding: "1rem", border: "1px solid red", borderRadius: "4px", marginBottom: "1rem" }}>
+          {error}
+        </div>
+      )}
+
+      <section style={{ opacity: (loading || isRefreshing) ? 0.6 : 1, transition: "opacity 0.2s" }}>
+        {stats ? (
+          <pre style={{ background: "#f8f8f8", padding: "1rem", borderRadius: "4px", overflow: "auto" }}>
+            {JSON.stringify(stats, null, 2)}
+          </pre>
+        ) : (
+          !loading && <p>No data available. Try refreshing.</p>
+        )}
+      </section>
     </main>
   );
 }

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 What: Added a manual "Refresh" button, "Last sync" timestamp, and enhanced loading/error states in the Web Dashboard.

🎯 Why: The original dashboard was static and replaced the entire view with a "Loading..." message during fetch, which was jarring. Users needed a way to manually update stats and see how fresh the data is.

♿ Accessibility:
- Added `aria-label="Refresh stats"` to the refresh button.
- Added `aria-live="polite"` to the loading status container.
- Added `role="alert"` to the error message box.
- Maintained keyboard focusability and stable layout to prevent disorientation.

Learnings from this task:
- Distinguishing between initial "Loading" and subsequent "Refreshing" states preserves layout stability.
- Timestamps for last successful sync are critical for user confidence in cached API environments.

---
*PR created automatically by Jules for task [1940616044473376125](https://jules.google.com/task/1940616044473376125) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manual refresh button to dashboard for real-time data updates.
  * Introduced "last updated" timestamp display for data transparency.

* **Improvements**
  * Enhanced loading and refresh state indicators with clearer visual feedback.
  * Improved error handling with better messaging and alerts.
  * Dashboard layout now remains stable during loading and error transitions.

* **Chores**
  * Updated build configuration to exclude Next.js output directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->