### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden Screeps API collection route

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -137,3 +137,8 @@
 **Vulnerability:** Denial of Service (DoS) via script crashes from uninitialized or partially initialized persistent memory state.
 **Learning:** Checking for the existence of a root object (`if (!Memory.stats)`) is insufficient if that object can be pre-initialized as an empty object (`{}`) by external systems, manual resets, or buggy code. Subsequent property access (e.g., `.push()`) or arithmetic on missing properties results in fatal TypeErrors or `NaN` propagation, hanging or crashing the AI.
 **Prevention:** Implement a robust initialization pattern that always iterates over a set of defaults and populates missing properties (using a non-destructive merging loop), even if the root object already exists. This ensures the system always has a valid, consistent state regardless of how the root object was created.
+
+## 2026-05-15 - Hardening Third-Party API Responses
+**Vulnerability:** Denial of Service (DoS) via runtime crash (TypeError) from malformed third-party API responses.
+**Learning:** Dashboard API routes (e.g., `dashboard/app/api/collect/route.ts`) that proxy or collect data from external services often assume the response structure is guaranteed. If the upstream service returns an unexpected format or missing nested objects (like `data.gcl`), accessing those properties directly causes a fatal TypeError that crashes the route for that request.
+**Prevention:** Always strictly validate the existence and type of the response data and its nested objects before property access. Use optional chaining (`?.`) as a secondary defense layer. Log detailed error information internally for debugging while returning generic, safe error messages to the client to prevent internal structure leakage.

--- a/dashboard/app/api/collect/route.ts
+++ b/dashboard/app/api/collect/route.ts
@@ -61,11 +61,20 @@ export async function GET(request: Request) {
 
     const data = await res.json();
 
+    // Security: Validate API response structure to prevent runtime errors from malformed data
+    if (!data || typeof data !== "object" || !data.gcl) {
+      console.error("Malformed Screeps API response: missing data or gcl object");
+      return NextResponse.json(
+        { error: "Malformed response from Screeps API" },
+        { status: 502 }
+      );
+    }
+
     if (supabase) {
       const { error } = await supabase.from("screeps_stats").insert({
-        gcl_level: data.gcl.level,
-        gcl_progress: data.gcl.progress,
-        gcl_progress_total: data.gcl.progressTotal,
+        gcl_level: data.gcl?.level,
+        gcl_progress: data.gcl?.progress,
+        gcl_progress_total: data.gcl?.progressTotal,
         power: data.power,
         cpu_used: data.cpuUsed,
         rooms: data.rooms,
@@ -83,6 +92,8 @@ export async function GET(request: Request) {
 
     return NextResponse.json({ success: true, data });
   } catch (err) {
+    // Security: Log the actual error for internal debugging while returning a generic message to the client
+    console.error("Screeps API collection error:", err);
     return NextResponse.json(
       { error: "Failed to fetch from Screeps API" },
       { status: 500 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential for runtime crash (TypeError) in `collect/route.ts` if the Screeps API returns a malformed response (e.g., missing `data.gcl`).
🎯 Impact: Denial of Service (DoS) for the specific data collection request and potential for unobserved failures due to missing error logs in the catch block.
🔧 Fix: Added explicit validation for the `data` and `data.gcl` objects before property access. Updated the `catch` block to log full error details for internal debugging while returning a safe, generic message to the client.
✅ Verification: Manually verified the code changes and ran the full Jest test suite (614/614 passing).

---
*PR created automatically by Jules for task [4773791744825735515](https://jules.google.com/task/4773791744825735515) started by @tadanobutubutu*

## Summary by Sourcery

Harden the Screeps data collection API route against malformed third-party responses and improve error observability.

Bug Fixes:
- Prevent runtime crashes in the Screeps collection route by validating the structure of the Screeps API response before accessing nested fields.

Enhancements:
- Use optional chaining when reading Screeps GCL fields to make the data insertion more resilient to partially missing fields.
- Log detailed errors on Screeps collection failures while returning a generic, safe error message to clients.

Documentation:
- Document the new security pattern for validating third-party API responses and preventing DoS from malformed data in the sentinel playbook.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of API data collection with enhanced validation and error handling
  * Better error messages and logging when API integration issues occur
  * Reduced risk of runtime crashes from unexpected response data formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->