### PR TITLE
🛡️ Sentinel: add security headers to dashboard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -102,3 +102,8 @@
 **Vulnerability:** Prototype Pollution via iteration over engine-provided objects and dynamic map lookups in `auto.evolution.js`.
 **Learning:** Iterating over engine objects (like `Game.rooms`) using `for...in` is vulnerable if `Object.prototype` is polluted. Similarly, using dynamic strings as keys for map lookups without validation can allow access to inherited properties like `constructor`.
 **Prevention:** Replace `for...in` with `Object.values()` for safe iteration. Use `Object.prototype.hasOwnProperty.call()` for map lookups and implement `isSafeKey` validation for all dynamic keys.
+
+## 2026-04-22 - Pragmatic CSP for Next.js Dashboard
+**Vulnerability:** Potential for XSS and Clickjacking due to missing security headers in the dashboard.
+**Learning:** A strict Content Security Policy (CSP) like `script-src 'self'` can break Next.js hydration, which relies on inline scripts for state and components. Pragmatic headers must balance security and functionality to prevent functional regressions.
+**Prevention:** Always include `'unsafe-inline'` in CSP `script-src` for Next.js applications unless a robust nonce/hash system is implemented for all hydration scripts. Implement `X-Frame-Options: DENY` and `X-Content-Type-Options: nosniff` as standard global defaults.

--- a/dashboard/next.config.mjs
+++ b/dashboard/next.config.mjs
@@ -5,5 +5,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+    async headers() {
+        return [
+            {
+                source: '/(.*)',
+                headers: [
+                    {
+                        key: 'X-Content-Type-Options',
+                        value: 'nosniff',
+                    },
+                    {
+                        key: 'X-Frame-Options',
+                        value: 'DENY',
+                    },
+                    {
+                        key: 'Referrer-Policy',
+                        value: 'strict-origin-when-cross-origin',
+                    },
+                    {
+                        key: 'Content-Security-Policy',
+                        value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';",
+                    },
+                ],
+            },
+        ];
+    },
+};
 export default nextConfig;


### PR DESCRIPTION
🛡️ Sentinel: add security headers to dashboard

This commit adds standard security headers to the Next.js dashboard to improve defense-in-depth:
- X-Content-Type-Options: nosniff
- X-Frame-Options: DENY
- Referrer-Policy: strict-origin-when-cross-origin
- Content-Security-Policy: restrict resource loading while allowing unsafe-inline for scripts/styles to support Next.js hydration.

Also updates the sentinel journal with learnings about pragmatic CSP.

---
*PR created automatically by Jules for task [14461792052631713279](https://jules.google.com/task/14461792052631713279) started by @tadanobutubutu*

## Summary by Sourcery

Add global security headers to the Next.js dashboard and document related security learnings in the Sentinel journal.

New Features:
- Apply standard security headers to all dashboard routes, including CSP, X-Frame-Options, X-Content-Type-Options, and Referrer-Policy.

Documentation:
- Document pragmatic Content Security Policy considerations and standard security headers for the dashboard in the Sentinel security journal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced dashboard security by adding HTTP headers that protect against XSS attacks, clickjacking attempts, and content-type sniffing exploits. These security measures are now enforced globally across all application routes.
* **Documentation**
  * Added guidance documenting security best practices and vulnerability prevention strategies for dashboard applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->