### PR TITLE
🎨 Palette: Dashboard UX polish and accessibility polish

### DIFF
--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -38,6 +38,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           kbd:hover {
             filter: brightness(0.9);
           }
+          kbd:active {
+            transform: translateY(1px);
+          }
           .interactive-hint {
             cursor: help;
             border-bottom: 1px dotted #888;

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -86,51 +86,54 @@ export default function Dashboard() {
         setTimeout(() => setResetSuccess(false), 2000);
     }, [isResetConfirming]);
 
-    const fetchStats = useCallback(async (isManual = false) => {
-        if (isManual) setIsRefreshing(true);
-        else setLoading(true);
+    const fetchStats = useCallback(
+        async (isManual = false) => {
+            if (isManual) setIsRefreshing(true);
+            else setLoading(true);
 
-        try {
-            // Security: sessionStorageからトークンを取得し、認証ヘッダーに含める
-            let token = sessionStorage.getItem('dashboard_token');
-            if (!token) {
-                token = window.prompt('Enter Dashboard Secret:');
-                if (token) {
-                    sessionStorage.setItem('dashboard_token', token);
-                } else {
-                    // 🔑 Security: プロンプトがキャンセルされた場合は、APIリクエストを中断する
-                    throw new Error('Authentication required: Secret not provided');
+            try {
+                // Security: sessionStorageからトークンを取得し、認証ヘッダーに含める
+                let token = sessionStorage.getItem('dashboard_token');
+                if (!token) {
+                    token = window.prompt('Enter Dashboard Secret:');
+                    if (token) {
+                        sessionStorage.setItem('dashboard_token', token);
+                    } else {
+                        // 🔑 Security: プロンプトがキャンセルされた場合は、APIリクエストを中断する
+                        throw new Error('Authentication required: Secret not provided');
+                    }
                 }
-            }
 
-            const r = await fetch('/api/screeps?endpoint=overview', {
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            });
+                const r = await fetch('/api/screeps?endpoint=overview', {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                    },
+                });
 
-            if (r.status === 401) {
-                sessionStorage.removeItem('dashboard_token');
-                throw new Error('Unauthorized: Invalid dashboard secret');
-            }
+                if (r.status === 401) {
+                    sessionStorage.removeItem('dashboard_token');
+                    throw new Error('Unauthorized: Invalid dashboard secret');
+                }
 
-            if (!r.ok) throw new Error(`API error: ${r.status}`);
-            const data = await r.json();
-            setPrevStats(stats);
-            setStats(data);
-            setLastUpdated(new Date());
-            setError(null);
-            if (isManual) {
-                setUpdated(true);
-                setTimeout(() => setUpdated(false), 2000);
+                if (!r.ok) throw new Error(`API error: ${r.status}`);
+                const data = await r.json();
+                setPrevStats(stats);
+                setStats(data);
+                setLastUpdated(new Date());
+                setError(null);
+                if (isManual) {
+                    setUpdated(true);
+                    setTimeout(() => setUpdated(false), 2000);
+                }
+            } catch (e) {
+                setError(String(e));
+            } finally {
+                setLoading(false);
+                setIsRefreshing(false);
             }
-        } catch (e) {
-            setError(String(e));
-        } finally {
-            setLoading(false);
-            setIsRefreshing(false);
-        }
-    }, [stats]);
+        },
+        [stats]
+    );
 
     useEffect(() => {
         fetchStats();
@@ -304,6 +307,11 @@ export default function Dashboard() {
                                         fontWeight: 'bold',
                                     }}
                                     aria-label={
+                                        roomDelta > 0
+                                            ? `Gained ${roomDelta} room`
+                                            : `Lost ${Math.abs(roomDelta)} room`
+                                    }
+                                    title={
                                         roomDelta > 0
                                             ? `Gained ${roomDelta} room`
                                             : `Lost ${Math.abs(roomDelta)} room`
@@ -743,6 +751,7 @@ export default function Dashboard() {
                                                 fontWeight: 'bold',
                                             }}
                                             aria-label={`Increased by ${powerDelta.toLocaleString()}`}
+                                            title={`Increased by ${powerDelta.toLocaleString()}`}
                                         >
                                             (+{powerDelta.toLocaleString()})
                                         </span>
@@ -772,6 +781,11 @@ export default function Dashboard() {
                                                 fontWeight: 'bold',
                                             }}
                                             aria-label={
+                                                cpuDelta > 0
+                                                    ? `Increased by ${cpuDelta.toLocaleString()}`
+                                                    : `Decreased by ${Math.abs(cpuDelta).toLocaleString()}`
+                                            }
+                                            title={
                                                 cpuDelta > 0
                                                     ? `Increased by ${cpuDelta.toLocaleString()}`
                                                     : `Decreased by ${Math.abs(cpuDelta).toLocaleString()}`
@@ -1043,7 +1057,7 @@ export default function Dashboard() {
                             a: 'Refresh stats',
                             state: isRefreshing ? 'a' : updated ? 's' : '',
                             onClick: () => fetchStats(true),
-                            icon: updated ? '✓' : 'R',
+                            icon: isRefreshing ? '🔄' : updated ? '✓' : 'R',
                         },
                         {
                             k: 'C',


### PR DESCRIPTION
🎨 **What:** This PR adds several micro-UX improvements to the Screeps Dashboard.
- **Accessibility:** Adds `title` attributes to statistical delta indicators (Rooms, Power, CPU) so mouse users can discover the meaning of the numbers on hover, mirroring the existing screen reader `aria-label` support.
- **Visual Feedback:** Updates the keyboard shortcut hint for 'Refresh' (R) to show a spinning `🔄` icon while data is being fetched, providing consistent feedback with the main refresh button.
- **Delight:** Adds a tactile `transform: translateY(1px)` effect to the `:active` state of `<kbd>` elements in the footer, making them feel like physical buttons when clicked.

🎯 **Why:** These small touches make the dashboard feel more interactive and responsive, helping users understand recent state changes and providing clearer feedback for asynchronous operations.

♿ **Accessibility:** Improved discoverability for mouse users via `title` attributes on important status indicators.

Verified with Playwright and Jest. No regressions in core logic.

---
*PR created automatically by Jules for task [13842376304651388151](https://jules.google.com/task/13842376304651388151) started by @tadanobutubutu*

## Summary by Sourcery

Polish dashboard UX and accessibility around stats deltas and manual refresh feedback.

Enhancements:
- Add hover titles to room, power, and CPU delta indicators to mirror existing screen reader labels and improve discoverability for mouse users.
- Update the keyboard shortcut hint for manual refresh to show a spinning icon while data is being fetched, aligning its feedback with the main refresh button.
- Add a subtle active-state press effect to footer <kbd> elements to make keyboard hints feel more tactile and interactive.