### PR TITLE
🧪 Add tests for _findAvailableContainer in harvester role

### DIFF
--- a/src/roles/harvester.js
+++ b/src/roles/harvester.js
@@ -249,4 +249,4 @@ function getBody(energy) {
     return [WORK, CARRY, MOVE];
 }
 
-module.exports = { run, getBody, TASK };
+module.exports = { run, getBody, TASK, _findAvailableContainer };

--- a/tests/src.roles.harvester.test.js
+++ b/tests/src.roles.harvester.test.js
@@ -137,3 +137,40 @@ describe('src/roles/harvester', () => {
     expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, controller, { range: 3 });
   });
 });
+
+describe('_findAvailableContainer', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('エネルギーが100未満のコンテナは無視し、条件を満たさない場合はnullを返す', () => {
+    const creep = { room: {}, pos: {} };
+    // エネルギーが100未満のコンテナのみを用意する
+    const containers = [
+      { store: { [global.RESOURCE_ENERGY]: 0 } },
+      { store: { [global.RESOURCE_ENERGY]: 99 } }
+    ];
+    mockCache.getContainers.mockReturnValue(containers);
+
+    const result = harvester._findAvailableContainer(creep);
+
+    expect(result).toBeNull();
+    expect(pathfinder.closest).not.toHaveBeenCalled();
+  });
+
+  test('エネルギーが100以上のコンテナがある場合、pathfinder.closestにフィルタリングされた配列を渡す', () => {
+    const creep = { room: {}, pos: { x: 1, y: 1 } };
+    const validContainer1 = { store: { [global.RESOURCE_ENERGY]: 100 } };
+    const validContainer2 = { store: { [global.RESOURCE_ENERGY]: 200 } };
+    const invalidContainer = { store: { [global.RESOURCE_ENERGY]: 50 } };
+
+    mockCache.getContainers.mockReturnValue([validContainer1, invalidContainer, validContainer2]);
+    pathfinder.closest.mockReturnValue(validContainer2);
+
+    const result = harvester._findAvailableContainer(creep);
+
+    // closestに渡される配列が、エネルギー100以上のコンテナのみであるかを確認
+    expect(pathfinder.closest).toHaveBeenCalledWith(creep.pos, [validContainer1, validContainer2]);
+    expect(result).toBe(validContainer2);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap for `_findAvailableContainer` in `src/roles/harvester.js` was addressed. Previously, this function had no direct unit tests to ensure it filters and prioritizes containers with energy >= 100 correctly. I modified `src/roles/harvester.js` to export `_findAvailableContainer` so it can be directly tested.

📊 **Coverage:** The new tests cover two main scenarios:
1. When no containers meet the criteria (energy >= 100), the function should correctly return `null` and avoid calling `pathfinder.closest`.
2. When multiple containers are present, it should properly filter out containers with less than 100 energy and only pass the valid containers to `pathfinder.closest`.

✨ **Result:** Test coverage for `src/roles/harvester.js` is improved, ensuring the container-finding logic works as intended and preventing regressions during future refactors. All comments in the test cases are written in Japanese to comply with repository standards.

---
*PR created automatically by Jules for task [593801665767029458](https://jules.google.com/task/593801665767029458) started by @tadanobutubutu*

## Summary by Sourcery

Add direct tests for the harvester role’s container selection helper and expose it from the module for testing.

Enhancements:
- Export the internal _findAvailableContainer helper from the harvester role module to allow direct testing.

Tests:
- Add unit tests covering container selection when no containers meet the energy threshold and when multiple containers do, ensuring only valid containers are passed to the pathfinder.