### PR TITLE
⚡ Bolt: optimize rainbowTrail with volatile cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -135,3 +135,7 @@
 ## 2026-12-01 - Optimizing High-Frequency Structure Scanning
 **Learning:** In the Screeps environment, rooms often contain thousands of walls which dominate the `FIND_STRUCTURES` array. Performing even basic Proxy property lookups (like `s.my` or `s.hits`) on these non-essential objects during every tick's scanning loop (`warmRoomCache`) is a massive CPU drain. Implementing an early `continue` for walls and hoisting `hits`/`hitsMax` into local variables for other structures significantly reduces per-tick CPU overhead.
 **Action:** Always use early `continue` for high-volume, non-essential objects in scanning loops and hoist frequently accessed engine properties to local variables to minimize Proxy lookup costs.
+
+## 2026-04-28 - Volatile Cache for Visual Effects
+**Learning:** Storing high-frequency visual data like trail positions in `Memory` causes significant CPU overhead due to JSON serialization/deserialization every tick. JavaScript `Map` in the module scope provides O(1) access and completely bypasses the `Memory` bottleneck. However, it requires manual cleanup (e.g., every 1500 ticks) to prevent memory leaks from dead creeps.
+**Action:** Use module-scoped `Map` for non-persistent, high-frequency data and implement periodic cleanup tied to object lifespans.

--- a/tests/visual.effects.test.js
+++ b/tests/visual.effects.test.js
@@ -205,16 +205,18 @@ describe('visual.effects', () => {
     global.Game.time = 1000; // 1000: 次のテスト用のキャッシュリセット値
   });
 
-  test('rainbowTrailのtrailPositionsが10件を超えた場合に古い位置を削除する', () => {
+  test('rainbowTrailはtrailPositionsをMemoryからvolatile cacheに移行する', () => {
     const mockCreep = {
+      id: 'creep1',
       pos: { x: 25, y: 25 },
       room: { name: 'W0N0' },
       memory: {
         trailPositions: Array.from({ length: 10 }, (_, i) => ({ x: i, y: i }))
       }
     };
-    global.Game.time = 2000; // 2000: 前のテストと異なるtickでキャッシュをリセット
+    global.Game.time = 2000;
     expect(() => visualEffects.rainbowTrail(mockCreep)).not.toThrow();
-    expect(mockCreep.memory.trailPositions.length).toBeLessThanOrEqual(10);
+    // Memoryからは削除されているはず
+    expect(mockCreep.memory.trailPositions).toBeUndefined();
   });
 });

--- a/visual.effects.js
+++ b/visual.effects.js
@@ -12,6 +12,10 @@ let _isVfxEnabledValue = true;
 let _visualsCache = {};
 let _visualsTick = -1;
 
+// ⚡ PERFORMANCE: Volatile cache for rainbow trail positions to avoid Memory serialization overhead.
+// Using a Map for O(1) lookups by creep ID.
+let _trailCache = new Map();
+
 /**
  * Checks if visual effects are enabled, with per-tick caching.
  */
@@ -274,26 +278,41 @@ const visualEffects = {
      * レインボートレイル
      */
     rainbowTrail: function (creep) {
+        // ⚡ PERFORMANCE: Periodic cleanup of the volatile trail cache (every 1500 ticks)
+        // This prevents memory leaks from creeps that have died.
+        if (Game.time % 1500 === 0 && _trailCache.size > 0) {
+            _trailCache.clear();
+        }
+
         if (!isVfxEnabled()) {
             if (creep.memory.trailPositions) {
                 delete creep.memory.trailPositions;
             }
+            _trailCache.delete(creep.id);
             return;
         }
         const visual = getVisual(creep.room.name);
 
-        if (!creep.memory.trailPositions) {
-            creep.memory.trailPositions = [];
+        // ⚡ PERFORMANCE: Migrate from Memory to volatile cache if existing data is found.
+        if (creep.memory.trailPositions) {
+            _trailCache.set(creep.id, creep.memory.trailPositions);
+            delete creep.memory.trailPositions;
         }
 
-        creep.memory.trailPositions.push({ x: creep.pos.x, y: creep.pos.y });
-
-        if (creep.memory.trailPositions.length > 10) {
-            creep.memory.trailPositions.shift();
+        let positions = _trailCache.get(creep.id);
+        if (!positions) {
+            positions = [];
+            _trailCache.set(creep.id, positions);
         }
 
-        for (let i = 0; i < creep.memory.trailPositions.length; i++) {
-            const trailPos = creep.memory.trailPositions[i];
+        positions.push({ x: creep.pos.x, y: creep.pos.y });
+
+        if (positions.length > 10) {
+            positions.shift();
+        }
+
+        for (let i = 0; i < positions.length; i++) {
+            const trailPos = positions[i];
             visual.circle(trailPos.x, trailPos.y, {
                 radius: 0.2,
                 fill: RAINBOW_COLORS[i % RAINBOW_COLORS.length],
@@ -428,6 +447,7 @@ const visualEffects = {
         _visualsCache = {};
         _visualsTick = -1;
         _isVfxEnabledTick = -1;
+        _trailCache.clear();
     },
 };
 


### PR DESCRIPTION
I have optimized the `rainbowTrail` effect in `visual.effects.js` by moving the trail position data from `creep.memory` to a volatile JavaScript `Map` cache. 

This change significantly reduces the CPU overhead associated with Screeps' automatic JSON serialization/deserialization of the `Memory` object every tick. 

The implementation includes:
1. A migration path for existing trail data in memory.
2. A periodic cleanup mechanism (every 1500 ticks) to prevent memory leaks in the global scope.
3. Updated unit tests to verify the new behavior.

This optimization follows Bolt's philosophy of making the codebase faster through surgical, measurable improvements without sacrificing readability.

---
*PR created automatically by Jules for task [10414364826654827501](https://jules.google.com/task/10414364826654827501) started by @tadanobutubutu*

## Summary by Sourcery

Optimize the rainbowTrail visual effect by moving creep trail position tracking from persistent Memory storage to a volatile in-process cache for reduced CPU overhead.

New Features:
- Introduce a module-scoped Map-based cache to store rainbow trail positions per creep instead of using creep.memory.

Enhancements:
- Add periodic cleanup of the rainbow trail cache and ensure it is cleared when visual effects are reset to avoid stale entries.
- Implement migration logic that transparently moves existing trail position data from creep.memory into the new volatile cache.
- Update Bolt engineering notes to document the caching strategy and guidelines for high-frequency visual data.

Tests:
- Adjust rainbowTrail tests to validate that trail position data is migrated out of Memory into the volatile cache.