### PR TITLE
🧹 [code health] Refactor deploy.js to use asynchronous fs.promises.readFile

### DIFF
--- a/deploy.js
+++ b/deploy.js
@@ -127,24 +127,24 @@ if (require.main === module) {
         { name: 'role.explorer', file: 'role.explorer.js' },
     ];
 
-    const modules = {};
-    console.log('Reading module files...');
-    for (const m of files) {
-        try {
-            // ファイルパスの検証
-            const filePath = validateFilePath(m.file);
-            modules[m.name] = fs.readFileSync(filePath, 'utf8');
-            console.log(`  [OK] ${m.name} (${m.file})`);
-        } catch (e) {
-            // エラーメッセージから機密情報を除外
-            const safeMessage = e.message.replace(/token/gi, '[REDACTED]');
-            console.error(`  [ERROR] Failed to read ${m.file}: ${safeMessage}`);
-            process.exit(1);
-        }
-    }
-
     (async () => {
         try {
+            const modules = {};
+            console.log('Reading module files...');
+            for (const m of files) {
+                try {
+                    // ファイルパスの検証
+                    const filePath = validateFilePath(m.file);
+                    modules[m.name] = await fs.promises.readFile(filePath, 'utf8');
+                    console.log(`  [OK] ${m.name} (${m.file})`);
+                } catch (e) {
+                    // エラーメッセージから機密情報を除外
+                    const safeMessage = e.message.replace(/token/gi, '[REDACTED]');
+                    console.error(`  [ERROR] Failed to read ${m.file}: ${safeMessage}`);
+                    process.exit(1);
+                }
+            }
+
             await deployTo('PTR', '/ptr/api/user/code', ptrToken, modules);
             await deployTo('PROD', '/api/user/code', prodToken, modules);
             console.log('All done!');


### PR DESCRIPTION
🎯 **What:** The `fs.readFileSync` method used during the module building process in `deploy.js` was replaced with `await fs.promises.readFile`.

💡 **Why:** Reading files synchronously blocks the event loop in Node.js, which is generally considered an anti-pattern. Even though this script is primarily intended for deployment and not a long-running server, utilizing asynchronous standard library methods adheres to modern best practices in Node.js, making the code more idiomatic, readable, and slightly more performant for I/O bounds.

✅ **Verification:** Verified that `tests/deploy.test.js` passes perfectly. Verified lint checking against `deploy.js` succeeds. Verified that rollup builds perfectly via `pnpm build`.

✨ **Result:** A safer, async-driven approach within the execution module of `deploy.js`.

---
*PR created automatically by Jules for task [11407845968725439765](https://jules.google.com/task/11407845968725439765) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Switch module file loading in deploy.js from synchronous fs.readFileSync to asynchronous fs.promises.readFile within the existing async deployment flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced deployment module loading with asynchronous file operations to improve system performance and reliability while maintaining existing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->