### PR TITLE
🎨 Palette: GCL Progress Delta Marker

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -817,6 +817,7 @@ export default function Dashboard() {
                                     : '#eeeeee',
                             borderRadius: '6px',
                             overflow: 'hidden',
+                            position: 'relative',
                             marginBottom: '0.5rem',
                             cursor: 'help',
                             boxShadow: isBarFocused ? '0 0 0 2px #0077aa' : 'none',
@@ -824,6 +825,19 @@ export default function Dashboard() {
                             transition: 'box-shadow 0.2s',
                         }}
                     >
+                        {prevStats?.gcl && gclDelta > 0 && stats.gcl.level === prevStats.gcl.level && (
+                            <div
+                                title={`Previous progress: ${prevGclPercent.toFixed(2)}%`}
+                                style={{
+                                    left: `${prevGclPercent}%`,
+                                    width: '2px',
+                                    height: '100%',
+                                    position: 'absolute',
+                                    background: 'rgba(255, 255, 255, 0.4)',
+                                    zIndex: 1,
+                                }}
+                            />
+                        )}
                         <div
                             style={{
                                 width: `${gclPercent}%`,


### PR DESCRIPTION
Implemented a micro-UX improvement by adding a visual marker for previous progress on the GCL progress bar in the Screeps dashboard. This allows users to see at a glance how much progress was gained since the last sync.

---
*PR created automatically by Jules for task [16193483282681362940](https://jules.google.com/task/16193483282681362940) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Introduce an overlay marker on the GCL progress bar showing prior progress percentage to highlight recent gains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The GCL progress bar now displays an overlay marker showing your previous progress position, making it easier to track how much progress you've earned at your current level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->