### PR TITLE
🛡️ Sentinel: Harden Memory Initialization against State Corruption

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -112,3 +112,8 @@
 **Vulnerability:** Memory Denial of Service (DoS) via unbounded room tracking in `role.scout.js`.
 **Learning:** While `isSafeKey` is critical for user-controlled strings, applying it to engine-provided strings like `room.name` can be redundant "security theater" if the engine enforces strict formats. However, even "safe" keys can cause DoS if allowed to grow unbounded in the 2MB Screeps memory. A tight limit (e.g., 20) can also cause functional degradation; limits must be balanced with the feature's purpose.
 **Prevention:** Enforce generous but firm limits (e.g., 100) on all dynamic collections in `Memory`. Use pre-calculated counters (`visitedCount`) instead of `Object.keys().length` to maintain performance during security checks.
+
+## 2026-04-24 - Robust Initialization against State Corruption
+**Vulnerability:** Denial of Service (DoS) via `NaN` propagation from partially initialized global `Memory` objects.
+**Learning:** Checking for the existence of a root object (`if (!Memory.stats)`) is insufficient if that object can be pre-initialized as an empty object (`{}`) by external systems, manual resets, or buggy code. Subsequent arithmetic operations on missing properties result in `NaN`, which can propagate and cause fatal errors or logical failures (e.g., `roomStats` access throwing `TypeError`).
+**Prevention:** Use a robust initialization pattern that always iterates over a set of defaults and populates missing properties, even if the root object already exists. This ensures the system always has a valid, consistent state regardless of how the root object was created.

--- a/tests/utils.stats.robustness.test.js
+++ b/tests/utils.stats.robustness.test.js
@@ -1,0 +1,40 @@
+/**
+ * utils.stats.js Robustness Tests
+ */
+
+global.Game = {
+  time: 100,
+  creeps: {},
+  rooms: {},
+  cpu: { getUsed: jest.fn().mockReturnValue(10) },
+};
+global.Memory = {};
+
+const StatsManager = require('../utils.stats');
+
+describe('utils.stats robustness', () => {
+  beforeEach(() => {
+    global.Memory = {};
+  });
+
+  test('recordHarvest correctly initializes and increments if Memory.stats is an empty object', () => {
+    // Simulate external system or manual mistake initializing Memory.stats as {}
+    global.Memory.stats = {};
+
+    // StatsManager.initMemory() should now populate defaults even for {}
+    StatsManager.recordHarvest(100);
+
+    expect(global.Memory.stats.totalEnergyProcessed).toBe(100);
+  });
+
+  test('recordRoomStat correctly initializes and records if Memory.stats is an empty object', () => {
+    global.Memory.stats = {};
+
+    // This should no longer throw and should correctly initialize roomStats
+    expect(() => {
+      StatsManager.recordRoomStat('W1N1', 'energy', 100);
+    }).not.toThrow();
+
+    expect(global.Memory.stats.roomStats['W1N1'].energy).toBe(100);
+  });
+});

--- a/utils.stats.js
+++ b/utils.stats.js
@@ -9,16 +9,24 @@ const MAX_ROOM_STATS = 50;
 const StatsManager = {
     initMemory() {
         if (!Memory.stats) {
-            Memory.stats = {
-                totalEnergyProcessed: 0,
-                totalEnergyUpgraded: 0,
-                totalBuildProgress: 0,
-                totalRepairDone: 0,
-                roomStats: {},
-                creepDeaths: 0,
-                creepsBorn: 0,
-                startTime: Game.time,
-            };
+            Memory.stats = {};
+        }
+
+        const defaults = {
+            totalEnergyProcessed: 0,
+            totalEnergyUpgraded: 0,
+            totalBuildProgress: 0,
+            totalRepairDone: 0,
+            roomStats: {},
+            creepDeaths: 0,
+            creepsBorn: 0,
+            startTime: Game.time,
+        };
+
+        for (const key in defaults) {
+            if (Memory.stats[key] === undefined) {
+                Memory.stats[key] = defaults[key];
+            }
         }
     },
 


### PR DESCRIPTION
This PR hardens the `utils.stats.js` module against state corruption. Previously, if `Memory.stats` was pre-initialized as an empty object (e.g., via manual reset), the system would fail to populate defaults, leading to `NaN` values and potential script crashes. The fix implements a robust defaults-merging pattern. Unit tests have been added to verify the fix.

---
*PR created automatically by Jules for task [15364330885926159674](https://jules.google.com/task/15364330885926159674) started by @tadanobutubutu*

## Summary by Sourcery

Harden stats memory initialization to remain robust when Memory.stats is pre-created or partially initialized.

Bug Fixes:
- Ensure stats defaults are applied even when Memory.stats is an existing empty or partially populated object, preventing NaN propagation and runtime errors in stats calculations.

Enhancements:
- Document the new robust initialization pattern and associated DoS risk in the Sentinel security notes.

Tests:
- Add robustness tests for utils.stats to verify correct behavior when Memory.stats starts as an empty object and when recording room stats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stats initialization to ensure all required statistics are properly populated and prevent crashes from missing or incomplete memory state.

* **Tests**
  * Added robustness test suite to verify stats recording functions correctly even with incomplete or empty memory initialization.

* **Documentation**
  * Documented a previously identified failure mode and its resolution strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->