### PR TITLE
🧹 [code health] Refactor overly long get function in cache.js

### DIFF
--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -62,6 +62,18 @@ function ensureCache() {
     return global.cache;
 }
 
+function _getValidEntry(cache, key) {
+    const entry = Object.prototype.hasOwnProperty.call(cache, key) ? cache[key] : undefined;
+    if (entry && typeof entry.expires === 'number' && entry.expires > Game.time) {
+        return entry;
+    }
+    return undefined;
+}
+
+function _canAddCacheEntry(cache) {
+    return Object.keys(cache).length < MAX_CACHE_ENTRIES;
+}
+
 /**
  * 汎用キャッシュ取得/設定
  * @param {string} key - キャッシュキー
@@ -71,21 +83,15 @@ function ensureCache() {
  */
 function get(key, fetcher, ttl) {
     // Security: Validate key
-    if (!isSafeKey(key)) {
-        return fetcher();
-    }
+    if (!isSafeKey(key)) return fetcher();
 
     const cache = ensureCache();
-    const entry = Object.prototype.hasOwnProperty.call(cache, key) ? cache[key] : undefined;
 
-    if (entry && typeof entry.expires === 'number' && entry.expires > Game.time) {
-        return entry.data;
-    }
+    const validEntry = _getValidEntry(cache, key);
+    if (validEntry) return validEntry.data;
 
     // Security: Cap the number of cache entries to prevent Memory DoS
-    if (!entry && Object.keys(cache).length >= MAX_CACHE_ENTRIES) {
-        return fetcher();
-    }
+    if (!_canAddCacheEntry(cache)) return fetcher();
 
     const data = fetcher();
     cache[key] = {


### PR DESCRIPTION
🎯 **What:**
Refactored the `get` function in `src/utils/cache.js` to address the code health issue of it being overly long. Extracted expiration checking logic into `_getValidEntry` and cache entry limit checking into `_canAddCacheEntry`.

💡 **Why:**
Breaking down the `get` function makes it easier to read and maintain. Extracting logic into focused helper functions adheres to the single responsibility principle.

✅ **Verification:**
1. Ran `npx jest tests/cache.test.js --reporters default` and verified that 14 tests pass correctly.
2. Manually verified the refactored code visually using `cat`.
3. Ran `pnpm build` to ensure no build errors are present. 

✨ **Result:**
The `get` function is now significantly shorter and its logic is decoupled into manageable helper functions, while preserving all existing cache functionalities such as TTL tracking and DoS limits.

---
*PR created automatically by Jules for task [16015308164480589281](https://jules.google.com/task/16015308164480589281) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Extract cache entry validation and capacity checking from the generic get function into dedicated helper functions to shorten and clarify the core cache access path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal cache handling logic by consolidating validation and capacity checks into helper functions. No user-facing changes or new capabilities added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->