### PR TITLE
🧪 Add missing test for towerManager empty enemies fallback

### DIFF
--- a/tests/towerManager.test.js
+++ b/tests/towerManager.test.js
@@ -98,6 +98,15 @@ describe('towerManager', () => {
       expect(mockTower.attack).toHaveBeenCalled();
     });
 
+    test('敵がいない場合は攻撃処理をスキップする', () => {
+      cache.getEnemies.mockReturnValue([]);
+      cache.getMyStructures.mockReturnValue([mockTower]);
+
+      towerManager.run(mockRoom);
+
+      expect(mockTower.attack).not.toHaveBeenCalled();
+    });
+
     test('味方が負傷している場合は回復する', () => {
       const mockCreep = {
         id: 'creep1',


### PR DESCRIPTION
🎯 **What:** The testing gap in `_tryAttack` where an empty `enemies` array is passed to it is now addressed.
📊 **Coverage:** The scenario where the tower does not attempt to attack when there are no enemies (or the enemies array falls back to empty) is now tested in `tests/towerManager.test.js`.
✨ **Result:** Test coverage for `src/managers/towerManager.js` has been improved, and the previously untested fallback is now explicitly verified to skip the attack and prevent errors.

---
*PR created automatically by Jules for task [4518612933357347292](https://jules.google.com/task/4518612933357347292) started by @tadanobutubutu*

## Summary by Sourcery

Tests:
- Add a unit test ensuring towerManager.run does not call tower attacks when the enemies list is empty.