### PR TITLE
🎨 Palette: Add accessible GCL progress bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -49,3 +49,7 @@
 ## 2026-03-10 - [Layout-Stable Feedback & Manual Refresh]
 **Learning:** In data-driven dashboards, especially those fetching from external APIs with potential latency or caching (like the Screeps API), showing a "Last sync" timestamp and providing a manual "Refresh" button significantly improves the user's sense of control and confidence in the data freshness. Furthermore, refactoring components to maintain the dashboard structure (headers, containers) during loading/error states—rather than replacing the entire view—prevents jarring layout shifts and provides a more professional, stable user experience.
 **Action:** Always provide manual refresh controls with "last updated" timestamps for external data views, and ensure the UI structure remains stable during async state transitions.
+
+## 2026-03-15 - [Accessible and Consistent Cross-Platform UI]
+**Learning:** When building external tools for a game (like a web dashboard), maintaining visual consistency by syncing color tokens (e.g., #00aaff for GCL) with the in-game UI improves the user's mental model. Furthermore, semantic HTML and ARIA attributes (e.g., `role="progressbar"`, `aria-valuenow`) are critical for ensuring that high-level metrics are accessible to users with assistive technologies, not just visually present.
+**Action:** Always use established brand/game colors for corresponding metrics in external dashboards and implement full ARIA suites for custom progress indicators.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -76,6 +76,24 @@ export default function Dashboard() {
         </div>
       )}
 
+      {stats?.gcl && (
+        <section style={{ marginBottom: "1.5rem", padding: "1rem", border: "1px solid #eee", borderRadius: "4px" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", marginBottom: "0.5rem" }}>
+            <strong>🌐 GCL: {stats.gcl.level}</strong>
+            <span>{Math.floor((stats.gcl.progress / stats.gcl.progressTotal) * 100)}%</span>
+          </div>
+          <div
+            role="progressbar"
+            aria-valuenow={Math.floor((stats.gcl.progress / stats.gcl.progressTotal) * 100)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            style={{ width: "100%", height: "10px", background: "#eee", borderRadius: "5px", overflow: "hidden" }}
+          >
+            <div style={{ width: `${(stats.gcl.progress / stats.gcl.progressTotal) * 100}%`, height: "100%", background: "#00aaff", transition: "width 0.3s ease" }} />
+          </div>
+        </section>
+      )}
+
       <section style={{ opacity: (loading || isRefreshing) ? 0.6 : 1, transition: "opacity 0.2s" }}>
         {stats ? (
           <pre style={{ background: "#f8f8f8", padding: "1rem", borderRadius: "4px", overflow: "auto" }}>

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 What: Added an accessible, visual GCL progress bar to the web dashboard using the '#00aaff' color token from the in-game UI.

🎯 Why: To provide immediate, at-a-glance feedback on game progress, reducing the cognitive load of parsing raw JSON data.

♿ Accessibility: Implemented `role="progressbar"` with appropriate `aria-valuenow`, `aria-valuemin`, and `aria-valuemax` attributes to ensure the metric is readable by screen readers.

Note: Frontend verification with screenshots was bypassed due to the requirement for a valid Screeps API token to populate the dashboard stats. The change was verified through a successful Next.js production build and manual code inspection.

---
*PR created automatically by Jules for task [6937010132351290751](https://jules.google.com/task/6937010132351290751) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GCL (Game Control Level) display to the dashboard showing current level and completion percentage with visual progress tracking
  * Enhanced progress indicators across the dashboard with improved accessibility features, including semantic HTML and ARIA attributes for better screen reader support
  * Improved cross-platform UI consistency with synchronized external dashboard color tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->