### PR TITLE
🛡️ Sentinel: Harden collect API with authorization

### DIFF
--- a/dashboard/app/api/collect/route.ts
+++ b/dashboard/app/api/collect/route.ts
@@ -3,7 +3,15 @@ import { createClient } from "@supabase/supabase-js";
 
 const SCREEPS_API = "https://screeps.com/api";
 
-export async function GET() {
+export async function GET(request: Request) {
+  // Security: Check for authorization secret to prevent unauthorized data collection triggers
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const token = process.env.SCREEPS_TOKEN;
   const username = process.env.SCREEPS_USERNAME;
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;


### PR DESCRIPTION
The `dashboard/app/api/collect/route.ts` endpoint was previously publicly accessible, allowing anyone to trigger data collection from the Screeps API and insertion into the Supabase database. This posed a risk of resource exhaustion and abuse of API rate limits.

I have implemented a standard authorization check using a `CRON_SECRET` environment variable and a Bearer token in the `Authorization` header. This ensures that only authorized callers (such as a configured CRON job) can trigger this endpoint.

- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Unauthorized API access
- 🎯 Impact: Potential resource exhaustion, API rate limit abuse, and unauthorized database writes.
- 🔧 Fix: Implemented Bearer token authorization check.
- ✅ Verification: Verified with a successful dashboard build and passing root-level tests.


---
*PR created automatically by Jules for task [11137907458418992185](https://jules.google.com/task/11137907458418992185) started by @tadanobutubutu*

## Summary by Sourcery

Bug Fixes:
- Restrict access to the collect API endpoint by requiring a Bearer token tied to a CRON_SECRET environment variable, returning 401 for unauthorized requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by adding authorization validation to the data collection API endpoint to prevent unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->