### PR TITLE
🧪 test: add missing edge case for getStats empty properties in roomManager

### DIFF
--- a/tests/roomManager.test.js
+++ b/tests/roomManager.test.js
@@ -158,6 +158,23 @@ describe('roomManager', () => {
       expect(stats.energyCapacity).toBe(300);
     });
 
+    test('プロパティが欠落しているエッジケースを処理する（コントローラーなし等）', () => {
+      const roomWithoutController = {
+        name: 'W1N2',
+        energyAvailable: 0,
+        energyCapacityAvailable: 0
+      };
+
+      const stats = roomManager.getStats(roomWithoutController);
+
+      expect(stats).toBeDefined();
+      expect(stats.name).toBe('W1N2');
+      expect(stats.rcl).toBe(0);
+      expect(stats.controllerProgress).toBe(0);
+      expect(stats.safeMode).toBe(false);
+      expect(stats.storageEnergy).toBe(0);
+    });
+
     test('クリープ数をロール別にカウントする', () => {
       global.Game.creeps = {
         creep1: { room: mockRoom, memory: { role: 'harvester' } },


### PR DESCRIPTION
🎯 **What:** The `getStats` function in `src/managers/roomManager.js` extracts data from rooms (like `controller.level` and `controller.progress`). If a room object passed to it is missing properties (such as lacking a `controller`), it includes fallbacks to `0` or `false`. However, this missing/empty properties edge case was not previously tested, leaving a potential gap where changes could inadvertently break these fallbacks.

📊 **Coverage:** A new test case `'プロパティが欠落しているエッジケースを処理する（コントローラーなし等）'` was added to the `getStats` test block in `tests/roomManager.test.js`. This test explicitly passes a mock room without a controller (and missing `storage`, etc.) to verify that the fallback values correctly trigger without causing runtime errors.

✨ **Result:** Test suite coverage is improved by explicitly verifying that `getStats` effectively shields against missing optional objects, ensuring reliable dashboard stat extraction even in edge cases or poorly initialized rooms. Total tests run and passed successfully.

---
*PR created automatically by Jules for task [2595959065204882579](https://jules.google.com/task/2595959065204882579) started by @tadanobutubutu*

## Summary by Sourcery

Tests:
- Add a unit test verifying getStats correctly returns fallback values when the room lacks a controller and other optional properties.