### PR TITLE
🛡️ Sentinel: Fix [HIGH] Fail-open authorization in collect route

### DIFF
--- a/dashboard/app/api/collect/route.ts
+++ b/dashboard/app/api/collect/route.ts
@@ -4,11 +4,12 @@ import { createClient } from "@supabase/supabase-js";
 const SCREEPS_API = "https://screeps.com/api";
 
 export async function GET(request: Request) {
-  // Security: Check for authorization secret to prevent unauthorized data collection triggers
+  // Security: Check for authorization secret to prevent unauthorized data collection triggers.
+  // We use a fail-closed logic: if CRON_SECRET is not set or doesn't match, we deny access.
   const authHeader = request.headers.get("authorization");
   const cronSecret = process.env.CRON_SECRET;
 
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Fail-open authorization in `/api/collect`.
🎯 Impact: If the `CRON_SECRET` environment variable was not configured, the authorization check was bypassed, allowing anyone to trigger data collection and potentially leaking account overview data (which contains GCL, power, and room information).
🔧 Fix: Implemented fail-closed logic. Deny access if `CRON_SECRET` is undefined OR if the Bearer token doesn't match.
✅ Verification: 
- Ran `pnpm build` in `dashboard/` to verify type safety and syntax.
- Ran `pnpm test` in root to ensure no regressions.
- Verified that the security logic handles missing environment variables correctly.

---
*PR created automatically by Jules for task [9849519441203515475](https://jules.google.com/task/9849519441203515475) started by @tadanobutubutu*

## Summary by Sourcery

Bug Fixes:
- Fix fail-open behavior in /api/collect by denying access when CRON_SECRET is unset or the provided Bearer token does not match.