### PR TITLE
🎨 Palette: Enhance dashboard accessibility and shortcut discoverability

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -89,3 +89,7 @@
 ## 2026-04-10 - [Contextual Tooltips for Summarized Metadata]
 **Learning:** Metadata counts (like "2 Rooms") are useful for high-level overviews but lose detail. Correctly handling pluralization ("1 Room" vs "2 Rooms") is a baseline for professional UX. Furthermore, utilizing the `title` attribute to provide a detailed list (e.g., actual room names) on hover adds a layer of depth and context that is available on demand without cluttering the primary interface.
 **Action:** Always pair summarized metadata counts with proper pluralization and detailed hover tooltips to provide drill-down context without visual noise.
+
+## 2026-04-11 - [Keyboard-Accessible Tooltips & Shortcut Discoverability]
+**Learning:** Standard HTML `title` attributes are inaccessible to keyboard-only users because they are only triggered by mouse hover. Adding `tabIndex={0}` and `cursor: "help"` to metadata elements (like room counts or timestamps) makes them focusable, allowing keyboard users to access the supplementary information in the tooltip. Furthermore, a dedicated keyboard shortcut legend in the footer improves discoverability more effectively than relying on tooltips alone.
+**Action:** Always ensure that informative metadata with tooltips is keyboard-focusable and provide a visible shortcut legend for better discoverability of power-user features.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -102,16 +102,18 @@ export default function Dashboard() {
         <div style={{ display: "flex", alignItems: "center", gap: "1rem", flexWrap: "wrap", justifyContent: "flex-end" }}>
           {stats?.rooms && (
             <span
-              style={{ fontSize: "0.9rem", color: "#575757", display: "flex", alignItems: "center", gap: "0.25rem" }}
+              style={{ fontSize: "0.9rem", color: "#575757", display: "flex", alignItems: "center", gap: "0.25rem", cursor: "help", borderBottom: "1px dotted #ccc" }}
               title={`Rooms: ${Object.keys(stats.rooms).join(", ")}`}
+              tabIndex={0}
             >
               <span role="img" aria-label="Rooms">🏠</span> {Object.keys(stats.rooms).length} Room{Object.keys(stats.rooms).length === 1 ? "" : "s"}
             </span>
           )}
           {lastUpdated && (
             <span
-              style={{ fontSize: "0.8rem", color: "#575757" }}
+              style={{ fontSize: "0.8rem", color: "#575757", cursor: "help", borderBottom: "1px dotted #ccc" }}
               title={lastUpdated.toLocaleString()}
+              tabIndex={0}
             >
               Last sync: {lastUpdated.toLocaleTimeString()}
             </span>
@@ -184,6 +186,7 @@ export default function Dashboard() {
           </div>
           <button
             onClick={() => fetchStats(true)}
+            disabled={loading || isRefreshing}
             aria-label="Retry fetching stats"
             aria-keyshortcuts="r"
             title="Retry (R)"
@@ -193,11 +196,14 @@ export default function Dashboard() {
               color: "#fff",
               border: "none",
               borderRadius: "4px",
-              cursor: "pointer",
-              fontSize: "0.8rem"
+              cursor: (loading || isRefreshing) ? "not-allowed" : "pointer",
+              fontSize: "0.8rem",
+              opacity: (loading || isRefreshing) ? 0.6 : 1,
+              transition: "all 0.2s",
+              userSelect: "none"
             }}
           >
-            Retry
+            {isRefreshing ? "Retrying..." : "Retry"}
           </button>
         </div>
       )}
@@ -234,6 +240,7 @@ export default function Dashboard() {
           </div>
           <div
             role="progressbar"
+            tabIndex={0}
             aria-label="Global Control Level progress"
             aria-describedby="gcl-percent"
             aria-valuenow={Math.min(100, Math.floor((stats.gcl.progress / stats.gcl.progressTotal) * 100))}
@@ -241,7 +248,7 @@ export default function Dashboard() {
             aria-valuemax={100}
             aria-valuetext={`${Math.min(100, Math.floor((stats.gcl.progress / stats.gcl.progressTotal) * 100))}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}`}
             title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}`}
-            style={{ width: "100%", height: "12px", background: stats.gcl.progress >= stats.gcl.progressTotal ? "#333333" : "#eeeeee", borderRadius: "6px", overflow: "hidden", marginBottom: "0.5rem" }}
+            style={{ width: "100%", height: "12px", background: stats.gcl.progress >= stats.gcl.progressTotal ? "#333333" : "#eeeeee", borderRadius: "6px", overflow: "hidden", marginBottom: "0.5rem", cursor: "help" }}
           >
             <div style={{ width: `${(stats.gcl.progress / stats.gcl.progressTotal) * 100}%`, height: "100%", background: stats.gcl.progress >= stats.gcl.progressTotal ? "#FFD700" : "#0077aa", transition: "width 0.5s ease-in-out" }} />
           </div>
@@ -334,6 +341,15 @@ export default function Dashboard() {
           )
         )}
       </section>
+
+      <footer style={{ marginTop: "3rem", paddingTop: "1rem", borderTop: "1px solid #eee", fontSize: "0.8rem", color: "#888", display: "flex", justifyContent: "space-between", flexWrap: "wrap", gap: "1rem" }}>
+        <div>
+          Keyboard Shortcuts: <kbd style={{ background: "#eee", padding: "0.1rem 0.3rem", borderRadius: "3px", border: "1px solid #ccc" }}>R</kbd> Refresh · <kbd style={{ background: "#eee", padding: "0.1rem 0.3rem", borderRadius: "3px", border: "1px solid #ccc" }}>C</kbd> Copy JSON
+        </div>
+        <div>
+          Hover/Focus items with <span style={{ cursor: "help", borderBottom: "1px dotted #888" }}>dotted underline</span> for details.
+        </div>
+      </footer>
     </main>
   );
 }


### PR DESCRIPTION
🎨 Palette: Dashboard UX Polish

This PR introduces small but impactful UX and accessibility improvements to the Screeps Dashboard:

1.  **Keyboard Shortcut Discoverability**: Added a dedicated legend in the footer using `<kbd>` tags to highlight the 'R' (Refresh) and 'C' (Copy JSON) shortcuts.
2.  **Accessible Tooltips**: Metadata elements like Room counts and Last Sync timestamps now have `tabIndex={0}`, `cursor: "help"`, and a dotted underline. This ensures keyboard-only users can focus these elements to trigger the native browser `title` tooltips.
3.  **Visual Consistency**: The "Retry" button in the error state was updated to match the primary "Refresh" button's polish, including transitions, `userSelect: none`, and a "Retrying..." loading state.
4.  **GCL Progress Accessibility**: Added `tabIndex={0}` to the GCL progress bar so that the detailed XP-to-next-level tooltip is available via keyboard navigation.

All changes are contained within `dashboard/components/Dashboard.tsx` and have been verified via `pnpm build` and Playwright visual inspection.

---
*PR created automatically by Jules for task [16391294014226909281](https://jules.google.com/task/16391294014226909281) started by @tadanobutubutu*

## Summary by Sourcery

Improve dashboard accessibility, tooltip usability, and shortcut discoverability.

New Features:
- Add a footer legend that documents keyboard shortcuts for refreshing stats and copying JSON.

Enhancements:
- Make metadata tooltips (room counts, last sync time, GCL progress) keyboard-focusable and visually marked as help elements.
- Refine the error-state Retry button to match the primary Refresh button with disabled/loading states and consistent styling.

Documentation:
- Extend the palette guidance with best practices for keyboard-accessible tooltips and visible shortcut legends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts legend in the footer for quick reference
  * Tooltip-based information elements are now keyboard navigable

* **Improvements**
  * Retry button now displays loading progress and disabled states with enhanced visual feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->