### PR TITLE
🧹 [Code Health] Extract circular replacer in logger.js

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -107,6 +107,17 @@ const _escapeHTML = (function () {
     };
 })();
 
+function _createCircularReplacer() {
+    const seen = new WeakSet();
+    return (key, value) => {
+        if (typeof value === 'object' && value !== null) {
+            if (seen.has(value)) return '[Circular]';
+            seen.add(value);
+        }
+        return value;
+    };
+}
+
 /**
  * Security: Safely stringifies an object, handling circular references and limiting length.
  * Prevents Denial of Service (DoS) mid-tick from JSON.stringify failures.
@@ -116,14 +127,7 @@ const _escapeHTML = (function () {
  */
 function _safeStringify(obj, maxLength = 500) {
     try {
-        const seen = new WeakSet();
-        const str = JSON.stringify(obj, (key, value) => {
-            if (typeof value === 'object' && value !== null) {
-                if (seen.has(value)) return '[Circular]';
-                seen.add(value);
-            }
-            return value;
-        });
+        const str = JSON.stringify(obj, _createCircularReplacer());
         return str.substring(0, maxLength);
     } catch (e) {
         return '[Unstringifiable Object]';


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was an overly long `_safeStringify` function in `src/utils/logger.js`. The inline logic for tracking circular references using `WeakSet` was extracted.
💡 **Why:** This improves maintainability and readability by separating the closure-generating logic from the stringification logic. It makes the `_safeStringify` function more concise.
✅ **Verification:** I ran the full test suite using `pnpm test`, verifying that `tests/logger.test.js`, `tests/logger_security.test.js` and `tests/utils.logging.test.js` all continued to pass.
✨ **Result:** The code is simpler and more organized without any change in behavior. The logic isolation prevents any potential state bleed across `JSON.stringify` calls.

---
*PR created automatically by Jules for task [8443157151303518582](https://jules.google.com/task/8443157151303518582) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Extract circular reference tracking logic from _safeStringify into a reusable circular replacer helper to simplify logger stringification.