### PR TITLE
🧹 [Code Health] Refactor displayStats in main.js

### DIFF
--- a/main.js
+++ b/main.js
@@ -455,11 +455,7 @@ function handleDefenseAndDashboard (rooms, isLoggingEnabled, isVisualEffectsEnab
   }
 }
 
-function displayStats (creeps) {
-  const isLoggingEnabled = adaptiveSystem.isEnabled('logging')
-  const isEmotionsEnabled = adaptiveSystem.isEnabled('emotions')
-  const isGamificationEnabled = adaptiveSystem.isEnabled('gamification')
-
+function _displayCoreStats (creeps) {
   console.log(
     '\n⚡ Tick: ' +
             Game.time +
@@ -477,29 +473,45 @@ function displayStats (creeps) {
             ')'
   )
   console.log('💾 Memory: ' + (RawMemory.get().length / 1024).toFixed(1) + ' KB')
+}
 
-  if (isLoggingEnabled) {
-    const logStats = logger.getStats()
-    if (logStats.errors > 0) {
-      logger.warn('Recent errors: ' + logStats.errors)
-    }
+function _displayLogStats () {
+  const logStats = logger.getStats()
+  if (logStats.errors > 0) {
+    logger.warn('Recent errors: ' + logStats.errors)
+  }
+}
+
+function _displayEmotionStats () {
+  const emotionStats = EmotionSystem.getStats()
+  console.log(
+    '😊 Happy: ' +
+              (emotionStats.veryHappy + emotionStats.happy) +
+              ', Neutral: ' +
+              emotionStats.neutral
+  )
+}
+
+function _displayGamificationStats () {
+  const gm = Memory.gamification
+  if (gm) {
+    console.log('🎮 Level: ' + gm.level + ', XP: ' + gm.xp + '/' + gm.xpToNext)
+  }
+}
+
+function displayStats (creeps) {
+  _displayCoreStats(creeps)
+
+  if (adaptiveSystem.isEnabled('logging')) {
+    _displayLogStats()
   }
 
-  if (isEmotionsEnabled) {
-    const emotionStats = EmotionSystem.getStats()
-    console.log(
-      '😊 Happy: ' +
-                (emotionStats.veryHappy + emotionStats.happy) +
-                ', Neutral: ' +
-                emotionStats.neutral
-    )
+  if (adaptiveSystem.isEnabled('emotions')) {
+    _displayEmotionStats()
   }
 
-  if (isGamificationEnabled) {
-    const gm = Memory.gamification
-    if (gm) {
-      console.log('🎮 Level: ' + gm.level + ', XP: ' + gm.xp + '/' + gm.xpToNext)
-    }
+  if (adaptiveSystem.isEnabled('gamification')) {
+    _displayGamificationStats()
   }
 }
 


### PR DESCRIPTION
🎯 **What:** Extracted the logic inside `displayStats` in `main.js` into smaller, focused helper functions.

💡 **Why:** `displayStats` was overly long and mixed various concerns (core engine stats, logging stats, emotion stats, and gamification stats). Refactoring it into smaller functions (`_displayCoreStats`, `_displayLogStats`, etc.) improves readability, testability, and maintainability.

✅ **Verification:** Ran the full test suite using `npx jest --reporters default`. All 567 tests passed successfully. The behavior of `displayStats` remains exactly the same.

✨ **Result:** A cleaner, more modular `displayStats` function in `main.js`.

---
*PR created automatically by Jules for task [15317476515309922488](https://jules.google.com/task/15317476515309922488) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Split the monolithic displayStats function into focused helpers for core, logging, emotion, and gamification stats while preserving behavior.