### PR TITLE
🧹 [Code Health] Refactor overly long _attack function in defender.js

### DIFF
--- a/src/roles/defender.js
+++ b/src/roles/defender.js
@@ -78,26 +78,59 @@ function _attack(creep, enemies) {
     const dist = creep.pos.getRangeTo(target);
 
     if (hasRanged) {
-        if (dist <= RANGED_RANGE) {
-            creep.rangedAttack(target);
-            // 近すぎる場合は距離を取る（kiting）
-            if (dist <= 1 && hasMelee) {
-                creep.attack(target);
-            } else if (dist <= 1) {
-                _fleeFrom(creep, target.pos);
-                return;
-            }
-        } else {
-            pathfinder.moveTo(creep, target, { range: RANGED_RANGE });
-        }
+        const shouldReturn = _executeRangedCombat(creep, target, dist, hasMelee);
+        if (shouldReturn) return;
     } else if (hasMelee) {
-        if (dist <= MELEE_RANGE) {
-            creep.attack(target);
-        } else {
-            pathfinder.moveTo(creep, target, { range: MELEE_RANGE });
-        }
+        _executeMeleeCombat(creep, target, dist);
     }
 
+    _drawAttackLine(creep, target);
+}
+
+/**
+ * 遠距離攻撃の実行とカイト処理
+ * @param {Creep} creep
+ * @param {Creep} target
+ * @param {number} dist
+ * @param {boolean} hasMelee
+ * @returns {boolean} 早期リターンすべきか
+ */
+function _executeRangedCombat(creep, target, dist, hasMelee) {
+    if (dist <= RANGED_RANGE) {
+        creep.rangedAttack(target);
+        // 近すぎる場合は距離を取る（kiting）
+        if (dist <= 1 && hasMelee) {
+            creep.attack(target);
+        } else if (dist <= 1) {
+            _fleeFrom(creep, target.pos);
+            return true;
+        }
+    } else {
+        pathfinder.moveTo(creep, target, { range: RANGED_RANGE });
+    }
+    return false;
+}
+
+/**
+ * 近接攻撃の実行
+ * @param {Creep} creep
+ * @param {Creep} target
+ * @param {number} dist
+ */
+function _executeMeleeCombat(creep, target, dist) {
+    if (dist <= MELEE_RANGE) {
+        creep.attack(target);
+    } else {
+        pathfinder.moveTo(creep, target, { range: MELEE_RANGE });
+    }
+}
+
+/**
+ * 攻撃対象へのビジュアルライン描画
+ * @param {Creep} creep
+ * @param {Creep} target
+ */
+function _drawAttackLine(creep, target) {
     // 攻撃対象をビジュアル表示
     creep.room.visual.line(creep.pos, target.pos, {
         color: '#ff4444',


### PR DESCRIPTION
🎯 **What:** Extracted the combat logic from the overly long `_attack` function in `src/roles/defender.js` into smaller helper functions (`_executeRangedCombat`, `_executeMeleeCombat`, `_drawAttackLine`).
💡 **Why:** This improves the readability and maintainability of the defender role by adhering to the single responsibility principle and breaking down complex nested logic.
✅ **Verification:** Verified by running the full test suite (`npx jest --reporters default`) to ensure no existing functionality (including the tricky kiting early-return logic) was broken.
✨ **Result:** The `_attack` function is now much cleaner and easier to understand, routing logic safely to dedicated helper functions.

---
*PR created automatically by Jules for task [13186016052976486510](https://jules.google.com/task/13186016052976486510) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Extract ranged combat, melee combat, and attack visualization from the defender _attack function into dedicated helpers to simplify and clarify defender behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to the defender role's combat mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->