### PR TITLE
🎨 Palette: Room delta tracking and staleness urgency

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-05-15 - [GCL/Power Delta Tracking]
 **Learning:** Adding immediate visual feedback for incremental progress (like GCL/Power increases) significantly enhances the "living" feel of a dashboard. However, implementation must strictly adhere to React best practices—specifically, avoiding state updates within other state updater functions to prevent side effects and maintain predictable rendering behavior.
 **Action:** Always perform related state updates sequentially in the main logic flow rather than nested within functional updaters. Maintain surgical edits to stay within line count constraints and follow existing style and design patterns.
+
+## 2025-05-16 - [Urgency Animations & Delta Feedback]
+**Learning:** Subtle, high-frequency animations (like `shake`) are more effective than slow animations (like `pulse`) for conveying critical status or urgency in compact UIs. Additionally, explicit delta indicators (e.g., `+1` for room gains) provide immediate "success feedback" that raw numbers lack, improving the user's sense of progress during brief dashboard checks.
+**Action:** Use `shake` for critical alerts and include numeric deltas for all key resources to emphasize recent changes.

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -30,6 +30,11 @@ export default function RootLayout({
             40% { transform: translateY(-10px); }
             60% { transform: translateY(-5px); }
           }
+          @keyframes shake {
+            0%, 100% { transform: translateX(0); }
+            25% { transform: translateX(-2px); }
+            75% { transform: translateX(2px); }
+          }
         `}</style>
       </head>
       <body>{children}</body>

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -36,6 +36,9 @@ export default function Dashboard() {
     const [timeAgo, setTimeAgo] = useState<string>('just now');
 
     const roomCount = stats?.rooms ? Object.keys(stats.rooms).length : 0;
+    const prevRoomCount = prevStats?.rooms ? Object.keys(prevStats.rooms).length : 0;
+    const roomDelta = prevStats ? roomCount - prevRoomCount : 0;
+
     const gclPercent = stats?.gcl
         ? Math.min(100, (stats.gcl.progress / stats.gcl.progressTotal) * 100)
         : 0;
@@ -292,6 +295,19 @@ export default function Dashboard() {
                                 {roomCount === 1 ? '🏠' : '🏘️'}
                             </span>{' '}
                             {roomCount} Room{roomCount === 1 ? '' : 's'}
+                            {roomDelta !== 0 && (
+                                <span
+                                    style={{
+                                        fontSize: '0.8rem',
+                                        color: roomDelta > 0 ? '#1e7e34' : '#d32f2f',
+                                        marginLeft: '0.25rem',
+                                        fontWeight: 'bold',
+                                    }}
+                                    aria-label={roomDelta > 0 ? `Gained ${roomDelta} room` : `Lost ${Math.abs(roomDelta)} room`}
+                                >
+                                    ({roomDelta > 0 ? '+' : ''}{roomDelta})
+                                </span>
+                            )}
                         </span>
                     )}
                     {lastUpdated && (
@@ -323,7 +339,7 @@ export default function Dashboard() {
                                 style={{
                                     animation:
                                         getStalenessInfo().icon === '🚨'
-                                            ? 'pulse 1.5s infinite'
+                                            ? 'shake 0.3s infinite'
                                             : 'none',
                                 }}
                             >


### PR DESCRIPTION
This PR implements a micro-UX enhancement for the Screeps Dashboard.

### 💡 What:
- Added a `roomDelta` indicator that shows gained (+X) or lost (-X) rooms next to the room count.
- Introduced a `@keyframes shake` animation in the global layout.
- Switched the critical staleness indicator (🚨) from a `pulse` to a `shake` animation.

### 🎯 Why:
- Raw numbers don't clearly communicate recent changes. Explicit deltas provide immediate success/failure feedback.
- Critical status alerts benefit from higher-frequency animations to better capture user attention compared to slow pulses.

### ♿ Accessibility:
- Added `aria-label` to the room delta indicators to ensure screen readers communicate the change status (e.g., "Gained 1 room").
- Maintained existing ARIA patterns for the refreshed components.

### ✅ Verification:
- Verified build with `pnpm build`.
- Visually verified with Playwright screenshots showing both gain (+1) and loss cases.
- Ensured no hallucinated lockfiles are included.

---
*PR created automatically by Jules for task [9102776015010546423](https://jules.google.com/task/9102776015010546423) started by @tadanobutubutu*

## Summary by Sourcery

Add room count delta indicators and update critical staleness animation to improve urgency signalling and feedback in the dashboard.

Enhancements:
- Display gained or lost room deltas alongside the room count, including accessible ARIA labels for screen readers.
- Introduce a reusable global `shake` keyframes animation and apply it to critical staleness indicators instead of the previous pulse effect.
- Document learnings about urgency animations and numeric delta feedback in the Jules palette notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays numeric delta indicators next to room counts to show increases and decreases.

* **Improvements**
  * Critical alert animation updated to a shake effect for improved visual urgency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->