### PR TITLE
🎨 Palette: Add visual feedback for dashboard updates

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -531,9 +531,11 @@ export default function Dashboard() {
                     style={{
                         marginBottom: '1.5rem',
                         padding: '1rem',
-                        border: '1px solid #eee',
+                        border: updated ? '1px solid #1e7e34' : '1px solid #eee',
                         borderRadius: '4px',
-                        boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
+                        boxShadow: updated
+                            ? '0 0 0 2px #1e7e34'
+                            : '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
                         opacity: loading || isRefreshing ? 0.6 : 1,
                         transition: 'all 0.2s ease-in-out',
                     }}
@@ -712,9 +714,10 @@ export default function Dashboard() {
                         style={{
                             position: 'relative',
                             // コントラスト比向上のため濃い緑に変更 (#28a745 -> #1e7e34)
+                            border: updated ? '1px solid #1e7e34' : 'none',
                             boxShadow: isJsonFocused
                                 ? '0 0 0 2px #0077aa'
-                                : copied
+                                : updated || copied
                                   ? '0 0 0 2px #1e7e34'
                                   : '0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)',
                             transition: 'all 0.2s ease-in-out',


### PR DESCRIPTION
This pull request implements a micro-UX enhancement for the Screeps Dashboard.

💡 **What:** Added conditional styling to the primary data containers (GCL stats and Raw JSON).
🎯 **Why:** Users need immediate, clear visual feedback after clicking "Refresh" to know that the data has indeed been updated, especially when values change subtly or not at all.
♿ **Accessibility:** The highlight uses a high-contrast green (#1e7e34) that meets WCAG AA standards against the white background.
📸 **Verification:** Confirmed via Playwright script; a green border and focus-like ring appear for 2 seconds after a successful refresh.

Note: Temporary build artifacts and lock files generated during verification have been excluded from this commit to keep the PR focused and clean.

---
*PR created automatically by Jules for task [12767660051356798983](https://jules.google.com/task/12767660051356798983) started by @tadanobutubutu*

## Summary by Sourcery

Add visual update highlighting to key dashboard data containers after refresh actions.

New Features:
- Provide conditional green border and focus-style ring for the main GCL stats container when data has been updated.
- Highlight the Raw JSON container with a green border and ring when its data is refreshed or copied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dashboard visual styling to enhance user experience. Statistics sections now feature green highlighting and enhanced shadows when data is refreshed, making recently updated information stand out. Improvements apply to both GCL stats and JSON containers, providing clearer visual feedback for data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->