### PR TITLE
🛡️ Sentinel: Harden spawnManager against Prototype Pollution

### DIFF
--- a/src/managers/spawnManager.js
+++ b/src/managers/spawnManager.js
@@ -121,7 +121,7 @@ function _buildSpawnQueue(room) {
  */
 function _getTargetCounts(room, rcl) {
     const baseTargets = TARGET_CREEPS_BY_RCL[rcl] || TARGET_CREEPS_BY_RCL[1];
-    const result = Object.assign({}, baseTargets);
+    const result = Object.assign(Object.create(null), baseTargets);
 
     // 建設サイトがある場合はビルダーを追加
     const sites = cache.getConstructionSites(room);
@@ -155,7 +155,7 @@ function _getTargetCounts(room, rcl) {
  * @returns {Object.<string, number>}
  */
 function _getCurrentCounts(room) {
-    const counts = {};
+    const counts = Object.create(null);
     for (const name in Game.creeps) {
         // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
         if (
@@ -348,6 +348,7 @@ function showStats(room) {
 
     logger.info(`[SpawnManager] ルーム ${room.name} のクリープ状況 (RCL ${rcl}):`);
     for (const role in targets) {
+        if (!Object.prototype.hasOwnProperty.call(targets, role)) continue;
         const t = targets[role];
         const c = current[role] || 0;
         const status = c >= t ? '✓' : '⚠️';


### PR DESCRIPTION
Harden `src/managers/spawnManager.js` by using `Object.create(null)` for objects used as maps (counts and targets) and adding `Object.prototype.hasOwnProperty.call()` checks in loops. This prevents Prototype Pollution vulnerabilities where dynamic role names could collide with inherited `Object` properties.

---
*PR created automatically by Jules for task [13810515321593719985](https://jules.google.com/task/13810515321593719985) started by @tadanobutubutu*

## Summary by Sourcery

Harden spawnManager’s creep counting and target tracking against prototype pollution when handling dynamic role keys.

Enhancements:
- Use prototype-less objects for target and current creep count maps to avoid inherited Object properties.
- Guard spawn statistics iteration with explicit hasOwnProperty checks to ensure only real role keys are processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal object handling and property enumeration safety within spawn management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->