### PR TITLE
🛡️ Sentinel: Harden logger against Memory DoS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -92,3 +92,8 @@
 **Vulnerability:** Prototype Pollution via unvalidated creep names and role keys during aggregation.
 **Learning:** Functions that aggregate data into local objects using dynamic keys (like creep names from `Game.creeps` or role names from configuration) are vulnerable to Prototype Pollution if the keys are not validated. Even if the data source seems "internal", inconsistent state or malicious environment manipulation could exploit these loops.
 **Prevention:** Always use `isSafeKey()` and `Object.prototype.hasOwnProperty.call()` when iterating over environment objects (like `Game.creeps`) and assigning to local objects.
+
+## 2026-04-12 - Memory DoS Hardening for Logging Utility
+**Vulnerability:** Memory Denial of Service (DoS) via unbounded log messages and stack traces in `src/utils/logger.js`.
+**Learning:** In memory-constrained environments like Screeps (2MB limit), utility functions that process and store strings (like loggers) must implement strict length limits. Furthermore, when implementing truncation, it is critical to use robust null/undefined checks (e.g., `val !== null && val !== undefined ? val : ''`) rather than simple falsy checks (e.g., `val || ''`) to ensure that values like `0` or `false` are preserved and correctly logged.
+**Prevention:** Enforce `MAX_LOG_MESSAGE_LENGTH` and `MAX_STACK_TRACE_LENGTH` constants across all logging paths. Always prioritize nullish-aware checks over falsy-based defaults when converting inputs to strings for truncation.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -24,6 +24,15 @@ const _stats = {
 const _history = [];
 const MAX_HISTORY = 50;
 
+/**
+ * Security: Limits for memory-intensive structures to prevent Memory DoS.
+ * Screeps memory is limited to 2MB; unbounded strings can crash the AI.
+ * セキュリティ：メモリ消費によるDoS攻撃を防ぐための制限。
+ * Screepsのメモリは2MBに制限されているため、無制限の文字列はAIをクラッシュさせる可能性があります。
+ */
+const MAX_LOG_MESSAGE_LENGTH = 500;
+const MAX_STACK_TRACE_LENGTH = 2000;
+
 // ============================================================
 // カラーコード（Screeps コンソール用 HTML）
 // ============================================================
@@ -149,9 +158,14 @@ function getLevel() {
 function debug(message, data) {
     if (_level > LOG_LEVEL.DEBUG) return;
     _stats.debug++;
+
+    // Security: Truncate message to avoid Memory DoS
+    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
+    const sanitizedMessage = String(message !== null && message !== undefined ? message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+
     const full = data !== undefined
-        ? `${message} ${_safeStringify(data)}`
-        : message;
+        ? `${sanitizedMessage} ${_safeStringify(data)}`
+        : sanitizedMessage;
     _record('debug', full);
     const escapedFull = _escapeHTML(full);
     console.log(_colorize(`${_prefix('debug')} ${escapedFull}`, COLORS.debug));
@@ -165,9 +179,14 @@ function debug(message, data) {
 function info(message, data) {
     if (_level > LOG_LEVEL.INFO) return;
     _stats.info++;
+
+    // Security: Truncate message to avoid Memory DoS
+    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
+    const sanitizedMessage = String(message !== null && message !== undefined ? message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+
     const full = data !== undefined
-        ? `${message} ${_safeStringify(data)}`
-        : message;
+        ? `${sanitizedMessage} ${_safeStringify(data)}`
+        : sanitizedMessage;
     _record('info', full);
     const escapedFull = _escapeHTML(full);
     console.log(_colorize(`${_prefix('info')} ${escapedFull}`, COLORS.info));
@@ -181,9 +200,14 @@ function info(message, data) {
 function warn(message, data) {
     if (_level > LOG_LEVEL.WARN) return;
     _stats.warn++;
+
+    // Security: Truncate message to avoid Memory DoS
+    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
+    const sanitizedMessage = String(message !== null && message !== undefined ? message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+
     const full = data !== undefined
-        ? `${message} ${_safeStringify(data)}`
-        : message;
+        ? `${sanitizedMessage} ${_safeStringify(data)}`
+        : sanitizedMessage;
     _record('warn', full);
     const escapedFull = _escapeHTML(full);
     console.log(_colorize(`${_prefix('warn')} ${escapedFull}`, COLORS.warn));
@@ -197,9 +221,16 @@ function warn(message, data) {
 function error(message, error) {
     if (_level > LOG_LEVEL.ERROR) return;
     _stats.error++;
-    let full = message;
+
+    // Security: Truncate message to avoid Memory DoS
+    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
+    const sanitizedMessage = String(message !== null && message !== undefined ? message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+
+    let full = sanitizedMessage;
     if (error instanceof Error) {
-        full += ` | ${error.message}`;
+        // Security: Truncate error message to avoid Memory DoS
+        const sanitizedErrorMsg = String(error.message !== null && error.message !== undefined ? error.message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+        full += ` | ${sanitizedErrorMsg}`;
         if (error.stack) {
             full += `\n${getSafeStack(error.stack)}`;
         }
@@ -218,8 +249,13 @@ function error(message, error) {
 function success(message) {
     if (_level > LOG_LEVEL.INFO) return;
     _stats.info++;
-    _record('info', message);
-    console.log(_colorize(`${_prefix('info')} ✓ ${message}`, COLORS.success));
+
+    // Security: Truncate message to avoid Memory DoS
+    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
+    const sanitizedMessage = String(message !== null && message !== undefined ? message : '').substring(0, MAX_LOG_MESSAGE_LENGTH);
+
+    _record('info', sanitizedMessage);
+    console.log(_colorize(`${_prefix('info')} ✓ ${sanitizedMessage}`, COLORS.success));
 }
 
 /**
@@ -232,7 +268,11 @@ function success(message) {
  */
 function getSafeStack(stack, maxLines) {
     if (!stack) return '';
-    const lines = stack.split('\n');
+
+    // Security: 巨大なスタックトレースによるメモリ消費やDoSを防ぐため、入力を2000文字に制限
+    const truncatedStack = String(stack).substring(0, MAX_STACK_TRACE_LENGTH);
+
+    const lines = truncatedStack.split('\n');
     return lines
         .slice(0, maxLines || 5)
         .map((line) => {

--- a/tests/logger_security.test.js
+++ b/tests/logger_security.test.js
@@ -1,0 +1,79 @@
+/**
+ * src/utils/logger.js のセキュリティ（DoS対策）テスト
+ */
+
+// グローバル設定
+global.Game = { time: 100 };
+global.Memory = { logs: [] };
+
+jest.mock('../src/constants', () => ({
+  LOG_LEVEL: {
+    DEBUG: 0,
+    INFO: 1,
+    WARN: 2,
+    ERROR: 3,
+    NONE: 4,
+  },
+  DEFAULT_LOG_LEVEL: 1,
+}), { virtual: true });
+
+const logger = require('../src/utils/logger');
+
+describe('logger security (DoS protection)', () => {
+  beforeEach(() => {
+    global.Memory = { logs: [] };
+    global.Game.time = 100;
+    console.log = jest.fn();
+    logger.setLevel(0);
+    logger.clear();
+  });
+
+  test('long info message should be truncated', () => {
+    const longMessage = 'A'.repeat(1000);
+    logger.info(longMessage);
+
+    const history = logger.getHistory(1);
+    expect(history[0].message.length).toBe(500);
+    expect(history[0].message).toBe('A'.repeat(500));
+  });
+
+  test('falsy values like 0 should be logged correctly', () => {
+    logger.info(0);
+    const history = logger.getHistory(1);
+    expect(history[0].message).toBe('0');
+  });
+
+  test('falsy values like false should be logged correctly', () => {
+    logger.info(false);
+    const history = logger.getHistory(1);
+    expect(history[0].message).toBe('false');
+  });
+
+  test('long error object message should be truncated', () => {
+    const longErrorMessage = 'E'.repeat(1000);
+    const error = new Error(longErrorMessage);
+    // Explicitly clear stack to focus on message truncation
+    error.stack = '';
+    logger.error('Context', error);
+
+    const history = logger.getHistory(1);
+    expect(history[0].message).toContain('Context');
+    expect(history[0].message).toContain('E'.repeat(500));
+    expect(history[0].message).not.toContain('E'.repeat(501));
+    // Full string: "Context" + " | " + 500 Es = 7 + 3 + 500 = 510
+    expect(history[0].message.length).toBe(7 + 3 + 500);
+  });
+
+  test('extremely long stack trace should be truncated in getSafeStack', () => {
+    const longStack = 'at someFunction (/path/to/file.js:1:1)\n'.repeat(100);
+    const safeStack = logger.getSafeStack(longStack);
+
+    // MAX_STACK_TRACE_LENGTH is 2000.
+    // Truncating to 2000 chars should happen before splitting.
+    expect(longStack.length).toBeGreaterThan(2000);
+
+    // The number of lines is also limited by .slice(0, 5)
+    const lines = safeStack.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Harden logger against Memory DoS

### 🚨 Severity: MEDIUM
### 💡 Vulnerability: Memory Denial of Service (DoS)
### 🎯 Impact: Unbounded log messages or stack traces could exceed the 2MB Screeps Memory limit, causing script crashes and loss of game state.
### 🔧 Fix: Implemented strict truncation for all log levels and stack trace processing. Refined truncation logic to correctly handle falsy values like `0` and `false`.
### ✅ Verification: Passed existing tests and new `tests/logger_security.test.js` suite. Verified that `logger.info(0)` correctly logs "0" while `logger.info("A".repeat(1000))` is truncated to 500 characters.

---
*PR created automatically by Jules for task [14455882254622133594](https://jules.google.com/task/14455882254622133594) started by @tadanobutubutu*

## Summary by Sourcery

Harden the logging utility against memory exhaustion by enforcing strict length limits on log messages and stack traces and ensuring safe handling of nullish values.

Enhancements:
- Introduce configurable maximum lengths for log messages and stack traces and apply them across all logger methods, including error handling and success logs.
- Improve stack trace processing to cap input size before line slicing to further limit memory usage.
- Refine string conversion logic in logger functions to correctly preserve and log falsy values like 0 and false instead of dropping them.

Documentation:
- Document the Memory DoS vulnerability and its mitigation in the Sentinel security notes, including best practices for truncation and nullish checks in the logger.

Tests:
- Add a dedicated logger security test suite to verify truncation behavior, safe handling of falsy values, and stack trace length limits.