### PR TITLE
🛡️ Sentinel: [security improvement] Harden memory and logging utilities against DoS via state corruption

### DIFF
--- a/tests/sentinel_dos_cache.test.js
+++ b/tests/sentinel_dos_cache.test.js
@@ -1,0 +1,68 @@
+/**
+ * tests/sentinel_dos_cache.test.js
+ * Reproduces a DoS vulnerability in utils.memory.js
+ */
+
+global.Game = { time: 100 };
+global.Memory = { cache: {} };
+
+const utilsMemory = require('../utils.memory');
+
+describe('utils.memory DoS reproduction', () => {
+    beforeEach(() => {
+        global.Memory = { cache: {} };
+    });
+
+    test('cleanCache should NOT throw if an entry is null and should remove it', () => {
+        // Corrupt memory with a null entry
+        global.Memory.cache = {
+            'corrupted_entry': null
+        };
+
+        // This should now run successfully
+        expect(() => utilsMemory.cleanCache()).not.toThrow();
+        expect(global.Memory.cache['corrupted_entry']).toBeUndefined();
+    });
+
+    test('cleanCache should remove entries with invalid timestamp', () => {
+        // Corrupt memory with an entry having invalid timestamp
+        global.Memory.cache = {
+            'invalid_timestamp': { value: 'test', timestamp: 'invalid' }
+        };
+
+        utilsMemory.cleanCache();
+        expect(global.Memory.cache['invalid_timestamp']).toBeUndefined();
+    });
+});
+
+const utilsLogging = require('../utils.logging');
+
+describe('utils.logging DoS hardening', () => {
+    beforeEach(() => {
+        global.Memory = { logs: [] };
+    });
+
+    test('getStats should NOT throw if logs contain null', () => {
+        global.Memory.logs = [
+            { level: 'error', message: 'test' },
+            null,
+            { level: 'info', message: 'test' }
+        ];
+
+        let stats;
+        expect(() => { stats = utilsLogging.getStats(); }).not.toThrow();
+        expect(stats.errors).toBe(1);
+        expect(stats.info).toBe(1);
+    });
+
+    test('getStats should handle logs with missing level', () => {
+        global.Memory.logs = [
+            { message: 'no level' }
+        ];
+
+        let stats;
+        expect(() => { stats = utilsLogging.getStats(); }).not.toThrow();
+        expect(stats.total).toBe(1);
+        expect(stats.errors).toBe(0);
+    });
+});

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -181,14 +181,17 @@ module.exports = {
         };
 
         Memory.logs.forEach((log) => {
-            if (log.level === 'error') {
-                stats.errors++;
-            } else if (log.level === 'warn') {
-                stats.warnings++;
-            } else if (log.level === 'info') {
-                stats.info++;
-            } else if (log.level === 'debug') {
-                stats.debug++;
+            // Security: Add null check and validate level to prevent DoS via state corruption.
+            if (log && typeof log.level === 'string') {
+                if (log.level === 'error') {
+                    stats.errors++;
+                } else if (log.level === 'warn') {
+                    stats.warnings++;
+                } else if (log.level === 'info') {
+                    stats.info++;
+                } else if (log.level === 'debug') {
+                    stats.debug++;
+                }
             }
         });
 

--- a/utils.memory.js
+++ b/utils.memory.js
@@ -160,7 +160,14 @@ module.exports = {
         for (const key in Memory.cache) {
             // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
             if (isSafeKey(key) && Object.prototype.hasOwnProperty.call(Memory.cache, key)) {
-                if (Game.time - Memory.cache[key].timestamp > maxAge) {
+                const entry = Memory.cache[key];
+                // Security: Add null check and ensure timestamp is a valid number to prevent DoS via state corruption.
+                if (entry && typeof entry.timestamp === 'number') {
+                    if (Game.time - entry.timestamp > maxAge) {
+                        delete Memory.cache[key];
+                    }
+                } else {
+                    // Security: If the entry is corrupted, delete it to restore consistency.
                     delete Memory.cache[key];
                 }
             }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential Denial of Service (DoS) through state corruption in persistent Memory objects.
🎯 Impact: If `Memory.cache` or `Memory.logs` contains `null` or malformed entries (due to bugs, manual intervention, or environment glitches), core cleanup and statistics functions would throw unhandled `TypeErrors`, potentially crashing the entire script loop repeatedly.
🔧 Fix: Added defensive null-checks and type validation (e.g., `typeof entry.timestamp === 'number'`) before property access in `utils.memory.js` and `utils.logging.js`. Malformed entries are now safely skipped or removed.
✅ Verification: Created `tests/sentinel_dos_cache.test.js` to reproduce the crashes and verify the fixes. Ran the full test suite (610 tests), all of which passed.

---
*PR created automatically by Jules for task [10123804608622228359](https://jules.google.com/task/10123804608622228359) started by @tadanobutubutu*

## Summary by Sourcery

Harden logging and memory cache utilities against crashes from corrupted in-memory state and add regression tests for the previous DoS condition.

Bug Fixes:
- Prevent getStats from throwing when Memory.logs contains null or entries without a valid level by validating log objects before counting.
- Prevent cleanCache from throwing when Memory.cache entries are null or have non-numeric timestamps by validating and purging corrupted entries.

Tests:
- Add sentinel_dos_cache tests to reproduce and verify resilience against DoS caused by corrupted Memory.cache and Memory.logs entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of memory management and logging utilities to gracefully handle corrupted or invalid data entries without failures or incorrect reporting.

* **Tests**
  * Added comprehensive test coverage for denial-of-service (DoS) hardening scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->