### PR TITLE
🛡️ Sentinel: Fix Console Injection in utils.logging.js

### DIFF
--- a/tests/sentinel_console_injection.test.js
+++ b/tests/sentinel_console_injection.test.js
@@ -1,0 +1,28 @@
+const utilsLogging = require('../utils.logging');
+
+describe('Sentinel: Console Injection in utils.logging.js', () => {
+    beforeEach(() => {
+        global.Game = { time: 100 };
+        global.Memory = { logs: [] };
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('log() should escape HTML tags in the level parameter to prevent Console Injection', () => {
+        const maliciousLevel = '<img src=x onerror=alert(1)>';
+        utilsLogging.log(maliciousLevel, 'test message');
+
+        const consoleCalls = console.log.mock.calls;
+        expect(consoleCalls.length).toBe(1);
+
+        // If it's not escaped, the console output will contain the raw HTML tags
+        const output = consoleCalls[0][0];
+
+        // We expect it to be escaped
+        expect(output).not.toContain('<img');
+        expect(output).toContain('&lt;img');
+    });
+});

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -73,12 +73,11 @@ module.exports = {
             ? emojiMap[sanitizedLevel]
             : '\ud83d\udcac';
 
-        // Security: Escape message to prevent HTML injection in the console
+        // Security: Escape level and message to prevent HTML injection in the console
+        const escapedLevel = this._escapeHTML(sanitizedLevel);
         const escapedMessage = this._escapeHTML(sanitizedMessage);
 
-        console.log(
-            `${emoji} [${sanitizedLevel}] ${escapedMessage}`
-        );
+        console.log(`${emoji} [${escapedLevel}] ${escapedMessage}`);
     },
 
     // Convenience methods


### PR DESCRIPTION
Hardened `utils.logging.js` by escaping the `level` parameter in the `log` function to prevent HTML injection in the Screeps console. This follows the principle of defense in depth by treating all metadata output to the console as untrusted. Added a new test suite to verify the fix and ensure no regressions.

---
*PR created automatically by Jules for task [12036357149106903547](https://jules.google.com/task/12036357149106903547) started by @tadanobutubutu*

## Summary by Sourcery

Escape log level metadata in console logging to prevent HTML/console injection vulnerabilities and add coverage for the regression scenario.

Bug Fixes:
- Escape the logging level string before writing to the Screeps console to prevent HTML injection via crafted level values.

Tests:
- Add a Sentinel regression test to ensure the log() function escapes HTML tags in the level parameter before logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced logging security by preventing HTML injection attacks through proper escaping of HTML tags in console output.

* **Tests**
  * Added test coverage validating console logging security protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->