### PR TITLE
🧪 [Testing Improvement] Add tests for formatNumber in utils.dashboard.js

### DIFF
--- a/tests/utils.dashboard.test.js
+++ b/tests/utils.dashboard.test.js
@@ -153,4 +153,24 @@ describe('DashboardRenderer', () => {
             expect.objectContaining({ opacity: expect.any(Number) })
         );
     });
+
+    describe('formatNumber', () => {
+        test('formats numbers under 1000 as string', () => {
+            expect(DashboardRenderer.formatNumber(0)).toBe('0');
+            expect(DashboardRenderer.formatNumber(500)).toBe('500');
+            expect(DashboardRenderer.formatNumber(999)).toBe('999');
+        });
+
+        test('formats numbers between 1000 and 1000000 with K suffix', () => {
+            expect(DashboardRenderer.formatNumber(1000)).toBe('1.0K');
+            expect(DashboardRenderer.formatNumber(1500)).toBe('1.5K');
+            expect(DashboardRenderer.formatNumber(999900)).toBe('999.9K');
+        });
+
+        test('formats numbers over 1000000 with M suffix', () => {
+            expect(DashboardRenderer.formatNumber(1000000)).toBe('1.0M');
+            expect(DashboardRenderer.formatNumber(1500000)).toBe('1.5M');
+            expect(DashboardRenderer.formatNumber(10000000)).toBe('10.0M');
+        });
+    });
 });

--- a/utils.dashboard.js
+++ b/utils.dashboard.js
@@ -14,6 +14,8 @@ function formatNumber(num) {
 }
 
 const DashboardRenderer = {
+    formatNumber,
+
     renderRoomDashboard(room) {
         // ⚡ PERFORMANCE OPTIMIZATION: Use centralized room caches pre-warmed in main.js.
         if (room._myCreepsTick !== Game.time) {


### PR DESCRIPTION
🎯 **What:** Added tests for the `formatNumber` pure function in `utils.dashboard.js`. Exposed the function as a property on `DashboardRenderer` to allow testing.
📊 **Coverage:** Tested all three formatting boundary conditions: numbers under 1,000 (rendered as strings), numbers from 1,000 to 999,999 (rendered with K suffix), and numbers 1,000,000+ (rendered with M suffix).
✨ **Result:** Increased test coverage for UI/Dashboard utilities, ensuring format behavior handles string coercion and numeric precision correctly.

---
*PR created automatically by Jules for task [13497743571784532146](https://jules.google.com/task/13497743571784532146) started by @tadanobutubutu*

## Summary by Sourcery

Add coverage for dashboard number formatting and expose the formatter via the dashboard renderer for direct testing.

Enhancements:
- Expose the internal formatNumber helper as a DashboardRenderer property to make its formatting behavior directly testable.

Tests:
- Add unit tests for DashboardRenderer.formatNumber to cover sub-1,000, thousands (K), and millions (M) formatting ranges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added number formatting utility that displays numbers below 1,000 as-is, numbers in thousands with 'K' suffix (one decimal place), and numbers in millions with 'M' suffix (one decimal place).

* **Tests**
  * Added comprehensive test coverage for the number formatting feature across all value ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->