### PR TITLE
🎨 Palette: Accessible skeleton loader for GCL dashboard

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -57,3 +57,7 @@
 ## 2024-03-28 - [Skeleton Loaders for Layout Stability]
 **Learning:** In data-driven dashboards, using a simple "Loading..." text causes jarring layout shifts when the data finally arrives. Implementing a "Skeleton" placeholder—a div that roughly matches the dimensions of the expected content—maintains the layout's structural integrity during async fetches, resulting in a much smoother and more professional user experience.
 **Action:** Use skeleton-style placeholders that mirror the shape of the final UI components to eliminate layout shifts during initial data loading.
+
+## 2026-03-29 - [Accessible Skeleton Loaders]
+**Learning:** Visual-only skeleton loaders can exclude non-visual users if the original loading text is removed. To ensure accessibility, skeleton loaders must include `aria-busy="true"`, a descriptive `aria-label`, and visually hidden text (e.g., using a "sr-only" style) within an `aria-live` region. Furthermore, skeleton bars must maintain at least a 3:1 contrast ratio (e.g., using #767676 on white) to be visible to users with low vision.
+**Action:** Always pair skeleton loaders with ARIA attributes and visually hidden descriptive text, and ensure contrast ratios meet WCAG AA standards.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -71,9 +71,24 @@ export default function Dashboard() {
 
       <div aria-live="polite">
         {loading && (
-          <div style={{ height: "100px", background: "#f0f0f0", borderRadius: "4px", marginBottom: "1.5rem", display: "flex", alignItems: "center", justifyContent: "center", color: "#999" }}>
-            Loading GCL stats...
-          </div>
+          <section
+            aria-busy="true"
+            aria-label="Loading GCL stats"
+            style={{ marginBottom: "1.5rem", padding: "1rem", border: "1px solid #eee", borderRadius: "4px", opacity: 0.6 }}
+          >
+            <span style={{ position: "absolute", width: "1px", height: "1px", padding: 0, margin: "-1px", overflow: "hidden", clip: "rect(0, 0, 0, 0)", whiteSpace: "nowrap", border: 0 }}>
+              Loading GCL stats...
+            </span>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "0.5rem" }}>
+              <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+                <div style={{ width: "120px", height: "1.2rem", background: "#767676", borderRadius: "4px" }} />
+                <div style={{ width: "80px", height: "0.9rem", background: "#888888", borderRadius: "4px" }} />
+              </div>
+              <div style={{ width: "40px", height: "1.2rem", background: "#767676", borderRadius: "4px" }} />
+            </div>
+            <div style={{ width: "100%", height: "12px", background: "#767676", borderRadius: "6px", marginBottom: "0.5rem" }} />
+            <div style={{ width: "150px", height: "0.75rem", background: "#888888", borderRadius: "4px", marginLeft: "auto" }} />
+          </section>
         )}
       </div>
 


### PR DESCRIPTION
Implemented a skeleton loader for the GCL dashboard to prevent layout shifts during initial data loading. The loader is fully accessible, featuring ARIA attributes (aria-busy, aria-label) and visually hidden text for screen readers. Skeleton bars use high-contrast grays (#767676, #888888) to ensure visibility for all users, adhering to WCAG AA standards.

---
*PR created automatically by Jules for task [15176540241974103778](https://jules.google.com/task/15176540241974103778) started by @tadanobutubutu*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced loading skeleton states with improved visual representation

* **Accessibility**
  * Improved accessibility support for loading states with proper ARIA attributes
  * Updated design standards for skeleton loaders to meet 3:1 contrast ratio requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->