### PR TITLE
🛡️ Sentinel: [security improvement] Harden cache utility against DoS

### DIFF
--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -90,8 +90,12 @@ function get(key, fetcher, ttl) {
     const validEntry = _getValidEntry(cache, key);
     if (validEntry) return validEntry.data;
 
-    // Security: Cap the number of cache entries to prevent Memory DoS
-    if (!_canAddCacheEntry(cache)) return fetcher();
+    // Security: Cap the number of cache entries to prevent Memory DoS.
+    // If full, attempt to cleanup expired entries once before giving up.
+    if (!_canAddCacheEntry(cache)) {
+        cleanup();
+        if (!_canAddCacheEntry(cache)) return fetcher();
+    }
 
     const data = fetcher();
     cache[key] = {
@@ -116,16 +120,23 @@ function invalidate(key) {
 /**
  * パターンに一致するキャッシュをまとめて無効化する
  * @param {RegExp|string} pattern - 無効化するキーのパターン
+ *
+ * Security: Wrapped in try-catch to prevent script crashes (DoS) from
+ * invalid or malicious regex strings.
  */
 function invalidatePattern(pattern) {
-    const cache = ensureCache();
-    const regex = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
-    for (const key in cache) {
-        if (isSafeKey(key) && Object.prototype.hasOwnProperty.call(cache, key)) {
-            if (regex.test(key)) {
-                delete cache[key];
+    try {
+        const cache = ensureCache();
+        const regex = typeof pattern === 'string' ? new RegExp(pattern) : pattern;
+        for (const key in cache) {
+            if (isSafeKey(key) && Object.prototype.hasOwnProperty.call(cache, key)) {
+                if (regex.test(key)) {
+                    delete cache[key];
+                }
             }
         }
+    } catch (e) {
+        // Silently fail if regex is invalid
     }
 }
 

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -77,6 +77,23 @@ describe('cache', () => {
 
       expect(fetcher).toHaveBeenCalledTimes(2);
     });
+
+    test('キャッシュがいっぱいの場合、期限切れをクリーンアップして新しいエントリを追加する', () => {
+      const MAX_CACHE_ENTRIES = 100;
+      // 期限切れのエントリでキャッシュを埋める
+      for (let i = 0; i < MAX_CACHE_ENTRIES; i++) {
+        cache.get(`key_${i}`, () => `data_${i}`, 10);
+      }
+
+      global.Game.time += 20; // すべて期限切れにする
+
+      const fetcher = jest.fn().mockReturnValue('new_data');
+      const result = cache.get('new_key', fetcher, 10);
+
+      expect(fetcher).toHaveBeenCalled();
+      expect(result).toBe('new_data');
+      expect(Object.keys(global.cache).length).toBe(1); // 以前のものはクリーンアップされ、新しい1つだけが残る
+    });
   });
 
   describe('invalidate', () => {
@@ -107,6 +124,12 @@ describe('cache', () => {
 
       expect(fetcher1).toHaveBeenCalledTimes(2);
       expect(fetcher2).toHaveBeenCalledTimes(2);
+    });
+
+    test('不正な正規表現文字列でクラッシュしない', () => {
+      expect(() => {
+        cache.invalidatePattern('['); // 不正な正規表現
+      }).not.toThrow();
     });
   });
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Availability Denial of Service (DoS) via cache exhaustion and regex injection.
🎯 Impact:
- Expired entries could occupy the cache, leading to frequent cache bypasses and increased CPU usage.
- Malicious or invalid regex strings passed to `invalidatePattern` could crash the script.
🔧 Fix:
- Implemented proactive `cleanup()` in `cache.get()` when the entry limit is reached to reclaim space from expired entries.
- Added `try-catch` block in `invalidatePattern()` to safely handle invalid regex inputs.
✅ Verification:
- Added unit tests in `tests/cache.test.js` to verify that `get()` successfully cleans up expired entries when full.
- Added a unit test to ensure `invalidatePattern()` does not throw on invalid regex.
- All 20 tests in `tests/cache.test.js` pass.

---
*PR created automatically by Jules for task [15440658402551251605](https://jules.google.com/task/15440658402551251605) started by @tadanobutubutu*

## Summary by Sourcery

Harden the cache utility against denial-of-service vectors by improving entry limit handling and making pattern-based invalidation resilient to invalid input.

Bug Fixes:
- Ensure cache.get() attempts to reclaim space from expired entries when the cache is full before bypassing the cache.
- Prevent cache.invalidatePattern() from throwing when given invalid or malicious regular expression strings.

Tests:
- Add tests verifying that a full cache cleans up expired entries and accepts new ones.
- Add a test confirming invalidatePattern() does not crash when called with an invalid regex string.