### PR TITLE
⚡ Bolt: Cached room-level min-hits repair target

### DIFF
--- a/main.js
+++ b/main.js
@@ -222,6 +222,8 @@ function processCreeps(isLoggingEnabled, isEmotionsEnabled) {
         const towers = [];
         const spawns = [];
         const freeSpawns = [];
+        let minHitsRepairTarget = null;
+        let minHits = Infinity;
 
         for (let i = 0; i < allStructures.length; i++) {
             const s = allStructures[i];
@@ -251,6 +253,11 @@ function processCreeps(isLoggingEnabled, isEmotionsEnabled) {
                 // 味方の構造物の修理（壁以外）
                 if (s.hits < s.hitsMax) {
                     repairTargets.push(s);
+                    // ⚡ PERFORMANCE: 最もダメージを受けているターゲットを追跡 (O(1) lookup用)
+                    if (s.hits < minHits) {
+                        minHits = s.hits;
+                        minHitsRepairTarget = s;
+                    }
                 }
             } else if (type === STRUCTURE_CONTAINER) {
                 containers.push(s);
@@ -259,10 +266,20 @@ function processCreeps(isLoggingEnabled, isEmotionsEnabled) {
                     if (store.getFreeCapacity(RESOURCE_ENERGY) > 0) fillableContainers.push(s);
                     if (store[RESOURCE_ENERGY] > 0) withdrawalSources.push(s);
                 }
-                if (s.hits < s.hitsMax) repairTargets.push(s);
+                if (s.hits < s.hitsMax) {
+                    repairTargets.push(s);
+                    if (s.hits < minHits) {
+                        minHits = s.hits;
+                        minHitsRepairTarget = s;
+                    }
+                }
             } else if (type !== STRUCTURE_WALL && s.hits < s.hitsMax) {
                 // 道路などの修理
                 repairTargets.push(s);
+                if (s.hits < minHits) {
+                    minHits = s.hits;
+                    minHitsRepairTarget = s;
+                }
             }
         }
 
@@ -276,6 +293,7 @@ function processCreeps(isLoggingEnabled, isEmotionsEnabled) {
         room._deliveryTargets = deliveryTargets;
         room._harvesterDeliveryTargets = harvesterDeliveryTargets;
         room._repairTargets = repairTargets;
+        room._minHitsRepairTarget = minHitsRepairTarget;
         room._containers = containers;
         room._containersTick = Game.time;
         room._fillableContainers = fillableContainers;

--- a/role.repairer.js
+++ b/role.repairer.js
@@ -19,16 +19,8 @@ const roleRepairer = {
 
                 // If target is invalid or fully repaired, find a new one
                 if (!target || target.hits === target.hitsMax) {
-                    // ⚡ PERFORMANCE: Find target with minimum hits in O(N)
-                    target = targets[0];
-                    let minHits = target.hits;
-
-                    for (let i = 1; i < targets.length; i++) {
-                        if (targets[i].hits < minHits) {
-                            target = targets[i];
-                            minHits = target.hits;
-                        }
-                    }
+                    // ⚡ PERFORMANCE: main.jsで計算済みの最優先修理ターゲットを使用 (O(1))
+                    target = creep.room._minHitsRepairTarget;
 
                     if (target) {
                         creep.memory.repairTargetId = target.id;

--- a/tests/role.repairer.test.js
+++ b/tests/role.repairer.test.js
@@ -103,6 +103,7 @@ describe('role.repairer', () => {
       upgradeController: jest.fn().mockReturnValue(global.OK),
       room: {
         _repairTargets: [damaged],
+        _minHitsRepairTarget: damaged,
         find: jest.fn().mockReturnValue([damaged]),
         controller: { id: 'controller1' },
       },


### PR DESCRIPTION
Implemented a performance optimization that caches the most damaged structure in each room during the global structure scanning loop. This allows all repairer creeps to find their highest-priority target in O(1) time instead of each performing an O(N) search.

Key changes:
- Track `minHitsRepairTarget` in `main.js` during the single-pass structure categorization.
- Update `role.repairer.js` to use `room._minHitsRepairTarget` for O(1) target selection.
- Update `tests/role.repairer.test.js` to support the new cached property.
- All comments are in Japanese as per project standards.
- Change is under 50 lines.

---
*PR created automatically by Jules for task [7765971381470081858](https://jules.google.com/task/7765971381470081858) started by @tadanobutubutu*

## Summary by Sourcery

Cache the most damaged repairable structure per room during structure scanning and update repairer creeps to use this cached target for constant-time selection.

New Features:
- Add a per-room cached reference to the lowest-hit repairable structure for prioritized repairs.

Enhancements:
- Leverage the cached minimum-hit repair target in the repairer role logic to avoid per-creep scans of all repair targets.

Tests:
- Adjust repairer role tests to account for and validate the new cached minimum-hit repair target on the room object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved repair target selection performance through optimized room processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->