### PR TITLE
🔒 Fix timing attack vulnerability in secret comparison

### DIFF
--- a/dashboard/app/api/collect/route.ts
+++ b/dashboard/app/api/collect/route.ts
@@ -1,15 +1,25 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
+import { timingSafeEqual, createHash } from "crypto";
 
 const SCREEPS_API = "https://screeps.com/api";
 
 export async function GET(request: Request) {
   // Security: Check for authorization secret to prevent unauthorized data collection triggers.
   // We use a fail-closed logic: if CRON_SECRET is not set or doesn't match, we deny access.
-  const authHeader = request.headers.get("authorization");
+  const authHeader = request.headers.get("authorization") || "";
   const cronSecret = process.env.CRON_SECRET;
 
-  if (!cronSecret || authHeader !== `Bearer ${cronSecret}`) {
+  // Security: タイミング攻撃を防ぐために、ハッシュ化した上で一定時間で比較(constant-time comparison)を行います。
+  let isAuthorized = false;
+  if (cronSecret && authHeader) {
+    const expectedAuth = `Bearer ${cronSecret}`;
+    const givenHash = createHash("sha256").update(authHeader).digest();
+    const expectedHash = createHash("sha256").update(expectedAuth).digest();
+    isAuthorized = timingSafeEqual(givenHash, expectedHash);
+  }
+
+  if (!isAuthorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 

--- a/dashboard/app/api/screeps/route.ts
+++ b/dashboard/app/api/screeps/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { timingSafeEqual, createHash } from "crypto";
 
 const SCREEPS_API = "https://screeps.com/api";
 const TOKEN = process.env.SCREEPS_TOKEN ?? "";
@@ -14,8 +15,18 @@ const ALLOWED_ENDPOINTS: Record<string, string> = {
 
 export async function GET(request: Request) {
   // Security: Bearerトークンによる認証を追加し、ダッシュボードへの未承認アクセスを防止
-  const authHeader = request.headers.get("authorization");
-  if (!DASHBOARD_SECRET || authHeader !== `Bearer ${DASHBOARD_SECRET}`) {
+  const authHeader = request.headers.get("authorization") || "";
+
+  // Security: タイミング攻撃を防ぐために、ハッシュ化した上で一定時間で比較(constant-time comparison)を行います。
+  let isAuthorized = false;
+  if (DASHBOARD_SECRET && authHeader) {
+    const expectedAuth = `Bearer ${DASHBOARD_SECRET}`;
+    const givenHash = createHash("sha256").update(authHeader).digest();
+    const expectedHash = createHash("sha256").update(expectedAuth).digest();
+    isAuthorized = timingSafeEqual(givenHash, expectedHash);
+  }
+
+  if (!isAuthorized) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 


### PR DESCRIPTION
🎯 **What:** The secret comparison in `/api/collect` and `/api/screeps` used standard string equality operators, making them vulnerable to timing attacks.
⚠️ **Risk:** An attacker could potentially measure the response time of failed authorization attempts to infer the correct `CRON_SECRET` or `DASHBOARD_SECRET` character by character, leading to unauthorized data collection triggers or unauthorized access to Screeps account data.
🛡️ **Solution:** The comparison has been replaced with a constant-time comparison mechanism using `crypto.timingSafeEqual()`. Both the user-provided token and the expected secret are first hashed using SHA-256 to guarantee identical buffer lengths, effectively preventing length-mismatch errors from revealing the token length and securing the endpoint against timing attacks.

---
*PR created automatically by Jules for task [7614620899670088115](https://jules.google.com/task/7614620899670088115) started by @tadanobutubutu*

## Summary by Sourcery

Harden API authorization for Screeps and collect endpoints to resist timing attacks during secret comparison.

Bug Fixes:
- Prevent timing attack vulnerabilities in DASHBOARD_SECRET bearer token checks for the Screeps API proxy endpoint.
- Prevent timing attack vulnerabilities in CRON_SECRET bearer token checks for the data collection endpoint.

Enhancements:
- Use constant-time, hash-based comparison for bearer authorization headers to avoid leaking secret length or partial matches.