### PR TITLE
🔒 [Security Fix] Remove 'unsafe-inline' from CSP script-src

### DIFF
--- a/dashboard/next.config.mjs
+++ b/dashboard/next.config.mjs
@@ -25,7 +25,7 @@ const nextConfig = {
                     },
                     {
                         key: 'Content-Security-Policy',
-                        value: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';",
+                        value: "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';",
                     },
                 ],
             },


### PR DESCRIPTION
🎯 **What:** Removed the `'unsafe-inline'` directive from the `'script-src'` policy in the Content-Security-Policy (CSP) header defined in `next.config.mjs`, and replaced it with `'unsafe-eval'`.
⚠️ **Risk:** The `'unsafe-inline'` directive allowed the execution of inline scripts, creating a severe vulnerability to Cross-Site Scripting (XSS) attacks. Attackers could potentially inject malicious scripts, compromising user data or application integrity.
🛡️ **Solution:** Updated the CSP header to strictly disallow `'unsafe-inline'` scripts in the `script-src` directive. `'unsafe-eval'` was added to ensure Next.js functionality during development and hydration processes is maintained without requiring a complex nonce/hash implementation, which significantly mitigates the XSS risk while avoiding a massive rewrite of how Next.js injects development scripts. (Note: `'unsafe-inline'` remains in `style-src` as it's required for the extensive use of React inline styles within the dashboard components, maintaining compatibility with the existing design patterns while patching the most critical injection vector.)

---
*PR created automatically by Jules for task [7271201103961437543](https://jules.google.com/task/7271201103961437543) started by @tadanobutubutu*

## Summary by Sourcery

Tighten the dashboard Content-Security-Policy by disallowing inline scripts while preserving required development behavior.

Bug Fixes:
- Remove the 'unsafe-inline' directive from the CSP script-src to reduce exposure to XSS attacks.

Enhancements:
- Allow 'unsafe-eval' in CSP script-src to maintain Next.js development and hydration behavior without inline scripts.