### PR TITLE
🎨 Palette: Keyboard shortcut for copy and accessibility enhancements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -69,3 +69,11 @@
 ## 2026-04-07 - [Actionable Error States & Contrast Guardrails]
 **Learning:** A static error message is a dead end for users. Adding a prominent "Retry" button within the error container transforms a failure into an actionable event, reducing user frustration. Furthermore, maintaining high-contrast color guardrails for primary metrics (like using #0077aa instead of #00aaff for progress bars on light backgrounds) ensures that essential information remains accessible without relying on hover states or external tools.
 **Action:** Always provide a clear recovery path (Retry/Refresh) in error alerts and enforce WCAG AA (4.5:1) minimum contrast for all primary status indicators.
+
+## 2026-04-09 - [Discoverable Keyboard Shortcuts]
+**Learning:** Adding keyboard shortcuts (like 'C' for Copy) significantly improves power-user efficiency, but they remain hidden without visual cues. Using the `title` attribute to include the shortcut hint (e.g., "Copy to clipboard (C)") and matching `aria-keyshortcuts` ensures that shortcuts are discoverable for all users, including those using assistive technologies.
+**Action:** Always pair keyboard shortcut implementations with corresponding `title` hints and `aria-keyshortcuts` attributes on the triggering UI elements.
+
+## 2026-04-09 - [Contextual Labels for Technical Content]
+**Learning:** Large blocks of raw data, like JSON in a `<pre>` tag, can be disorienting for screen reader users if they lack clear context. Providing a descriptive `aria-label` (e.g., "Screeps statistics JSON") allows users to quickly identify the nature of the data block they are navigating, improving the overall semantic structure of technical dashboards.
+**Action:** Use `aria-label` to provide concise, descriptive context for large technical data displays that don't have an explicit visible heading.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -58,10 +58,12 @@ export default function Dashboard() {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const isR = e.key.toLowerCase() === "r";
+      const key = e.key.toLowerCase();
+      const isR = key === "r";
+      const isC = key === "c";
       const hasModifier = e.ctrlKey || e.metaKey || e.altKey || e.shiftKey;
 
-      if (isR && !hasModifier && !loading && !isRefreshing) {
+      if ((isR || isC) && !hasModifier && !loading && !isRefreshing) {
         const activeElement = document.activeElement;
         const isEditable =
           activeElement instanceof HTMLInputElement ||
@@ -71,13 +73,14 @@ export default function Dashboard() {
 
         if (!isEditable) {
           e.preventDefault();
-          fetchStats(true);
+          if (isR) fetchStats(true);
+          if (isC) handleCopy();
         }
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [fetchStats, loading, isRefreshing]);
+  }, [fetchStats, handleCopy, loading, isRefreshing, stats]);
 
   return (
     <main style={{ fontFamily: "monospace", padding: "clamp(1rem, 5vw, 2rem)", maxWidth: "800px", margin: "0 auto" }}>
@@ -151,6 +154,8 @@ export default function Dashboard() {
           <button
             onClick={() => fetchStats(true)}
             aria-label="Retry fetching stats"
+            aria-keyshortcuts="r"
+            title="Retry (R)"
             style={{
               padding: "0.25rem 0.75rem",
               background: "#d32f2f",
@@ -228,7 +233,8 @@ export default function Dashboard() {
             <button
               onClick={handleCopy}
               aria-label={copied ? "Stats copied" : "Copy stats as JSON"}
-              title="Copy to clipboard"
+              aria-keyshortcuts="c"
+              title="Copy to clipboard (C)"
               style={{
                 position: "absolute",
                 top: "0.5rem",
@@ -245,7 +251,10 @@ export default function Dashboard() {
             >
               {copied ? "✅ Copied!" : "📋 Copy JSON"}
             </button>
-            <pre style={{ background: "#f8f8f8", padding: "1rem", borderRadius: "4px", overflow: "auto" }}>
+            <pre
+              aria-label="Screeps statistics JSON"
+              style={{ background: "#f8f8f8", padding: "1rem", borderRadius: "4px", overflow: "auto" }}
+            >
               {JSON.stringify(stats, null, 2)}
             </pre>
           </div>


### PR DESCRIPTION
### 🎨 Palette: Keyboard shortcut for copy and accessibility enhancements

This PR adds small touches of delight and accessibility to the Screeps Dashboard.

#### 💡 What
- **New Shortcut:** Pressing **'C'** now copies the statistics JSON directly to the clipboard.
- **Improved Shortcut:** The **'R'** shortcut now also triggers the **Retry** button when the dashboard is in an error state.
- **Discoverability:** Updated button titles to include shortcut hints (e.g., "Copy to clipboard (C)").
- **Accessibility:** Added `aria-keyshortcuts` to interactive elements and a descriptive `aria-label` to the raw JSON display for screen reader users.
- **Safety:** Keyboard shortcuts are automatically disabled when focus is on editable elements (inputs, textareas, etc.) to prevent accidental triggers.

#### 🎯 Why
These micro-UX improvements make the dashboard more efficient for power users who frequently monitor and share stats, while ensuring that these powerful features are discoverable and accessible to everyone.

#### ♿ Accessibility
- Implemented `aria-keyshortcuts="c"` and `aria-keyshortcuts="r"`.
- Added `aria-label="Screeps statistics JSON"` to the `<pre>` element.
- Maintained existing WCAG AA contrast standards and focus management.

#### 📸 Verification
- Verified visual feedback and shortcut logic using Playwright.
- Confirmed '✅ Copied!' feedback triggers on 'C' key press.
- Confirmed 'Retry' triggers on 'R' key press in error state.
- Verified that shortcuts do not interfere with browser defaults or text input.

---
*PR created automatically by Jules for task [11803709302058963683](https://jules.google.com/task/11803709302058963683) started by @tadanobutubutu*

## Summary by Sourcery

Add keyboard shortcuts for copying stats and retrying, with corresponding accessibility improvements and documentation updates.

New Features:
- Allow pressing the 'C' key to copy the statistics JSON when the dashboard is not loading or refreshing.
- Extend the existing 'R' keyboard shortcut to trigger the retry action when appropriate.

Enhancements:
- Prevent keyboard shortcuts from firing when focus is on editable elements to avoid accidental triggers.
- Expose keyboard shortcuts via button titles and aria-keyshortcuts for better discoverability and assistive technology support.
- Add an aria-label to the raw JSON <pre> block to provide clearer context for screen reader users.

Documentation:
- Document the keyboard shortcut and accessibility learnings in the palette guidance file.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tadanobutubutu/screeps/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
