### PR TITLE
🛡️ Sentinel: Fix absolute path leakage in logger stack traces

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -57,3 +57,8 @@
 **Vulnerability:** Memory Denial of Service (DoS) via unbounded global cache growth and excessively large property keys.
 **Learning:** In memory-constrained environments like Screeps (2MB limit), utility functions that store data in the global `Memory` object (e.g., `memoize`) must have built-in limits. Without a cap on the number of entries or the length of keys, a system can be crashed by simply requesting many unique or large-keyed operations.
 **Prevention:** Enforce a strict `MAX_KEY_LENGTH` (e.g., 256) for all user-controlled or dynamic keys and a `MAX_CACHE_ENTRIES` cap for global collections. Implement periodic cache pruning to ensure memory is reclaimed.
+
+## 2026-03-27 - Absolute Path Leakage in Source Logger
+**Vulnerability:** Internal directory structure leakage via unsanitized stack traces in `src/utils/logger.js`.
+**Learning:** While `utils.logging.js` (root utility) was already hardened, duplicated or alternative logging logic in `src/utils/logger.js` still used a naive `slice`-based approach that preserved absolute paths. Splicing or slicing stack trace lines is insufficient for security; the content of each line must be sanitized.
+**Prevention:** Standardize stack trace sanitization across the entire codebase using a robust regex-based extraction of `filename:line:col`, effectively stripping all leading directory information regardless of the OS path format.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -170,15 +170,28 @@ function success(message) {
 }
 
 /**
- * スタックトレースから安全な部分を抽出する（長すぎる場合に切り詰め）
+ * スタックトレースから安全な部分を抽出する（長すぎる場合に切り詰め、絶対パスを削除）
  * @param {string} stack
  * @param {number} [maxLines=5] - 返す最大行数
  * @returns {string}
+ *
+ * Security: Absolute paths are removed to prevent internal directory structure leakage.
  */
 function getSafeStack(stack, maxLines) {
     if (!stack) return '';
     const lines = stack.split('\n');
-    return lines.slice(0, maxLines || 5).join('\n');
+    return lines
+        .slice(0, maxLines || 5)
+        .map((line) => {
+            // Match "filename:line:col" at the end of a path segment.
+            // Uses a simple non-backtracking pattern to avoid ReDoS.
+            const match = line.match(/[^/\\]+:\d+:\d+/);
+            if (match) {
+                return `    at ${match[0]}`;
+            }
+            return line;
+        })
+        .join('\n');
 }
 
 /**

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -84,4 +84,26 @@ describe('logger', () => {
       expect(global.Memory.logs).toBeDefined();
     });
   });
+
+  describe('getSafeStack', () => {
+    test('絶対パスをスタックトレースから削除する', () => {
+      const stack =
+        'Error: something went wrong\n' +
+        '    at Object.run (/home/user/project/main.js:10:5)\n' +
+        '    at /usr/local/lib/node_modules/screeps/index.js:100:20';
+
+      const safeStack = logger.getSafeStack(stack);
+
+      expect(safeStack).not.toContain('/home/user/project/');
+      expect(safeStack).not.toContain('/usr/local/lib/node_modules/screeps/');
+      expect(safeStack).toContain('main.js:10:5');
+      expect(safeStack).toContain('index.js:100:20');
+      expect(safeStack.split('\n').length).toBeLessThanOrEqual(5);
+    });
+
+    test('空のスタックトレースに対して空文字列を返す', () => {
+      expect(logger.getSafeStack('')).toBe('');
+      expect(logger.getSafeStack(null)).toBe('');
+    });
+  });
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Absolute path leakage in stack traces.
🎯 Impact: Internal directory structure and host usernames could be exposed in log outputs.
🔧 Fix: Enhanced `getSafeStack` in `src/utils/logger.js` to strip absolute paths, keeping only the filename, line, and column.
✅ Verification: Added new test cases in `tests/logger.test.js` and confirmed all 388 tests pass.

---
*PR created automatically by Jules for task [18377978681235243707](https://jules.google.com/task/18377978681235243707) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
