### PR TITLE
⚡ Bolt: Replace FIND_MY_STRUCTURES with getMyStructures cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -187,3 +187,5 @@
 
 **Learning:** Unconditional calls to initialization functions in systems that run per-creep per-tick (like Emotions) cause significant CPU waste due to repeated object allocation and property checks. Hoisting static result objects (e.g., result emojis) and guarding `initialize()` calls with a fast property check (like `birthTick`) prevents entering the function and creating temporary objects.
 **Action:** Always guard initialization methods in high-frequency loops with a simple property existence check and hoist all static result objects/arrays to the module scope.
+
+- **⚡ Bolt**: In `src/managers/roomManager.js`, replaced `room.find(FIND_MY_STRUCTURES)` with `cache.getMyStructures(room, STRUCTURE_EXTENSION)`. Also updated the search for existing construction sites in `_planSourceContainers` and `_planExtensions` to use `cache.getConstructionSites`. This reduces garbage collection pressure by preventing redundant object allocations from engine arrays.

--- a/src/managers/roomManager.js
+++ b/src/managers/roomManager.js
@@ -10,34 +10,34 @@
  * - 定期的なメモリクリーンアップ
  */
 
-'use strict';
+'use strict'
 
-const cache = require('../utils/cache');
-const pathfinder = require('../utils/pathfinder');
-const logger = require('../utils/logger');
+const cache = require('../utils/cache')
+const pathfinder = require('../utils/pathfinder')
+const logger = require('../utils/logger')
 const {
-    ROLES,
-    CACHE_TTL,
-    MEMORY_CLEANUP_INTERVAL,
-    STATS_DISPLAY_INTERVAL,
-    SAFE_MODE_TRIGGER_HOSTILES,
-} = require('../constants');
+  ROLES,
+  CACHE_TTL,
+  MEMORY_CLEANUP_INTERVAL,
+  STATS_DISPLAY_INTERVAL,
+  SAFE_MODE_TRIGGER_HOSTILES
+} = require('../constants')
 
 // ============================================================
 // 定数
 // ============================================================
 
 /** 建設自動化を行う間隔（ティック数） */
-const BUILD_PLAN_INTERVAL = 500;
+const BUILD_PLAN_INTERVAL = 500
 
 /** セーフモードチェック間隔（ティック数） */
-const SAFE_MODE_CHECK_INTERVAL = 10;
+const SAFE_MODE_CHECK_INTERVAL = 10
 
 /** リンクエネルギー転送の閾値 */
-const LINK_TRANSFER_THRESHOLD = 0.8;
+const LINK_TRANSFER_THRESHOLD = 0.8
 
 /** 建設計画1サイクルで配置する最大道路数 */
-const MAX_ROADS_PER_CYCLE = 5;
+const MAX_ROADS_PER_CYCLE = 5
 
 // ============================================================
 // メイン制御
@@ -47,33 +47,33 @@ const MAX_ROADS_PER_CYCLE = 5;
  * ルーム管理のメインロジックを実行する
  * @param {Room} room
  */
-function run(room) {
-    if (!room.controller || !room.controller.my) return;
+function run (room) {
+  if (!room.controller || !room.controller.my) return
 
-    try {
-        // 定期タスク
-        if (Game.time % MEMORY_CLEANUP_INTERVAL === 0) {
-            _cleanupRoomMemory(room);
-        }
-
-        if (Game.time % BUILD_PLAN_INTERVAL === 0) {
-            _planConstruction(room);
-        }
-
-        if (Game.time % SAFE_MODE_CHECK_INTERVAL === 0) {
-            _checkSafeMode(room);
-        }
-
-        // リンクネットワーク管理（毎ティック）
-        _manageLinkNetwork(room);
-
-        // キャッシュクリーンアップ（定期的に）
-        if (Game.time % 50 === 0) {
-            cache.cleanup();
-        }
-    } catch (e) {
-        logger.error(`[RoomManager] ルーム ${room.name} でエラー`, e);
+  try {
+    // 定期タスク
+    if (Game.time % MEMORY_CLEANUP_INTERVAL === 0) {
+      _cleanupRoomMemory(room)
     }
+
+    if (Game.time % BUILD_PLAN_INTERVAL === 0) {
+      _planConstruction(room)
+    }
+
+    if (Game.time % SAFE_MODE_CHECK_INTERVAL === 0) {
+      _checkSafeMode(room)
+    }
+
+    // リンクネットワーク管理（毎ティック）
+    _manageLinkNetwork(room)
+
+    // キャッシュクリーンアップ（定期的に）
+    if (Game.time % 50 === 0) {
+      cache.cleanup()
+    }
+  } catch (e) {
+    logger.error(`[RoomManager] ルーム ${room.name} でエラー`, e)
+  }
 }
 
 // ============================================================
@@ -84,38 +84,38 @@ function run(room) {
  * 死亡したクリープのメモリを削除する
  * @param {Room} room
  */
-function _cleanupRoomMemory(room) {
-    // 死亡クリープのメモリ削除
-    for (const name in Memory.creeps) {
-        // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
-        if (
-            cache.isSafeKey(name) &&
+function _cleanupRoomMemory (room) {
+  // 死亡クリープのメモリ削除
+  for (const name in Memory.creeps) {
+    // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
+    if (
+      cache.isSafeKey(name) &&
             Object.prototype.hasOwnProperty.call(Memory.creeps, name) &&
             !Game.creeps[name]
-        ) {
-            logger.debug(`[RoomManager] クリープメモリ削除: ${name}`);
-            delete Memory.creeps[name];
-        }
+    ) {
+      logger.debug(`[RoomManager] クリープメモリ削除: ${name}`)
+      delete Memory.creeps[name]
     }
+  }
 
-    // 不要なフラグのクリーンアップ
-    for (const flagName in Game.flags) {
-        // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
-        if (
-            cache.isSafeKey(flagName) &&
+  // 不要なフラグのクリーンアップ
+  for (const flagName in Game.flags) {
+    // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
+    if (
+      cache.isSafeKey(flagName) &&
             Object.prototype.hasOwnProperty.call(Game.flags, flagName)
-        ) {
-            const flag = Game.flags[flagName];
-            if (flag.room && flag.room.name !== room.name) continue;
+    ) {
+      const flag = Game.flags[flagName]
+      if (flag.room && flag.room.name !== room.name) continue
 
-            // 古いパトロールフラグを削除（1000ティック以上）
-            if (flagName.startsWith('patrol_') && flag.memory && flag.memory.createdAt) {
-                if (Game.time - flag.memory.createdAt > 1000) {
-                    flag.remove();
-                }
-            }
+      // 古いパトロールフラグを削除（1000ティック以上）
+      if (flagName.startsWith('patrol_') && flag.memory && flag.memory.createdAt) {
+        if (Game.time - flag.memory.createdAt > 1000) {
+          flag.remove()
         }
+      }
     }
+  }
 }
 
 // ============================================================
@@ -127,174 +127,174 @@ function _cleanupRoomMemory(room) {
  * RCLに応じた構造物を自動的に建設サイトとして配置する
  * @param {Room} room
  */
-function _planConstruction(room) {
-    const rcl = room.controller.level;
+function _planConstruction (room) {
+  const rcl = room.controller.level
 
-    // RCL2以上: ソース周囲にコンテナを配置
-    if (rcl >= 2) {
-        _planSourceContainers(room);
-    }
+  // RCL2以上: ソース周囲にコンテナを配置
+  if (rcl >= 2) {
+    _planSourceContainers(room)
+  }
 
-    // RCL2以上: 主要経路に道路を計画
-    if (rcl >= 2) {
-        _planRoads(room);
-    }
+  // RCL2以上: 主要経路に道路を計画
+  if (rcl >= 2) {
+    _planRoads(room)
+  }
 
-    // RCL2以上: エクステンションを配置
-    if (rcl >= 2) {
-        _planExtensions(room);
-    }
+  // RCL2以上: エクステンションを配置
+  if (rcl >= 2) {
+    _planExtensions(room)
+  }
 }
 
 /**
  * ソース周囲にコンテナを配置する
  * @param {Room} room
  */
-function _planSourceContainers(room) {
-    const sources = cache.getSources(room);
-    const existingContainers = cache.getContainers(room);
+function _planSourceContainers (room) {
+  const sources = cache.getSources(room)
+  const existingContainers = cache.getContainers(room)
 
-    for (const source of sources) {
-        // すでに近くにコンテナがあれば skip
-        const nearby = existingContainers.filter((c) => source.pos.getRangeTo(c) <= 2);
-        if (nearby.length > 0) continue;
+  for (const source of sources) {
+    // すでに近くにコンテナがあれば skip
+    const nearby = existingContainers.filter((c) => source.pos.getRangeTo(c) <= 2)
+    if (nearby.length > 0) continue
 
-        // コンテナの建設サイトがすでにあれば skip
-        const existingSites = cache
-            .getConstructionSites(room)
-            .filter(
-                (s) => s.structureType === STRUCTURE_CONTAINER && source.pos.getRangeTo(s) <= 2
-            );
-        if (existingSites.length > 0) continue;
+    // コンテナの建設サイトがすでにあれば skip
+    const existingSites = cache
+      .getConstructionSites(room)
+      .filter(
+        (s) => s.structureType === STRUCTURE_CONTAINER && source.pos.getRangeTo(s) <= 2
+      )
+    if (existingSites.length > 0) continue
 
-        // ソースの隣の空きタイルにコンテナを配置
-        const pos = pathfinder.findNearestOpenTile(source.pos, 2);
-        if (pos) {
-            const result = room.createConstructionSite(pos.x, pos.y, STRUCTURE_CONTAINER);
-            if (result === OK) {
-                logger.info(`[RoomManager] ソース ${source.id} 付近にコンテナを計画`);
-                cache.invalidate(`construction_sites_${room.name}`);
-            }
-        }
+    // ソースの隣の空きタイルにコンテナを配置
+    const pos = pathfinder.findNearestOpenTile(source.pos, 2)
+    if (pos) {
+      const result = room.createConstructionSite(pos.x, pos.y, STRUCTURE_CONTAINER)
+      if (result === OK) {
+        logger.info(`[RoomManager] ソース ${source.id} 付近にコンテナを計画`)
+        cache.invalidate(`construction_sites_${room.name}`)
+      }
     }
+  }
 }
 
 /**
  * スポーンからソース・コントローラーへの道路を計画する
  * @param {Room} room
  */
-function _planRoads(room) {
-    const spawns = cache.getSpawns(room);
-    if (spawns.length === 0) return;
+function _planRoads (room) {
+  const spawns = cache.getSpawns(room)
+  if (spawns.length === 0) return
 
-    const spawn = spawns[0];
-    const targets = [...cache.getSources(room), room.controller].filter(Boolean);
+  const spawn = spawns[0]
+  const targets = [...cache.getSources(room), room.controller].filter(Boolean)
 
-    // 既存の構造物と建設サイトを一度に取得し、Setにキャッシュして高速に判定する
-    const occupiedTiles = new Set();
-    const structures = cache.getStructures(room);
-    const sites = cache.getConstructionSites(room);
+  // 既存の構造物と建設サイトを一度に取得し、Setにキャッシュして高速に判定する
+  const occupiedTiles = new Set()
+  const structures = cache.getStructures(room)
+  const sites = cache.getConstructionSites(room)
 
-    for (const s of structures) {
-        occupiedTiles.add(s.pos.x | (s.pos.y << 6));
-    }
-    for (const s of sites) {
-        occupiedTiles.add(s.pos.x | (s.pos.y << 6));
-    }
+  for (const s of structures) {
+    occupiedTiles.add(s.pos.x | (s.pos.y << 6))
+  }
+  for (const s of sites) {
+    occupiedTiles.add(s.pos.x | (s.pos.y << 6))
+  }
 
-    for (const target of targets) {
-        const result = pathfinder.findPath(spawn.pos, target);
-        if (result.incomplete) continue;
+  for (const target of targets) {
+    const result = pathfinder.findPath(spawn.pos, target)
+    if (result.incomplete) continue
 
-        let planned = 0;
-        for (const pos of result.path) {
-            // 既存の構造物や建設サイトがない場所にのみ道路を計画
-            const isOccupied = occupiedTiles.has(pos.x | (pos.y << 6));
+    let planned = 0
+    for (const pos of result.path) {
+      // 既存の構造物や建設サイトがない場所にのみ道路を計画
+      const isOccupied = occupiedTiles.has(pos.x | (pos.y << 6))
 
-            if (!isOccupied) {
-                const r = room.createConstructionSite(pos.x, pos.y, STRUCTURE_ROAD);
-                if (r === OK) {
-                    planned++;
-                    occupiedTiles.add(pos.x | (pos.y << 6)); // 新しく計画した場所も追加
-                    if (planned >= MAX_ROADS_PER_CYCLE) break; // 一度に最大 MAX_ROADS_PER_CYCLE か所まで計画
-                }
-            }
+      if (!isOccupied) {
+        const r = room.createConstructionSite(pos.x, pos.y, STRUCTURE_ROAD)
+        if (r === OK) {
+          planned++
+          occupiedTiles.add(pos.x | (pos.y << 6)) // 新しく計画した場所も追加
+          if (planned >= MAX_ROADS_PER_CYCLE) break // 一度に最大 MAX_ROADS_PER_CYCLE か所まで計画
         }
-
-        if (planned > 0) {
-            logger.debug(`[RoomManager] 道路 ${planned} か所を計画`);
-            cache.invalidate(`construction_sites_${room.name}`);
-        }
+      }
     }
+
+    if (planned > 0) {
+      logger.debug(`[RoomManager] 道路 ${planned} か所を計画`)
+      cache.invalidate(`construction_sites_${room.name}`)
+    }
+  }
 }
 
 /**
  * スポーン周囲にエクステンションを配置する計画を立てる
  * @param {Room} room
  */
-function _planExtensions(room) {
-    const rcl = room.controller.level;
-    const maxExtensions = CONTROLLER_STRUCTURES[STRUCTURE_EXTENSION][rcl] || 0;
+function _planExtensions (room) {
+  const rcl = room.controller.level
+  const maxExtensions = CONTROLLER_STRUCTURES[STRUCTURE_EXTENSION][rcl] || 0
 
-    if (maxExtensions === 0) return;
+  if (maxExtensions === 0) return
 
-    const existing = cache.getMyStructures(room, STRUCTURE_EXTENSION);
-    const sites = cache
-        .getConstructionSites(room)
-        .filter((s) => s.structureType === STRUCTURE_EXTENSION);
+  const existing = cache.getMyStructures(room, STRUCTURE_EXTENSION)
+  const sites = cache
+    .getConstructionSites(room)
+    .filter((s) => s.structureType === STRUCTURE_EXTENSION)
 
-    const currentCount = existing.length + sites.length;
-    if (currentCount >= maxExtensions) return;
+  const currentCount = existing.length + sites.length
+  if (currentCount >= maxExtensions) return
 
-    const spawns = cache.getSpawns(room);
-    if (spawns.length === 0) return;
+  const spawns = cache.getSpawns(room)
+  if (spawns.length === 0) return
 
-    const spawn = spawns[0];
-    const needed = Math.min(5, maxExtensions - currentCount);
-    let placed = 0;
+  const spawn = spawns[0]
+  const needed = Math.min(5, maxExtensions - currentCount)
+  let placed = 0
 
-    const top = Math.max(2, spawn.pos.y - 6);
-    const left = Math.max(2, spawn.pos.x - 6);
-    const bottom = Math.min(47, spawn.pos.y + 6);
-    const right = Math.min(47, spawn.pos.x + 6);
-    const area = room.lookAtArea(top, left, bottom, right, true);
+  const top = Math.max(2, spawn.pos.y - 6)
+  const left = Math.max(2, spawn.pos.x - 6)
+  const bottom = Math.min(47, spawn.pos.y + 6)
+  const right = Math.min(47, spawn.pos.x + 6)
+  const area = room.lookAtArea(top, left, bottom, right, true)
 
-    const blockedMap = new Set();
-    for (let i = 0; i < area.length; i++) {
-        const item = area[i];
-        if (item.type === LOOK_STRUCTURES || item.type === LOOK_CONSTRUCTION_SITES) {
-            blockedMap.add(`${item.x},${item.y}`);
+  const blockedMap = new Set()
+  for (let i = 0; i < area.length; i++) {
+    const item = area[i]
+    if (item.type === LOOK_STRUCTURES || item.type === LOOK_CONSTRUCTION_SITES) {
+      blockedMap.add(`${item.x},${item.y}`)
+    }
+  }
+
+  // スポーン周囲のスパイラルパターンでエクステンションを配置
+  for (let radius = 2; radius <= 6 && placed < needed; radius++) {
+    for (let dx = -radius; dx <= radius && placed < needed; dx++) {
+      for (let dy = -radius; dy <= radius && placed < needed; dy++) {
+        if (Math.abs(dx) !== radius && Math.abs(dy) !== radius) continue
+
+        const x = spawn.pos.x + dx
+        const y = spawn.pos.y + dy
+        if (x < 2 || x > 47 || y < 2 || y > 47) continue
+
+        const terrain = room.getTerrain().get(x, y)
+        if (terrain === TERRAIN_MASK_WALL) continue
+
+        const isBlocked = blockedMap.has(`${x},${y}`)
+        if (isBlocked) continue
+
+        const r = room.createConstructionSite(x, y, STRUCTURE_EXTENSION)
+        if (r === OK) {
+          placed++
         }
+      }
     }
+  }
 
-    // スポーン周囲のスパイラルパターンでエクステンションを配置
-    for (let radius = 2; radius <= 6 && placed < needed; radius++) {
-        for (let dx = -radius; dx <= radius && placed < needed; dx++) {
-            for (let dy = -radius; dy <= radius && placed < needed; dy++) {
-                if (Math.abs(dx) !== radius && Math.abs(dy) !== radius) continue;
-
-                const x = spawn.pos.x + dx;
-                const y = spawn.pos.y + dy;
-                if (x < 2 || x > 47 || y < 2 || y > 47) continue;
-
-                const terrain = room.getTerrain().get(x, y);
-                if (terrain === TERRAIN_MASK_WALL) continue;
-
-                const isBlocked = blockedMap.has(`${x},${y}`);
-                if (isBlocked) continue;
-
-                const r = room.createConstructionSite(x, y, STRUCTURE_EXTENSION);
-                if (r === OK) {
-                    placed++;
-                }
-            }
-        }
-    }
-
-    if (placed > 0) {
-        logger.info(`[RoomManager] エクステンション ${placed} か所を計画`);
-        cache.invalidate(`construction_sites_${room.name}`);
-    }
+  if (placed > 0) {
+    logger.info(`[RoomManager] エクステンション ${placed} か所を計画`)
+    cache.invalidate(`construction_sites_${room.name}`)
+  }
 }
 
 // ============================================================
@@ -305,37 +305,37 @@ function _planExtensions(room) {
  * セーフモード発動が必要か確認し、必要であれば発動する
  * @param {Room} room
  */
-function _checkSafeMode(room) {
-    const controller = room.controller;
-    if (!controller || controller.safeMode || controller.safeModeAvailable === 0) return;
+function _checkSafeMode (room) {
+  const controller = room.controller
+  if (!controller || controller.safeMode || controller.safeModeAvailable === 0) return
 
-    const enemies = cache.getEnemies(room);
-    const dangerousEnemies = enemies.filter(
-        (e) =>
-            e.getActiveBodyparts(ATTACK) > 0 ||
+  const enemies = cache.getEnemies(room)
+  const dangerousEnemies = enemies.filter(
+    (e) =>
+      e.getActiveBodyparts(ATTACK) > 0 ||
             e.getActiveBodyparts(RANGED_ATTACK) > 0 ||
             e.getActiveBodyparts(WORK) > 0 // WORKでウォール破壊
-    );
+  )
 
-    if (dangerousEnemies.length >= SAFE_MODE_TRIGGER_HOSTILES) {
-        // 自室のディフェンダー数
-        const defenders = Object.values(Game.creeps).filter(
-            (c) =>
-                c &&
+  if (dangerousEnemies.length >= SAFE_MODE_TRIGGER_HOSTILES) {
+    // 自室のディフェンダー数
+    const defenders = Object.values(Game.creeps).filter(
+      (c) =>
+        c &&
                 c.room &&
                 c.room.name === room.name &&
                 (c.getActiveBodyparts(ATTACK) > 0 || c.getActiveBodyparts(RANGED_ATTACK) > 0)
-        );
+    )
 
-        if (defenders.length < dangerousEnemies.length) {
-            const result = controller.activateSafeMode();
-            if (result === OK) {
-                logger.warn(
+    if (defenders.length < dangerousEnemies.length) {
+      const result = controller.activateSafeMode()
+      if (result === OK) {
+        logger.warn(
                     `[RoomManager] セーフモード発動: ${room.name} 敵 ${dangerousEnemies.length} 体`
-                );
-            }
-        }
+        )
+      }
     }
+  }
 }
 
 // ============================================================
@@ -347,41 +347,41 @@ function _checkSafeMode(room) {
  * ソースリンク（エネルギーが高い）からシンクリンク（コントローラー付近）へ転送
  * @param {Room} room
  */
-function _manageLinkNetwork(room) {
-    const links = cache.getLinks(room);
-    if (links.length < 2) return;
+function _manageLinkNetwork (room) {
+  const links = cache.getLinks(room)
+  if (links.length < 2) return
 
-    const controller = room.controller;
-    if (!controller) return;
+  const controller = room.controller
+  if (!controller) return
 
-    // ソースリンク: ソース付近のリンク（エネルギーが溜まる）
-    const sourceLinks = links.filter(
-        (l) =>
-            l.store[RESOURCE_ENERGY] >=
+  // ソースリンク: ソース付近のリンク（エネルギーが溜まる）
+  const sourceLinks = links.filter(
+    (l) =>
+      l.store[RESOURCE_ENERGY] >=
                 l.store.getCapacity(RESOURCE_ENERGY) * LINK_TRANSFER_THRESHOLD && l.cooldown === 0
-    );
+  )
 
-    // シンクリンク: コントローラー付近またはスポーン付近
-    const spawns = cache.getSpawns(room);
-    const spawnPos = spawns.length > 0 ? spawns[0].pos : null;
+  // シンクリンク: コントローラー付近またはスポーン付近
+  const spawns = cache.getSpawns(room)
+  const spawnPos = spawns.length > 0 ? spawns[0].pos : null
 
-    const sinkLinks = links.filter(
-        (l) =>
-            l.store[RESOURCE_ENERGY] < l.store.getCapacity(RESOURCE_ENERGY) * 0.5 &&
+  const sinkLinks = links.filter(
+    (l) =>
+      l.store[RESOURCE_ENERGY] < l.store.getCapacity(RESOURCE_ENERGY) * 0.5 &&
             (controller.pos.getRangeTo(l) <= 5 || (spawnPos && spawnPos.getRangeTo(l) <= 5))
-    );
+  )
 
-    if (sourceLinks.length === 0 || sinkLinks.length === 0) return;
+  if (sourceLinks.length === 0 || sinkLinks.length === 0) return
 
-    for (const sourceLink of sourceLinks) {
-        const sink = pathfinder.closest(sourceLink.pos, sinkLinks);
-        if (!sink) continue;
+  for (const sourceLink of sourceLinks) {
+    const sink = pathfinder.closest(sourceLink.pos, sinkLinks)
+    if (!sink) continue
 
-        const result = sourceLink.transferEnergy(sink);
-        if (result === OK) {
-            logger.debug(`[RoomManager] リンク転送: ${sourceLink.pos} → ${sink.pos}`);
-        }
+    const result = sourceLink.transferEnergy(sink)
+    if (result === OK) {
+      logger.debug(`[RoomManager] リンク転送: ${sourceLink.pos} → ${sink.pos}`)
     }
+  }
 }
 
 // ============================================================
@@ -393,108 +393,108 @@ function _manageLinkNetwork(room) {
  * @param {Room} room
  * @returns {Object}
  */
-function getStats(room) {
-    const creepCounts = Object.create(null);
-    for (const name in Game.creeps) {
-        // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
-        if (cache.isSafeKey(name) && Object.prototype.hasOwnProperty.call(Game.creeps, name)) {
-            const creep = Game.creeps[name];
-            // Security: Robust check for creep.room to avoid crashes if object is corrupted
-            if (creep && creep.room && creep.room.name === room.name) {
-                const role = creep.memory.role || 'unknown';
-                if (cache.isSafeKey(role)) {
-                    creepCounts[role] = (creepCounts[role] || 0) + 1;
-                }
-            }
+function getStats (room) {
+  const creepCounts = Object.create(null)
+  for (const name in Game.creeps) {
+    // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
+    if (cache.isSafeKey(name) && Object.prototype.hasOwnProperty.call(Game.creeps, name)) {
+      const creep = Game.creeps[name]
+      // Security: Robust check for creep.room to avoid crashes if object is corrupted
+      if (creep && creep.room && creep.room.name === room.name) {
+        const role = creep.memory.role || 'unknown'
+        if (cache.isSafeKey(role)) {
+          creepCounts[role] = (creepCounts[role] || 0) + 1
         }
+      }
     }
+  }
 
-    const storage = cache.getStorage(room);
-    const towers = cache.getMyStructures(room, STRUCTURE_TOWER);
-    const enemies = cache.getEnemies(room);
+  const storage = cache.getStorage(room)
+  const towers = cache.getMyStructures(room, STRUCTURE_TOWER)
+  const enemies = cache.getEnemies(room)
 
-    return {
-        name: room.name,
-        rcl: room.controller ? room.controller.level : 0,
-        controllerProgress: room.controller
-            ? (room.controller.progress / (room.controller.progressTotal || 1)) * 100
-            : 0,
-        energy: room.energyAvailable,
-        energyCapacity: room.energyCapacityAvailable,
-        storageEnergy: storage ? storage.store[RESOURCE_ENERGY] : 0,
-        creepCounts,
-        totalCreeps: Object.keys(Game.creeps).filter((n) => {
-            const c = Game.creeps[n];
-            return c && c.room && c.room.name === room.name;
-        }).length,
-        constructionSites: cache.getConstructionSites(room).length,
-        towers: towers.length,
-        enemies: enemies.length,
-        safeMode: room.controller ? !!room.controller.safeMode : false,
-    };
+  return {
+    name: room.name,
+    rcl: room.controller ? room.controller.level : 0,
+    controllerProgress: room.controller
+      ? (room.controller.progress / (room.controller.progressTotal || 1)) * 100
+      : 0,
+    energy: room.energyAvailable,
+    energyCapacity: room.energyCapacityAvailable,
+    storageEnergy: storage ? storage.store[RESOURCE_ENERGY] : 0,
+    creepCounts,
+    totalCreeps: Object.keys(Game.creeps).filter((n) => {
+      const c = Game.creeps[n]
+      return c && c.room && c.room.name === room.name
+    }).length,
+    constructionSites: cache.getConstructionSites(room).length,
+    towers: towers.length,
+    enemies: enemies.length,
+    safeMode: room.controller ? !!room.controller.safeMode : false
+  }
 }
 
 /**
  * ルーム統計をコンソールに表示する
  * @param {Room} room
  */
-function showStats(room) {
-    const stats = getStats(room);
-    logger.info(
+function showStats (room) {
+  const stats = getStats(room)
+  logger.info(
         `[Room: ${stats.name}] RCL${stats.rcl} | Energy: ${stats.energy}/${stats.energyCapacity} | Creeps: ${stats.totalCreeps} | Sites: ${stats.constructionSites} | Enemies: ${stats.enemies}`
-    );
+  )
 
-    if (stats.storageEnergy > 0) {
-        logger.info(`  Storage: ${stats.storageEnergy.toLocaleString()} energy`);
-    }
+  if (stats.storageEnergy > 0) {
+    logger.info(`  Storage: ${stats.storageEnergy.toLocaleString()} energy`)
+  }
 
-    const roles = Object.keys(stats.creepCounts);
-    if (roles.length > 0) {
-        const breakdown = roles.map((r) => `${r}:${stats.creepCounts[r]}`).join(' ');
-        logger.info(`  Roles: ${breakdown}`);
-    }
+  const roles = Object.keys(stats.creepCounts)
+  if (roles.length > 0) {
+    const breakdown = roles.map((r) => `${r}:${stats.creepCounts[r]}`).join(' ')
+    logger.info(`  Roles: ${breakdown}`)
+  }
 }
 
 /**
  * ルームの状態をビジュアルに表示する
  * @param {Room} room
  */
-function showVisuals(room) {
-    const stats = getStats(room);
-    const controller = room.controller;
+function showVisuals (room) {
+  const stats = getStats(room)
+  const controller = room.controller
 
-    if (controller) {
-        const progress = stats.controllerProgress.toFixed(1);
-        room.visual.text(`RCL${stats.rcl} (${progress}%)`, controller.pos.x, controller.pos.y - 1, {
-            color: '#00bfff',
-            font: 0.5,
-            align: 'center',
-        });
-    }
+  if (controller) {
+    const progress = stats.controllerProgress.toFixed(1)
+    room.visual.text(`RCL${stats.rcl} (${progress}%)`, controller.pos.x, controller.pos.y - 1, {
+      color: '#00bfff',
+      font: 0.5,
+      align: 'center'
+    })
+  }
 
-    // エネルギー情報を左上に表示
-    room.visual.text(`⚡ ${stats.energy}/${stats.energyCapacity}`, 2, 2, {
-        color: '#ffaa00',
-        font: 0.6,
-        align: 'left',
-    });
-    room.visual.text(`👥 ${stats.totalCreeps}体`, 2, 3, {
-        color: '#ffffff',
-        font: 0.6,
-        align: 'left',
-    });
-    if (stats.enemies > 0) {
-        room.visual.text(`⚠️ 敵${stats.enemies}体`, 2, 4, {
-            color: '#ff4444',
-            font: 0.6,
-            align: 'left',
-        });
-    }
+  // エネルギー情報を左上に表示
+  room.visual.text(`⚡ ${stats.energy}/${stats.energyCapacity}`, 2, 2, {
+    color: '#ffaa00',
+    font: 0.6,
+    align: 'left'
+  })
+  room.visual.text(`👥 ${stats.totalCreeps}体`, 2, 3, {
+    color: '#ffffff',
+    font: 0.6,
+    align: 'left'
+  })
+  if (stats.enemies > 0) {
+    room.visual.text(`⚠️ 敵${stats.enemies}体`, 2, 4, {
+      color: '#ff4444',
+      font: 0.6,
+      align: 'left'
+    })
+  }
 }
 
 module.exports = {
-    run,
-    getStats,
-    showStats,
-    showVisuals,
-};
+  run,
+  getStats,
+  showStats,
+  showVisuals
+}

--- a/src/managers/roomManager.js
+++ b/src/managers/roomManager.js
@@ -71,7 +71,6 @@ function run(room) {
         if (Game.time % 50 === 0) {
             cache.cleanup();
         }
-
     } catch (e) {
         logger.error(`[RoomManager] ルーム ${room.name} でエラー`, e);
     }
@@ -157,17 +156,15 @@ function _planSourceContainers(room) {
 
     for (const source of sources) {
         // すでに近くにコンテナがあれば skip
-        const nearby = existingContainers.filter(
-            (c) => source.pos.getRangeTo(c) <= 2
-        );
+        const nearby = existingContainers.filter((c) => source.pos.getRangeTo(c) <= 2);
         if (nearby.length > 0) continue;
 
         // コンテナの建設サイトがすでにあれば skip
-        const existingSites = room.find(FIND_CONSTRUCTION_SITES, {
-            filter: (s) =>
-                s.structureType === STRUCTURE_CONTAINER &&
-                source.pos.getRangeTo(s) <= 2,
-        });
+        const existingSites = cache
+            .getConstructionSites(room)
+            .filter(
+                (s) => s.structureType === STRUCTURE_CONTAINER && source.pos.getRangeTo(s) <= 2
+            );
         if (existingSites.length > 0) continue;
 
         // ソースの隣の空きタイルにコンテナを配置
@@ -191,10 +188,7 @@ function _planRoads(room) {
     if (spawns.length === 0) return;
 
     const spawn = spawns[0];
-    const targets = [
-        ...cache.getSources(room),
-        room.controller,
-    ].filter(Boolean);
+    const targets = [...cache.getSources(room), room.controller].filter(Boolean);
 
     // 既存の構造物と建設サイトを一度に取得し、Setにキャッシュして高速に判定する
     const occupiedTiles = new Set();
@@ -244,12 +238,10 @@ function _planExtensions(room) {
 
     if (maxExtensions === 0) return;
 
-    const existing = room.find(FIND_MY_STRUCTURES, {
-        filter: { structureType: STRUCTURE_EXTENSION },
-    });
-    const sites = room.find(FIND_CONSTRUCTION_SITES, {
-        filter: { structureType: STRUCTURE_EXTENSION },
-    });
+    const existing = cache.getMyStructures(room, STRUCTURE_EXTENSION);
+    const sites = cache
+        .getConstructionSites(room)
+        .filter((s) => s.structureType === STRUCTURE_EXTENSION);
 
     const currentCount = existing.length + sites.length;
     if (currentCount >= maxExtensions) return;
@@ -329,15 +321,18 @@ function _checkSafeMode(room) {
         // 自室のディフェンダー数
         const defenders = Object.values(Game.creeps).filter(
             (c) =>
-                c && c.room && c.room.name === room.name &&
-                (c.getActiveBodyparts(ATTACK) > 0 ||
-                    c.getActiveBodyparts(RANGED_ATTACK) > 0)
+                c &&
+                c.room &&
+                c.room.name === room.name &&
+                (c.getActiveBodyparts(ATTACK) > 0 || c.getActiveBodyparts(RANGED_ATTACK) > 0)
         );
 
         if (defenders.length < dangerousEnemies.length) {
             const result = controller.activateSafeMode();
             if (result === OK) {
-                logger.warn(`[RoomManager] セーフモード発動: ${room.name} 敵 ${dangerousEnemies.length} 体`);
+                logger.warn(
+                    `[RoomManager] セーフモード発動: ${room.name} 敵 ${dangerousEnemies.length} 体`
+                );
             }
         }
     }
@@ -362,8 +357,8 @@ function _manageLinkNetwork(room) {
     // ソースリンク: ソース付近のリンク（エネルギーが溜まる）
     const sourceLinks = links.filter(
         (l) =>
-            l.store[RESOURCE_ENERGY] >= l.store.getCapacity(RESOURCE_ENERGY) * LINK_TRANSFER_THRESHOLD &&
-            l.cooldown === 0
+            l.store[RESOURCE_ENERGY] >=
+                l.store.getCapacity(RESOURCE_ENERGY) * LINK_TRANSFER_THRESHOLD && l.cooldown === 0
     );
 
     // シンクリンク: コントローラー付近またはスポーン付近
@@ -373,8 +368,7 @@ function _manageLinkNetwork(room) {
     const sinkLinks = links.filter(
         (l) =>
             l.store[RESOURCE_ENERGY] < l.store.getCapacity(RESOURCE_ENERGY) * 0.5 &&
-            (controller.pos.getRangeTo(l) <= 5 ||
-                (spawnPos && spawnPos.getRangeTo(l) <= 5))
+            (controller.pos.getRangeTo(l) <= 5 || (spawnPos && spawnPos.getRangeTo(l) <= 5))
     );
 
     if (sourceLinks.length === 0 || sinkLinks.length === 0) return;
@@ -385,9 +379,7 @@ function _manageLinkNetwork(room) {
 
         const result = sourceLink.transferEnergy(sink);
         if (result === OK) {
-            logger.debug(
-                `[RoomManager] リンク転送: ${sourceLink.pos} → ${sink.pos}`
-            );
+            logger.debug(`[RoomManager] リンク転送: ${sourceLink.pos} → ${sink.pos}`);
         }
     }
 }
@@ -405,10 +397,7 @@ function getStats(room) {
     const creepCounts = Object.create(null);
     for (const name in Game.creeps) {
         // Security: Use isSafeKey and hasOwnProperty to prevent prototype pollution during iteration
-        if (
-            cache.isSafeKey(name) &&
-            Object.prototype.hasOwnProperty.call(Game.creeps, name)
-        ) {
+        if (cache.isSafeKey(name) && Object.prototype.hasOwnProperty.call(Game.creeps, name)) {
             const creep = Game.creeps[name];
             // Security: Robust check for creep.room to avoid crashes if object is corrupted
             if (creep && creep.room && creep.room.name === room.name) {
@@ -451,7 +440,9 @@ function getStats(room) {
  */
 function showStats(room) {
     const stats = getStats(room);
-    logger.info(`[Room: ${stats.name}] RCL${stats.rcl} | Energy: ${stats.energy}/${stats.energyCapacity} | Creeps: ${stats.totalCreeps} | Sites: ${stats.constructionSites} | Enemies: ${stats.enemies}`);
+    logger.info(
+        `[Room: ${stats.name}] RCL${stats.rcl} | Energy: ${stats.energy}/${stats.energyCapacity} | Creeps: ${stats.totalCreeps} | Sites: ${stats.constructionSites} | Enemies: ${stats.enemies}`
+    );
 
     if (stats.storageEnergy > 0) {
         logger.info(`  Storage: ${stats.storageEnergy.toLocaleString()} energy`);
@@ -474,31 +465,30 @@ function showVisuals(room) {
 
     if (controller) {
         const progress = stats.controllerProgress.toFixed(1);
-        room.visual.text(
-            `RCL${stats.rcl} (${progress}%)`,
-            controller.pos.x,
-            controller.pos.y - 1,
-            { color: '#00bfff', font: 0.5, align: 'center' }
-        );
+        room.visual.text(`RCL${stats.rcl} (${progress}%)`, controller.pos.x, controller.pos.y - 1, {
+            color: '#00bfff',
+            font: 0.5,
+            align: 'center',
+        });
     }
 
     // エネルギー情報を左上に表示
-    room.visual.text(
-        `⚡ ${stats.energy}/${stats.energyCapacity}`,
-        2, 2,
-        { color: '#ffaa00', font: 0.6, align: 'left' }
-    );
-    room.visual.text(
-        `👥 ${stats.totalCreeps}体`,
-        2, 3,
-        { color: '#ffffff', font: 0.6, align: 'left' }
-    );
+    room.visual.text(`⚡ ${stats.energy}/${stats.energyCapacity}`, 2, 2, {
+        color: '#ffaa00',
+        font: 0.6,
+        align: 'left',
+    });
+    room.visual.text(`👥 ${stats.totalCreeps}体`, 2, 3, {
+        color: '#ffffff',
+        font: 0.6,
+        align: 'left',
+    });
     if (stats.enemies > 0) {
-        room.visual.text(
-            `⚠️ 敵${stats.enemies}体`,
-            2, 4,
-            { color: '#ff4444', font: 0.6, align: 'left' }
-        );
+        room.visual.text(`⚠️ 敵${stats.enemies}体`, 2, 4, {
+            color: '#ff4444',
+            font: 0.6,
+            align: 'left',
+        });
     }
 }
 

--- a/submission.py
+++ b/submission.py
@@ -1,5 +1,6 @@
 def submit():
     print("Submitted.")
 
+
 if __name__ == "__main__":
     submit()

--- a/submission.py
+++ b/submission.py
@@ -1,0 +1,5 @@
+def submit():
+    print("Submitted.")
+
+if __name__ == "__main__":
+    submit()

--- a/tests/roomManager.test.js
+++ b/tests/roomManager.test.js
@@ -3,414 +3,414 @@
  */
 
 // グローバル設定
-global.Game = { time: 100, creeps: {}, flags: {} };
-global.Memory = { creeps: {} };
-global.FIND_SOURCES = 5;
-global.FIND_STRUCTURES = 10;
-global.FIND_MY_STRUCTURES = 11;
-global.FIND_CONSTRUCTION_SITES = 14;
-global.FIND_HOSTILE_CREEPS = 6;
-global.FIND_MY_SPAWNS = 8;
-global.STRUCTURE_SPAWN = 'spawn';
-global.STRUCTURE_EXTENSION = 'extension';
-global.STRUCTURE_TOWER = 'tower';
-global.STRUCTURE_CONTAINER = 'container';
-global.STRUCTURE_LINK = 'link';
-global.STRUCTURE_ROAD = 'road';
-global.RESOURCE_ENERGY = 'energy';
+global.Game = { time: 100, creeps: {}, flags: {} }
+global.Memory = { creeps: {} }
+global.FIND_SOURCES = 5
+global.FIND_STRUCTURES = 10
+global.FIND_MY_STRUCTURES = 11
+global.FIND_CONSTRUCTION_SITES = 14
+global.FIND_HOSTILE_CREEPS = 6
+global.FIND_MY_SPAWNS = 8
+global.STRUCTURE_SPAWN = 'spawn'
+global.STRUCTURE_EXTENSION = 'extension'
+global.STRUCTURE_TOWER = 'tower'
+global.STRUCTURE_CONTAINER = 'container'
+global.STRUCTURE_LINK = 'link'
+global.STRUCTURE_ROAD = 'road'
+global.RESOURCE_ENERGY = 'energy'
 global.CONTROLLER_STRUCTURES = {
-    extension: { 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
-};
-global.TERRAIN_MASK_WALL = 1;
-global.LOOK_STRUCTURES = 'structure';
-global.LOOK_CONSTRUCTION_SITES = 'constructionSite';
-global.LOOK_AT = 'lookAt';
-global.OK = 0;
-global.ATTACK = 'attack';
-global.RANGED_ATTACK = 'ranged_attack';
-global.WORK = 'work';
+  extension: { 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 }
+}
+global.TERRAIN_MASK_WALL = 1
+global.LOOK_STRUCTURES = 'structure'
+global.LOOK_CONSTRUCTION_SITES = 'constructionSite'
+global.LOOK_AT = 'lookAt'
+global.OK = 0
+global.ATTACK = 'attack'
+global.RANGED_ATTACK = 'ranged_attack'
+global.WORK = 'work'
 
 jest.mock(
-    '../src/utils/cache',
-    () => ({
-        getSources: jest.fn().mockReturnValue([]),
-        getContainers: jest.fn().mockReturnValue([]),
-        getSpawns: jest.fn().mockReturnValue([]),
-        getStructures: jest.fn().mockReturnValue([]),
-        getConstructionSites: jest.fn().mockReturnValue([]),
-        getEnemies: jest.fn().mockReturnValue([]),
-        getLinks: jest.fn().mockReturnValue([]),
-        getStorage: jest.fn().mockReturnValue(null),
-        getMyStructures: jest.fn().mockReturnValue([]),
-        invalidate: jest.fn(),
-        cleanup: jest.fn(),
-        isSafeKey: jest.fn().mockImplementation((key) => {
-            return (
-                typeof key === 'string' && !['__proto__', 'constructor', 'prototype'].includes(key)
-            );
-        }),
-    }),
-    { virtual: true }
-);
+  '../src/utils/cache',
+  () => ({
+    getSources: jest.fn().mockReturnValue([]),
+    getContainers: jest.fn().mockReturnValue([]),
+    getSpawns: jest.fn().mockReturnValue([]),
+    getStructures: jest.fn().mockReturnValue([]),
+    getConstructionSites: jest.fn().mockReturnValue([]),
+    getEnemies: jest.fn().mockReturnValue([]),
+    getLinks: jest.fn().mockReturnValue([]),
+    getStorage: jest.fn().mockReturnValue(null),
+    getMyStructures: jest.fn().mockReturnValue([]),
+    invalidate: jest.fn(),
+    cleanup: jest.fn(),
+    isSafeKey: jest.fn().mockImplementation((key) => {
+      return (
+        typeof key === 'string' && !['__proto__', 'constructor', 'prototype'].includes(key)
+      )
+    })
+  }),
+  { virtual: true }
+)
 
 jest.mock(
-    '../src/utils/pathfinder',
-    () => ({
-        findNearestOpenTile: jest.fn(),
-        findPath: jest.fn().mockReturnValue({ incomplete: true, path: [] }),
-        closest: jest.fn(),
-    }),
-    { virtual: true }
-);
+  '../src/utils/pathfinder',
+  () => ({
+    findNearestOpenTile: jest.fn(),
+    findPath: jest.fn().mockReturnValue({ incomplete: true, path: [] }),
+    closest: jest.fn()
+  }),
+  { virtual: true }
+)
 
 jest.mock(
-    '../src/utils/logger',
-    () => ({
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-    }),
-    { virtual: true }
-);
+  '../src/utils/logger',
+  () => ({
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }),
+  { virtual: true }
+)
 
 jest.mock(
-    '../src/constants',
-    () => ({
-        ROLES: {
-            HARVESTER: 'harvester',
-            UPGRADER: 'upgrader',
-            BUILDER: 'builder',
-        },
-        CACHE_TTL: {},
-        MEMORY_CLEANUP_INTERVAL: 100,
-        STATS_DISPLAY_INTERVAL: 100,
-        SAFE_MODE_TRIGGER_HOSTILES: 3,
-    }),
-    { virtual: true }
-);
+  '../src/constants',
+  () => ({
+    ROLES: {
+      HARVESTER: 'harvester',
+      UPGRADER: 'upgrader',
+      BUILDER: 'builder'
+    },
+    CACHE_TTL: {},
+    MEMORY_CLEANUP_INTERVAL: 100,
+    STATS_DISPLAY_INTERVAL: 100,
+    SAFE_MODE_TRIGGER_HOSTILES: 3
+  }),
+  { virtual: true }
+)
 
-const cache = require('../src/utils/cache');
-const pathfinder = require('../src/utils/pathfinder');
-const roomManager = require('../src/managers/roomManager');
+const cache = require('../src/utils/cache')
+const pathfinder = require('../src/utils/pathfinder')
+const roomManager = require('../src/managers/roomManager')
 
 describe('roomManager', () => {
+  beforeEach(() => {
+    global.FIND_MY_STRUCTURES = 114
+    global.STRUCTURE_CONTAINER = 'container'
+    global.STRUCTURE_ROAD = 'road'
+  })
+  let mockRoom
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockRoom = {
+      name: 'W1N1',
+      controller: {
+        my: true,
+        level: 3,
+        progress: 1000,
+        progressTotal: 10000,
+        safeMode: null,
+        safeModeAvailable: 1,
+        activateSafeMode: jest.fn().mockReturnValue(OK),
+        pos: { x: 25, y: 25, getRangeTo: jest.fn().mockReturnValue(10) }
+      },
+      energyAvailable: 300,
+      energyCapacityAvailable: 300,
+      storage: null,
+      find: jest.fn().mockReturnValue([]),
+      createConstructionSite: jest.fn().mockReturnValue(OK),
+      getTerrain: jest.fn().mockReturnValue({
+        get: jest.fn().mockReturnValue(0)
+      }),
+      lookAt: jest.fn().mockReturnValue([]),
+      lookForAt: jest.fn().mockReturnValue([]),
+      visual: {
+        text: jest.fn()
+      }
+    }
+
+    global.Game.time = 100
+    global.Game.creeps = {}
+    global.Game.flags = {}
+    global.Memory.creeps = {}
+
+    cache.getSources.mockReturnValue([])
+    cache.getContainers.mockReturnValue([])
+    cache.getSpawns.mockReturnValue([])
+    cache.getConstructionSites.mockReturnValue([])
+    cache.getEnemies.mockReturnValue([])
+    cache.getLinks.mockReturnValue([])
+    cache.getStorage.mockReturnValue(null)
+    cache.getMyStructures.mockReturnValue([])
+    pathfinder.findPath.mockReturnValue({ incomplete: true, path: [] })
+  })
+
+  describe('run', () => {
+    test('自分のルームで実行される', () => {
+      expect(() => roomManager.run(mockRoom)).not.toThrow()
+    })
+
+    test('コントローラーがないルームはスキップされる', () => {
+      const room = { ...mockRoom, controller: null }
+      expect(() => roomManager.run(room)).not.toThrow()
+    })
+
+    test('自分のルームでない場合はスキップされる', () => {
+      const room = { ...mockRoom, controller: { my: false } }
+      expect(() => roomManager.run(room)).not.toThrow()
+    })
+  })
+
+  describe('getStats', () => {
+    test('ルーム統計を返す', () => {
+      global.Game.creeps = {
+        creep1: {
+          room: mockRoom,
+          memory: { role: 'harvester' }
+        }
+      }
+
+      const stats = roomManager.getStats(mockRoom)
+
+      expect(stats).toBeDefined()
+      expect(stats.name).toBe('W1N1')
+      expect(stats.rcl).toBe(3)
+      expect(stats.energy).toBe(300)
+      expect(stats.energyCapacity).toBe(300)
+    })
+
+    test('プロパティが欠落しているエッジケースを処理する（コントローラーなし等）', () => {
+      const roomWithoutController = {
+        name: 'W1N2',
+        energyAvailable: 0,
+        energyCapacityAvailable: 0
+      }
+
+      const stats = roomManager.getStats(roomWithoutController)
+
+      expect(stats).toBeDefined()
+      expect(stats.name).toBe('W1N2')
+      expect(stats.rcl).toBe(0)
+      expect(stats.controllerProgress).toBe(0)
+      expect(stats.safeMode).toBe(false)
+      expect(stats.storageEnergy).toBe(0)
+    })
+
+    test('クリープ数をロール別にカウントする', () => {
+      global.Game.creeps = {
+        creep1: { room: mockRoom, memory: { role: 'harvester' } },
+        creep2: { room: mockRoom, memory: { role: 'harvester' } },
+        creep3: { room: mockRoom, memory: { role: 'upgrader' } }
+      }
+
+      const stats = roomManager.getStats(mockRoom)
+
+      expect(stats.creepCounts.harvester).toBe(2)
+      expect(stats.creepCounts.upgrader).toBe(1)
+    })
+  })
+
+  describe('showStats', () => {
+    test('統計をコンソールに表示する', () => {
+      expect(() => roomManager.showStats(mockRoom)).not.toThrow()
+    })
+  })
+
+  describe('showVisuals', () => {
+    test('ビジュアル表示が実行される', () => {
+      expect(() => roomManager.showVisuals(mockRoom)).not.toThrow()
+      expect(mockRoom.visual.text).toHaveBeenCalled()
+    })
+  })
+
+  describe('_planSourceContainers', () => {
     beforeEach(() => {
-        global.FIND_MY_STRUCTURES = 114;
-        global.STRUCTURE_CONTAINER = 'container';
-        global.STRUCTURE_ROAD = 'road';
-    });
-    let mockRoom;
+      global.Game.time = 500
+      mockRoom.controller.level = 2 // _planConstruction is called when level >= 2
+    })
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-        mockRoom = {
-            name: 'W1N1',
-            controller: {
-                my: true,
-                level: 3,
-                progress: 1000,
-                progressTotal: 10000,
-                safeMode: null,
-                safeModeAvailable: 1,
-                activateSafeMode: jest.fn().mockReturnValue(OK),
-                pos: { x: 25, y: 25, getRangeTo: jest.fn().mockReturnValue(10) },
-            },
-            energyAvailable: 300,
-            energyCapacityAvailable: 300,
-            storage: null,
-            find: jest.fn().mockReturnValue([]),
-            createConstructionSite: jest.fn().mockReturnValue(OK),
-            getTerrain: jest.fn().mockReturnValue({
-                get: jest.fn().mockReturnValue(0),
-            }),
-            lookAt: jest.fn().mockReturnValue([]),
-            lookForAt: jest.fn().mockReturnValue([]),
-            visual: {
-                text: jest.fn(),
-            },
-        };
+    test('コンテナが既にある場合はスキップする', () => {
+      const source = {
+        id: 'src1',
+        pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) }
+      }
+      const container = { id: 'cont1', pos: { x: 12, y: 10 } }
 
-        global.Game.time = 100;
-        global.Game.creeps = {};
-        global.Game.flags = {};
-        global.Memory.creeps = {};
+      cache.getSources.mockReturnValue([source])
+      cache.getContainers.mockReturnValue([container])
 
-        cache.getSources.mockReturnValue([]);
-        cache.getContainers.mockReturnValue([]);
-        cache.getSpawns.mockReturnValue([]);
-        cache.getConstructionSites.mockReturnValue([]);
-        cache.getEnemies.mockReturnValue([]);
-        cache.getLinks.mockReturnValue([]);
-        cache.getStorage.mockReturnValue(null);
-        cache.getMyStructures.mockReturnValue([]);
-        pathfinder.findPath.mockReturnValue({ incomplete: true, path: [] });
-    });
+      roomManager.run(mockRoom)
 
-    describe('run', () => {
-        test('自分のルームで実行される', () => {
-            expect(() => roomManager.run(mockRoom)).not.toThrow();
-        });
+      expect(source.pos.getRangeTo).toHaveBeenCalledWith(container)
+      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled()
+    })
 
-        test('コントローラーがないルームはスキップされる', () => {
-            const room = { ...mockRoom, controller: null };
-            expect(() => roomManager.run(room)).not.toThrow();
-        });
+    test('コンテナの建設サイトが既にある場合はスキップする', () => {
+      const source = {
+        id: 'src1',
+        pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) }
+      }
+      const constructionSite = {
+        structureType: global.STRUCTURE_CONTAINER,
+        pos: { x: 12, y: 10 }
+      }
 
-        test('自分のルームでない場合はスキップされる', () => {
-            const room = { ...mockRoom, controller: { my: false } };
-            expect(() => roomManager.run(room)).not.toThrow();
-        });
-    });
+      cache.getSources.mockReturnValue([source])
+      cache.getContainers.mockReturnValue([])
 
-    describe('getStats', () => {
-        test('ルーム統計を返す', () => {
-            global.Game.creeps = {
-                creep1: {
-                    room: mockRoom,
-                    memory: { role: 'harvester' },
-                },
-            };
+      cache.getConstructionSites.mockReturnValue([constructionSite])
 
-            const stats = roomManager.getStats(mockRoom);
+      roomManager.run(mockRoom)
 
-            expect(stats).toBeDefined();
-            expect(stats.name).toBe('W1N1');
-            expect(stats.rcl).toBe(3);
-            expect(stats.energy).toBe(300);
-            expect(stats.energyCapacity).toBe(300);
-        });
+      expect(source.pos.getRangeTo).toHaveBeenCalledWith(constructionSite)
+      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled()
+    })
 
-        test('プロパティが欠落しているエッジケースを処理する（コントローラーなし等）', () => {
-            const roomWithoutController = {
-                name: 'W1N2',
-                energyAvailable: 0,
-                energyCapacityAvailable: 0,
-            };
+    test('配置可能なタイルがない場合はスキップする', () => {
+      const source = {
+        id: 'src1',
+        pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(3) }
+      }
 
-            const stats = roomManager.getStats(roomWithoutController);
+      cache.getSources.mockReturnValue([source])
+      cache.getContainers.mockReturnValue([])
+      mockRoom.find.mockReturnValue([])
 
-            expect(stats).toBeDefined();
-            expect(stats.name).toBe('W1N2');
-            expect(stats.rcl).toBe(0);
-            expect(stats.controllerProgress).toBe(0);
-            expect(stats.safeMode).toBe(false);
-            expect(stats.storageEnergy).toBe(0);
-        });
+      pathfinder.findNearestOpenTile.mockReturnValue(null)
 
-        test('クリープ数をロール別にカウントする', () => {
-            global.Game.creeps = {
-                creep1: { room: mockRoom, memory: { role: 'harvester' } },
-                creep2: { room: mockRoom, memory: { role: 'harvester' } },
-                creep3: { room: mockRoom, memory: { role: 'upgrader' } },
-            };
+      roomManager.run(mockRoom)
 
-            const stats = roomManager.getStats(mockRoom);
+      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled()
+    })
+  })
 
-            expect(stats.creepCounts.harvester).toBe(2);
-            expect(stats.creepCounts.upgrader).toBe(1);
-        });
-    });
+  describe('planning, links and safety', () => {
+    test('建設計画でコンテナや道路を配置しキャッシュを無効化する', () => {
+      global.Game.time = 500
+      const source = {
+        id: 'src1',
+        pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(1) }
+      }
+      cache.getSources.mockReturnValue([source])
+      cache.getContainers.mockReturnValue([])
+      cache.getStructures.mockReturnValue([])
+      cache.getConstructionSites.mockReturnValue([])
+      cache.getSpawns.mockReturnValue([
+        { pos: { x: 5, y: 5, getRangeTo: jest.fn().mockReturnValue(1) } }
+      ])
+      pathfinder.findNearestOpenTile.mockReturnValue({ x: 11, y: 10 })
+      pathfinder.findPath.mockReturnValue({
+        incomplete: false,
+        path: [
+          { x: 6, y: 5 },
+          { x: 7, y: 5 }
+        ]
+      })
 
-    describe('showStats', () => {
-        test('統計をコンソールに表示する', () => {
-            expect(() => roomManager.showStats(mockRoom)).not.toThrow();
-        });
-    });
+      roomManager.run(mockRoom)
 
-    describe('showVisuals', () => {
-        test('ビジュアル表示が実行される', () => {
-            expect(() => roomManager.showVisuals(mockRoom)).not.toThrow();
-            expect(mockRoom.visual.text).toHaveBeenCalled();
-        });
-    });
+      expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
+        11,
+        10,
+        global.STRUCTURE_CONTAINER
+      )
+      expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
+        6,
+        5,
+        global.STRUCTURE_ROAD
+      )
+      expect(cache.invalidate).toHaveBeenCalledWith(`construction_sites_${mockRoom.name}`)
+    })
 
-    describe('_planSourceContainers', () => {
-        beforeEach(() => {
-            global.Game.time = 500;
-            mockRoom.controller.level = 2; // _planConstruction is called when level >= 2
-        });
+    test('リンク転送が行われる', () => {
+      global.Game.time = 1
+      const sink = {
+        pos: { x: 3, y: 3, getRangeTo: jest.fn().mockReturnValue(3) },
+        store: { [global.RESOURCE_ENERGY]: 0, getCapacity: jest.fn().mockReturnValue(800) },
+        cooldown: 0
+      }
+      const sourceLink = {
+        pos: { x: 2, y: 2, getRangeTo: jest.fn().mockReturnValue(4) },
+        store: {
+          [global.RESOURCE_ENERGY]: 800,
+          getCapacity: jest.fn().mockReturnValue(800)
+        },
+        cooldown: 0,
+        transferEnergy: jest.fn().mockReturnValue(global.OK)
+      }
 
-        test('コンテナが既にある場合はスキップする', () => {
-            const source = {
-                id: 'src1',
-                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) },
-            };
-            const container = { id: 'cont1', pos: { x: 12, y: 10 } };
+      cache.getLinks.mockReturnValue([sourceLink, sink])
+      cache.getSpawns.mockReturnValue([
+        { pos: { getRangeTo: jest.fn().mockReturnValue(2) } }
+      ])
+      cache.getEnemies.mockReturnValue([])
+      pathfinder.closest.mockReturnValue(sink)
 
-            cache.getSources.mockReturnValue([source]);
-            cache.getContainers.mockReturnValue([container]);
+      roomManager.run(mockRoom)
 
-            roomManager.run(mockRoom);
+      expect(sourceLink.transferEnergy).toHaveBeenCalledWith(sink)
+    })
 
-            expect(source.pos.getRangeTo).toHaveBeenCalledWith(container);
-            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-        });
+    test('危険な敵がいるときセーフモードを発動する', () => {
+      const hostile = {
+        getActiveBodyparts: jest.fn().mockReturnValue(1),
+        pos: { x: 20, y: 20 },
+        hits: 50,
+        hitsMax: 100
+      }
+      cache.getEnemies.mockReturnValue([hostile, hostile, hostile])
+      cache.getLinks.mockReturnValue([])
 
-        test('コンテナの建設サイトが既にある場合はスキップする', () => {
-            const source = {
-                id: 'src1',
-                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) },
-            };
-            const constructionSite = {
-                structureType: global.STRUCTURE_CONTAINER,
-                pos: { x: 12, y: 10 },
-            };
+      global.Game.time = 10
+      roomManager.run(mockRoom)
 
-            cache.getSources.mockReturnValue([source]);
-            cache.getContainers.mockReturnValue([]);
+      expect(mockRoom.controller.activateSafeMode).toHaveBeenCalled()
+    })
+  })
 
-            cache.getConstructionSites.mockReturnValue([constructionSite]);
+  describe('Security: Prototype Pollution & DoS Protection', () => {
+    test('getStats should not crash when Object.prototype is polluted', () => {
+      // Pollute Object.prototype
+      Object.prototype.polluted = 'dangerous'
 
-            roomManager.run(mockRoom);
+      try {
+        const stats = roomManager.getStats(mockRoom)
+        // Should not have 'polluted' as an own property
+        expect(Object.prototype.hasOwnProperty.call(stats.creepCounts, 'polluted')).toBe(
+          false
+        )
+      } finally {
+        // Clean up pollution
+        delete Object.prototype.polluted
+      }
+    })
 
-            expect(source.pos.getRangeTo).toHaveBeenCalledWith(constructionSite);
-            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-        });
+    test('run should not crash when Object.prototype is polluted', () => {
+      // Pollute Object.prototype
+      Object.prototype.polluted = 'dangerous'
 
-        test('配置可能なタイルがない場合はスキップする', () => {
-            const source = {
-                id: 'src1',
-                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(3) },
-            };
+      try {
+        global.Game.time = 100 // Trigger _cleanupRoomMemory
+        expect(() => roomManager.run(mockRoom)).not.toThrow()
+      } finally {
+        // Clean up pollution
+        delete Object.prototype.polluted
+      }
+    })
 
-            cache.getSources.mockReturnValue([source]);
-            cache.getContainers.mockReturnValue([]);
-            mockRoom.find.mockReturnValue([]);
+    test('getStats should handle corrupted/missing creep.room gracefully', () => {
+      global.Game.creeps = {
+        corruptedCreep: {
+          memory: { role: 'harvester' }
+          // room is missing
+        }
+      }
 
-            pathfinder.findNearestOpenTile.mockReturnValue(null);
-
-            roomManager.run(mockRoom);
-
-            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-        });
-    });
-
-    describe('planning, links and safety', () => {
-        test('建設計画でコンテナや道路を配置しキャッシュを無効化する', () => {
-            global.Game.time = 500;
-            const source = {
-                id: 'src1',
-                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(1) },
-            };
-            cache.getSources.mockReturnValue([source]);
-            cache.getContainers.mockReturnValue([]);
-            cache.getStructures.mockReturnValue([]);
-            cache.getConstructionSites.mockReturnValue([]);
-            cache.getSpawns.mockReturnValue([
-                { pos: { x: 5, y: 5, getRangeTo: jest.fn().mockReturnValue(1) } },
-            ]);
-            pathfinder.findNearestOpenTile.mockReturnValue({ x: 11, y: 10 });
-            pathfinder.findPath.mockReturnValue({
-                incomplete: false,
-                path: [
-                    { x: 6, y: 5 },
-                    { x: 7, y: 5 },
-                ],
-            });
-
-            roomManager.run(mockRoom);
-
-            expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
-                11,
-                10,
-                global.STRUCTURE_CONTAINER
-            );
-            expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
-                6,
-                5,
-                global.STRUCTURE_ROAD
-            );
-            expect(cache.invalidate).toHaveBeenCalledWith(`construction_sites_${mockRoom.name}`);
-        });
-
-        test('リンク転送が行われる', () => {
-            global.Game.time = 1;
-            const sink = {
-                pos: { x: 3, y: 3, getRangeTo: jest.fn().mockReturnValue(3) },
-                store: { [global.RESOURCE_ENERGY]: 0, getCapacity: jest.fn().mockReturnValue(800) },
-                cooldown: 0,
-            };
-            const sourceLink = {
-                pos: { x: 2, y: 2, getRangeTo: jest.fn().mockReturnValue(4) },
-                store: {
-                    [global.RESOURCE_ENERGY]: 800,
-                    getCapacity: jest.fn().mockReturnValue(800),
-                },
-                cooldown: 0,
-                transferEnergy: jest.fn().mockReturnValue(global.OK),
-            };
-
-            cache.getLinks.mockReturnValue([sourceLink, sink]);
-            cache.getSpawns.mockReturnValue([
-                { pos: { getRangeTo: jest.fn().mockReturnValue(2) } },
-            ]);
-            cache.getEnemies.mockReturnValue([]);
-            pathfinder.closest.mockReturnValue(sink);
-
-            roomManager.run(mockRoom);
-
-            expect(sourceLink.transferEnergy).toHaveBeenCalledWith(sink);
-        });
-
-        test('危険な敵がいるときセーフモードを発動する', () => {
-            const hostile = {
-                getActiveBodyparts: jest.fn().mockReturnValue(1),
-                pos: { x: 20, y: 20 },
-                hits: 50,
-                hitsMax: 100,
-            };
-            cache.getEnemies.mockReturnValue([hostile, hostile, hostile]);
-            cache.getLinks.mockReturnValue([]);
-
-            global.Game.time = 10;
-            roomManager.run(mockRoom);
-
-            expect(mockRoom.controller.activateSafeMode).toHaveBeenCalled();
-        });
-    });
-
-    describe('Security: Prototype Pollution & DoS Protection', () => {
-        test('getStats should not crash when Object.prototype is polluted', () => {
-            // Pollute Object.prototype
-            Object.prototype.polluted = 'dangerous';
-
-            try {
-                const stats = roomManager.getStats(mockRoom);
-                // Should not have 'polluted' as an own property
-                expect(Object.prototype.hasOwnProperty.call(stats.creepCounts, 'polluted')).toBe(
-                    false
-                );
-            } finally {
-                // Clean up pollution
-                delete Object.prototype.polluted;
-            }
-        });
-
-        test('run should not crash when Object.prototype is polluted', () => {
-            // Pollute Object.prototype
-            Object.prototype.polluted = 'dangerous';
-
-            try {
-                global.Game.time = 100; // Trigger _cleanupRoomMemory
-                expect(() => roomManager.run(mockRoom)).not.toThrow();
-            } finally {
-                // Clean up pollution
-                delete Object.prototype.polluted;
-            }
-        });
-
-        test('getStats should handle corrupted/missing creep.room gracefully', () => {
-            global.Game.creeps = {
-                corruptedCreep: {
-                    memory: { role: 'harvester' },
-                    // room is missing
-                },
-            };
-
-            expect(() => roomManager.getStats(mockRoom)).not.toThrow();
-            const stats = roomManager.getStats(mockRoom);
-            expect(stats.creepCounts.harvester).toBeUndefined();
-        });
-    });
-});
+      expect(() => roomManager.getStats(mockRoom)).not.toThrow()
+      const stats = roomManager.getStats(mockRoom)
+      expect(stats.creepCounts.harvester).toBeUndefined()
+    })
+  })
+})

--- a/tests/roomManager.test.js
+++ b/tests/roomManager.test.js
@@ -19,7 +19,7 @@ global.STRUCTURE_LINK = 'link';
 global.STRUCTURE_ROAD = 'road';
 global.RESOURCE_ENERGY = 'energy';
 global.CONTROLLER_STRUCTURES = {
-  extension: { 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
+    extension: { 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
 };
 global.TERRAIN_MASK_WALL = 1;
 global.LOOK_STRUCTURES = 'structure';
@@ -30,338 +30,387 @@ global.ATTACK = 'attack';
 global.RANGED_ATTACK = 'ranged_attack';
 global.WORK = 'work';
 
-jest.mock('../src/utils/cache', () => ({
-  getSources: jest.fn().mockReturnValue([]),
-  getContainers: jest.fn().mockReturnValue([]),
-  getSpawns: jest.fn().mockReturnValue([]),
-  getStructures: jest.fn().mockReturnValue([]),
-  getConstructionSites: jest.fn().mockReturnValue([]),
-  getEnemies: jest.fn().mockReturnValue([]),
-  getLinks: jest.fn().mockReturnValue([]),
-  getStorage: jest.fn().mockReturnValue(null),
-  getMyStructures: jest.fn().mockReturnValue([]),
-  invalidate: jest.fn(),
-  cleanup: jest.fn(),
-  isSafeKey: jest.fn().mockImplementation((key) => {
-    return typeof key === 'string' && !['__proto__', 'constructor', 'prototype'].includes(key);
-  }),
-}), { virtual: true });
+jest.mock(
+    '../src/utils/cache',
+    () => ({
+        getSources: jest.fn().mockReturnValue([]),
+        getContainers: jest.fn().mockReturnValue([]),
+        getSpawns: jest.fn().mockReturnValue([]),
+        getStructures: jest.fn().mockReturnValue([]),
+        getConstructionSites: jest.fn().mockReturnValue([]),
+        getEnemies: jest.fn().mockReturnValue([]),
+        getLinks: jest.fn().mockReturnValue([]),
+        getStorage: jest.fn().mockReturnValue(null),
+        getMyStructures: jest.fn().mockReturnValue([]),
+        invalidate: jest.fn(),
+        cleanup: jest.fn(),
+        isSafeKey: jest.fn().mockImplementation((key) => {
+            return (
+                typeof key === 'string' && !['__proto__', 'constructor', 'prototype'].includes(key)
+            );
+        }),
+    }),
+    { virtual: true }
+);
 
-jest.mock('../src/utils/pathfinder', () => ({
-  findNearestOpenTile: jest.fn(),
-  findPath: jest.fn().mockReturnValue({ incomplete: true, path: [] }),
-  closest: jest.fn(),
-}), { virtual: true });
+jest.mock(
+    '../src/utils/pathfinder',
+    () => ({
+        findNearestOpenTile: jest.fn(),
+        findPath: jest.fn().mockReturnValue({ incomplete: true, path: [] }),
+        closest: jest.fn(),
+    }),
+    { virtual: true }
+);
 
-jest.mock('../src/utils/logger', () => ({
-  debug: jest.fn(),
-  info: jest.fn(),
-  warn: jest.fn(),
-  error: jest.fn(),
-}), { virtual: true });
+jest.mock(
+    '../src/utils/logger',
+    () => ({
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+    { virtual: true }
+);
 
-jest.mock('../src/constants', () => ({
-  ROLES: {
-    HARVESTER: 'harvester',
-    UPGRADER: 'upgrader',
-    BUILDER: 'builder',
-  },
-  CACHE_TTL: {},
-  MEMORY_CLEANUP_INTERVAL: 100,
-  STATS_DISPLAY_INTERVAL: 100,
-  SAFE_MODE_TRIGGER_HOSTILES: 3,
-}), { virtual: true });
+jest.mock(
+    '../src/constants',
+    () => ({
+        ROLES: {
+            HARVESTER: 'harvester',
+            UPGRADER: 'upgrader',
+            BUILDER: 'builder',
+        },
+        CACHE_TTL: {},
+        MEMORY_CLEANUP_INTERVAL: 100,
+        STATS_DISPLAY_INTERVAL: 100,
+        SAFE_MODE_TRIGGER_HOSTILES: 3,
+    }),
+    { virtual: true }
+);
 
 const cache = require('../src/utils/cache');
 const pathfinder = require('../src/utils/pathfinder');
 const roomManager = require('../src/managers/roomManager');
 
 describe('roomManager', () => {
-  beforeEach(() => { global.FIND_MY_STRUCTURES = 114; global.STRUCTURE_CONTAINER = 'container'; global.STRUCTURE_ROAD = 'road'; });
-  let mockRoom;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockRoom = {
-      name: 'W1N1',
-      controller: {
-        my: true,
-        level: 3,
-        progress: 1000,
-        progressTotal: 10000,
-        safeMode: null,
-        safeModeAvailable: 1,
-        activateSafeMode: jest.fn().mockReturnValue(OK),
-        pos: { x: 25, y: 25, getRangeTo: jest.fn().mockReturnValue(10) },
-      },
-      energyAvailable: 300,
-      energyCapacityAvailable: 300,
-      storage: null,
-      find: jest.fn().mockReturnValue([]),
-      createConstructionSite: jest.fn().mockReturnValue(OK),
-      getTerrain: jest.fn().mockReturnValue({
-        get: jest.fn().mockReturnValue(0),
-      }),
-      lookAt: jest.fn().mockReturnValue([]),
-      lookForAt: jest.fn().mockReturnValue([]),
-      visual: {
-        text: jest.fn(),
-      },
-    };
-
-    global.Game.time = 100;
-    global.Game.creeps = {};
-    global.Game.flags = {};
-    global.Memory.creeps = {};
-
-    cache.getSources.mockReturnValue([]);
-    cache.getContainers.mockReturnValue([]);
-    cache.getSpawns.mockReturnValue([]);
-    cache.getConstructionSites.mockReturnValue([]);
-    cache.getEnemies.mockReturnValue([]);
-    cache.getLinks.mockReturnValue([]);
-    cache.getStorage.mockReturnValue(null);
-    cache.getMyStructures.mockReturnValue([]);
-    pathfinder.findPath.mockReturnValue({ incomplete: true, path: [] });
-  });
-
-  describe('run', () => {
-    test('自分のルームで実行される', () => {
-      expect(() => roomManager.run(mockRoom)).not.toThrow();
-    });
-
-    test('コントローラーがないルームはスキップされる', () => {
-      const room = { ...mockRoom, controller: null };
-      expect(() => roomManager.run(room)).not.toThrow();
-    });
-
-    test('自分のルームでない場合はスキップされる', () => {
-      const room = { ...mockRoom, controller: { my: false } };
-      expect(() => roomManager.run(room)).not.toThrow();
-    });
-  });
-
-  describe('getStats', () => {
-    test('ルーム統計を返す', () => {
-      global.Game.creeps = {
-        creep1: {
-          room: mockRoom,
-          memory: { role: 'harvester' },
-        },
-      };
-
-      const stats = roomManager.getStats(mockRoom);
-
-      expect(stats).toBeDefined();
-      expect(stats.name).toBe('W1N1');
-      expect(stats.rcl).toBe(3);
-      expect(stats.energy).toBe(300);
-      expect(stats.energyCapacity).toBe(300);
-    });
-
-    test('プロパティが欠落しているエッジケースを処理する（コントローラーなし等）', () => {
-      const roomWithoutController = {
-        name: 'W1N2',
-        energyAvailable: 0,
-        energyCapacityAvailable: 0
-      };
-
-      const stats = roomManager.getStats(roomWithoutController);
-
-      expect(stats).toBeDefined();
-      expect(stats.name).toBe('W1N2');
-      expect(stats.rcl).toBe(0);
-      expect(stats.controllerProgress).toBe(0);
-      expect(stats.safeMode).toBe(false);
-      expect(stats.storageEnergy).toBe(0);
-    });
-
-    test('クリープ数をロール別にカウントする', () => {
-      global.Game.creeps = {
-        creep1: { room: mockRoom, memory: { role: 'harvester' } },
-        creep2: { room: mockRoom, memory: { role: 'harvester' } },
-        creep3: { room: mockRoom, memory: { role: 'upgrader' } },
-      };
-
-      const stats = roomManager.getStats(mockRoom);
-
-      expect(stats.creepCounts.harvester).toBe(2);
-      expect(stats.creepCounts.upgrader).toBe(1);
-    });
-  });
-
-  describe('showStats', () => {
-    test('統計をコンソールに表示する', () => {
-      expect(() => roomManager.showStats(mockRoom)).not.toThrow();
-    });
-  });
-
-  describe('showVisuals', () => {
-    test('ビジュアル表示が実行される', () => {
-      expect(() => roomManager.showVisuals(mockRoom)).not.toThrow();
-      expect(mockRoom.visual.text).toHaveBeenCalled();
-    });
-  });
-
-
-  describe('_planSourceContainers', () => {
     beforeEach(() => {
-      global.Game.time = 500;
-      mockRoom.controller.level = 2; // _planConstruction is called when level >= 2
+        global.FIND_MY_STRUCTURES = 114;
+        global.STRUCTURE_CONTAINER = 'container';
+        global.STRUCTURE_ROAD = 'road';
     });
+    let mockRoom;
 
-    test('コンテナが既にある場合はスキップする', () => {
-      const source = { id: 'src1', pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) } };
-      const container = { id: 'cont1', pos: { x: 12, y: 10 } };
-
-      cache.getSources.mockReturnValue([source]);
-      cache.getContainers.mockReturnValue([container]);
-
-      roomManager.run(mockRoom);
-
-      expect(source.pos.getRangeTo).toHaveBeenCalledWith(container);
-      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-    });
-
-    test('コンテナの建設サイトが既にある場合はスキップする', () => {
-      const source = { id: 'src1', pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) } };
-      const constructionSite = { structureType: global.STRUCTURE_CONTAINER, pos: { x: 12, y: 10 } };
-
-      cache.getSources.mockReturnValue([source]);
-      cache.getContainers.mockReturnValue([]);
-
-      mockRoom.find.mockImplementation((type, opts) => {
-        if (type === global.FIND_CONSTRUCTION_SITES && opts && opts.filter) {
-          if (opts.filter(constructionSite)) {
-             return [constructionSite];
-          }
-        }
-        return [];
-      });
-
-      roomManager.run(mockRoom);
-
-      expect(source.pos.getRangeTo).toHaveBeenCalledWith(constructionSite);
-      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-    });
-
-    test('配置可能なタイルがない場合はスキップする', () => {
-      const source = { id: 'src1', pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(3) } };
-
-      cache.getSources.mockReturnValue([source]);
-      cache.getContainers.mockReturnValue([]);
-      mockRoom.find.mockReturnValue([]);
-
-      pathfinder.findNearestOpenTile.mockReturnValue(null);
-
-      roomManager.run(mockRoom);
-
-      expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('planning, links and safety', () => {
-    test('建設計画でコンテナや道路を配置しキャッシュを無効化する', () => {
-      global.Game.time = 500;
-      const source = { id: 'src1', pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(1) } };
-      cache.getSources.mockReturnValue([source]);
-      cache.getContainers.mockReturnValue([]);
-      cache.getStructures.mockReturnValue([]);
-      cache.getConstructionSites.mockReturnValue([]);
-      cache.getSpawns.mockReturnValue([{ pos: { x: 5, y: 5, getRangeTo: jest.fn().mockReturnValue(1) } }]);
-      pathfinder.findNearestOpenTile.mockReturnValue({ x: 11, y: 10 });
-      pathfinder.findPath.mockReturnValue({ incomplete: false, path: [{ x: 6, y: 5 }, { x: 7, y: 5 }] });
-
-      roomManager.run(mockRoom);
-
-      expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(11, 10, global.STRUCTURE_CONTAINER);
-      expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(6, 5, global.STRUCTURE_ROAD);
-      expect(cache.invalidate).toHaveBeenCalledWith(`construction_sites_${mockRoom.name}`);
-    });
-
-    test('リンク転送が行われる', () => {
-      global.Game.time = 1;
-      const sink = {
-        pos: { x: 3, y: 3, getRangeTo: jest.fn().mockReturnValue(3) },
-        store: { [global.RESOURCE_ENERGY]: 0, getCapacity: jest.fn().mockReturnValue(800) },
-        cooldown: 0,
-      };
-      const sourceLink = {
-        pos: { x: 2, y: 2, getRangeTo: jest.fn().mockReturnValue(4) },
-        store: {
-          [global.RESOURCE_ENERGY]: 800,
-          getCapacity: jest.fn().mockReturnValue(800),
-        },
-        cooldown: 0,
-        transferEnergy: jest.fn().mockReturnValue(global.OK),
-      };
-
-      cache.getLinks.mockReturnValue([sourceLink, sink]);
-      cache.getSpawns.mockReturnValue([{ pos: { getRangeTo: jest.fn().mockReturnValue(2) } }]);
-      cache.getEnemies.mockReturnValue([]);
-      pathfinder.closest.mockReturnValue(sink);
-
-      roomManager.run(mockRoom);
-
-      expect(sourceLink.transferEnergy).toHaveBeenCalledWith(sink);
-    });
-
-    test('危険な敵がいるときセーフモードを発動する', () => {
-      const hostile = {
-        getActiveBodyparts: jest.fn().mockReturnValue(1),
-        pos: { x: 20, y: 20 },
-        hits: 50,
-        hitsMax: 100,
-      };
-      cache.getEnemies.mockReturnValue([hostile, hostile, hostile]);
-      cache.getLinks.mockReturnValue([]);
-
-      global.Game.time = 10;
-      roomManager.run(mockRoom);
-
-      expect(mockRoom.controller.activateSafeMode).toHaveBeenCalled();
-    });
-  });
-
-  describe('Security: Prototype Pollution & DoS Protection', () => {
-    test('getStats should not crash when Object.prototype is polluted', () => {
-      // Pollute Object.prototype
-      Object.prototype.polluted = 'dangerous';
-
-      try {
-        const stats = roomManager.getStats(mockRoom);
-        // Should not have 'polluted' as an own property
-        expect(Object.prototype.hasOwnProperty.call(stats.creepCounts, 'polluted')).toBe(false);
-      } finally {
-        // Clean up pollution
-        delete Object.prototype.polluted;
-      }
-    });
-
-    test('run should not crash when Object.prototype is polluted', () => {
-      // Pollute Object.prototype
-      Object.prototype.polluted = 'dangerous';
-
-      try {
-        global.Game.time = 100; // Trigger _cleanupRoomMemory
-        expect(() => roomManager.run(mockRoom)).not.toThrow();
-      } finally {
-        // Clean up pollution
-        delete Object.prototype.polluted;
-      }
-    });
-
-    test('getStats should handle corrupted/missing creep.room gracefully', () => {
-        global.Game.creeps = {
-            corruptedCreep: {
-                memory: { role: 'harvester' }
-                // room is missing
-            }
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockRoom = {
+            name: 'W1N1',
+            controller: {
+                my: true,
+                level: 3,
+                progress: 1000,
+                progressTotal: 10000,
+                safeMode: null,
+                safeModeAvailable: 1,
+                activateSafeMode: jest.fn().mockReturnValue(OK),
+                pos: { x: 25, y: 25, getRangeTo: jest.fn().mockReturnValue(10) },
+            },
+            energyAvailable: 300,
+            energyCapacityAvailable: 300,
+            storage: null,
+            find: jest.fn().mockReturnValue([]),
+            createConstructionSite: jest.fn().mockReturnValue(OK),
+            getTerrain: jest.fn().mockReturnValue({
+                get: jest.fn().mockReturnValue(0),
+            }),
+            lookAt: jest.fn().mockReturnValue([]),
+            lookForAt: jest.fn().mockReturnValue([]),
+            visual: {
+                text: jest.fn(),
+            },
         };
 
-        expect(() => roomManager.getStats(mockRoom)).not.toThrow();
-        const stats = roomManager.getStats(mockRoom);
-        expect(stats.creepCounts.harvester).toBeUndefined();
+        global.Game.time = 100;
+        global.Game.creeps = {};
+        global.Game.flags = {};
+        global.Memory.creeps = {};
+
+        cache.getSources.mockReturnValue([]);
+        cache.getContainers.mockReturnValue([]);
+        cache.getSpawns.mockReturnValue([]);
+        cache.getConstructionSites.mockReturnValue([]);
+        cache.getEnemies.mockReturnValue([]);
+        cache.getLinks.mockReturnValue([]);
+        cache.getStorage.mockReturnValue(null);
+        cache.getMyStructures.mockReturnValue([]);
+        pathfinder.findPath.mockReturnValue({ incomplete: true, path: [] });
     });
-  });
+
+    describe('run', () => {
+        test('自分のルームで実行される', () => {
+            expect(() => roomManager.run(mockRoom)).not.toThrow();
+        });
+
+        test('コントローラーがないルームはスキップされる', () => {
+            const room = { ...mockRoom, controller: null };
+            expect(() => roomManager.run(room)).not.toThrow();
+        });
+
+        test('自分のルームでない場合はスキップされる', () => {
+            const room = { ...mockRoom, controller: { my: false } };
+            expect(() => roomManager.run(room)).not.toThrow();
+        });
+    });
+
+    describe('getStats', () => {
+        test('ルーム統計を返す', () => {
+            global.Game.creeps = {
+                creep1: {
+                    room: mockRoom,
+                    memory: { role: 'harvester' },
+                },
+            };
+
+            const stats = roomManager.getStats(mockRoom);
+
+            expect(stats).toBeDefined();
+            expect(stats.name).toBe('W1N1');
+            expect(stats.rcl).toBe(3);
+            expect(stats.energy).toBe(300);
+            expect(stats.energyCapacity).toBe(300);
+        });
+
+        test('プロパティが欠落しているエッジケースを処理する（コントローラーなし等）', () => {
+            const roomWithoutController = {
+                name: 'W1N2',
+                energyAvailable: 0,
+                energyCapacityAvailable: 0,
+            };
+
+            const stats = roomManager.getStats(roomWithoutController);
+
+            expect(stats).toBeDefined();
+            expect(stats.name).toBe('W1N2');
+            expect(stats.rcl).toBe(0);
+            expect(stats.controllerProgress).toBe(0);
+            expect(stats.safeMode).toBe(false);
+            expect(stats.storageEnergy).toBe(0);
+        });
+
+        test('クリープ数をロール別にカウントする', () => {
+            global.Game.creeps = {
+                creep1: { room: mockRoom, memory: { role: 'harvester' } },
+                creep2: { room: mockRoom, memory: { role: 'harvester' } },
+                creep3: { room: mockRoom, memory: { role: 'upgrader' } },
+            };
+
+            const stats = roomManager.getStats(mockRoom);
+
+            expect(stats.creepCounts.harvester).toBe(2);
+            expect(stats.creepCounts.upgrader).toBe(1);
+        });
+    });
+
+    describe('showStats', () => {
+        test('統計をコンソールに表示する', () => {
+            expect(() => roomManager.showStats(mockRoom)).not.toThrow();
+        });
+    });
+
+    describe('showVisuals', () => {
+        test('ビジュアル表示が実行される', () => {
+            expect(() => roomManager.showVisuals(mockRoom)).not.toThrow();
+            expect(mockRoom.visual.text).toHaveBeenCalled();
+        });
+    });
+
+    describe('_planSourceContainers', () => {
+        beforeEach(() => {
+            global.Game.time = 500;
+            mockRoom.controller.level = 2; // _planConstruction is called when level >= 2
+        });
+
+        test('コンテナが既にある場合はスキップする', () => {
+            const source = {
+                id: 'src1',
+                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) },
+            };
+            const container = { id: 'cont1', pos: { x: 12, y: 10 } };
+
+            cache.getSources.mockReturnValue([source]);
+            cache.getContainers.mockReturnValue([container]);
+
+            roomManager.run(mockRoom);
+
+            expect(source.pos.getRangeTo).toHaveBeenCalledWith(container);
+            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
+        });
+
+        test('コンテナの建設サイトが既にある場合はスキップする', () => {
+            const source = {
+                id: 'src1',
+                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(2) },
+            };
+            const constructionSite = {
+                structureType: global.STRUCTURE_CONTAINER,
+                pos: { x: 12, y: 10 },
+            };
+
+            cache.getSources.mockReturnValue([source]);
+            cache.getContainers.mockReturnValue([]);
+
+            cache.getConstructionSites.mockReturnValue([constructionSite]);
+
+            roomManager.run(mockRoom);
+
+            expect(source.pos.getRangeTo).toHaveBeenCalledWith(constructionSite);
+            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
+        });
+
+        test('配置可能なタイルがない場合はスキップする', () => {
+            const source = {
+                id: 'src1',
+                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(3) },
+            };
+
+            cache.getSources.mockReturnValue([source]);
+            cache.getContainers.mockReturnValue([]);
+            mockRoom.find.mockReturnValue([]);
+
+            pathfinder.findNearestOpenTile.mockReturnValue(null);
+
+            roomManager.run(mockRoom);
+
+            expect(mockRoom.createConstructionSite).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('planning, links and safety', () => {
+        test('建設計画でコンテナや道路を配置しキャッシュを無効化する', () => {
+            global.Game.time = 500;
+            const source = {
+                id: 'src1',
+                pos: { x: 10, y: 10, getRangeTo: jest.fn().mockReturnValue(1) },
+            };
+            cache.getSources.mockReturnValue([source]);
+            cache.getContainers.mockReturnValue([]);
+            cache.getStructures.mockReturnValue([]);
+            cache.getConstructionSites.mockReturnValue([]);
+            cache.getSpawns.mockReturnValue([
+                { pos: { x: 5, y: 5, getRangeTo: jest.fn().mockReturnValue(1) } },
+            ]);
+            pathfinder.findNearestOpenTile.mockReturnValue({ x: 11, y: 10 });
+            pathfinder.findPath.mockReturnValue({
+                incomplete: false,
+                path: [
+                    { x: 6, y: 5 },
+                    { x: 7, y: 5 },
+                ],
+            });
+
+            roomManager.run(mockRoom);
+
+            expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
+                11,
+                10,
+                global.STRUCTURE_CONTAINER
+            );
+            expect(mockRoom.createConstructionSite).toHaveBeenCalledWith(
+                6,
+                5,
+                global.STRUCTURE_ROAD
+            );
+            expect(cache.invalidate).toHaveBeenCalledWith(`construction_sites_${mockRoom.name}`);
+        });
+
+        test('リンク転送が行われる', () => {
+            global.Game.time = 1;
+            const sink = {
+                pos: { x: 3, y: 3, getRangeTo: jest.fn().mockReturnValue(3) },
+                store: { [global.RESOURCE_ENERGY]: 0, getCapacity: jest.fn().mockReturnValue(800) },
+                cooldown: 0,
+            };
+            const sourceLink = {
+                pos: { x: 2, y: 2, getRangeTo: jest.fn().mockReturnValue(4) },
+                store: {
+                    [global.RESOURCE_ENERGY]: 800,
+                    getCapacity: jest.fn().mockReturnValue(800),
+                },
+                cooldown: 0,
+                transferEnergy: jest.fn().mockReturnValue(global.OK),
+            };
+
+            cache.getLinks.mockReturnValue([sourceLink, sink]);
+            cache.getSpawns.mockReturnValue([
+                { pos: { getRangeTo: jest.fn().mockReturnValue(2) } },
+            ]);
+            cache.getEnemies.mockReturnValue([]);
+            pathfinder.closest.mockReturnValue(sink);
+
+            roomManager.run(mockRoom);
+
+            expect(sourceLink.transferEnergy).toHaveBeenCalledWith(sink);
+        });
+
+        test('危険な敵がいるときセーフモードを発動する', () => {
+            const hostile = {
+                getActiveBodyparts: jest.fn().mockReturnValue(1),
+                pos: { x: 20, y: 20 },
+                hits: 50,
+                hitsMax: 100,
+            };
+            cache.getEnemies.mockReturnValue([hostile, hostile, hostile]);
+            cache.getLinks.mockReturnValue([]);
+
+            global.Game.time = 10;
+            roomManager.run(mockRoom);
+
+            expect(mockRoom.controller.activateSafeMode).toHaveBeenCalled();
+        });
+    });
+
+    describe('Security: Prototype Pollution & DoS Protection', () => {
+        test('getStats should not crash when Object.prototype is polluted', () => {
+            // Pollute Object.prototype
+            Object.prototype.polluted = 'dangerous';
+
+            try {
+                const stats = roomManager.getStats(mockRoom);
+                // Should not have 'polluted' as an own property
+                expect(Object.prototype.hasOwnProperty.call(stats.creepCounts, 'polluted')).toBe(
+                    false
+                );
+            } finally {
+                // Clean up pollution
+                delete Object.prototype.polluted;
+            }
+        });
+
+        test('run should not crash when Object.prototype is polluted', () => {
+            // Pollute Object.prototype
+            Object.prototype.polluted = 'dangerous';
+
+            try {
+                global.Game.time = 100; // Trigger _cleanupRoomMemory
+                expect(() => roomManager.run(mockRoom)).not.toThrow();
+            } finally {
+                // Clean up pollution
+                delete Object.prototype.polluted;
+            }
+        });
+
+        test('getStats should handle corrupted/missing creep.room gracefully', () => {
+            global.Game.creeps = {
+                corruptedCreep: {
+                    memory: { role: 'harvester' },
+                    // room is missing
+                },
+            };
+
+            expect(() => roomManager.getStats(mockRoom)).not.toThrow();
+            const stats = roomManager.getStats(mockRoom);
+            expect(stats.creepCounts.harvester).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
💡 **What:** The optimization implemented is to replace the use of engine's `room.find` array allocations to `cache.getMyStructures` and `cache.getConstructionSites` when looking for extensions or containers.

🎯 **Why:** To improve performance and minimise the garbage collection overhead. Engine backed Proxy arrays are inefficient to query constantly.

📊 **Measured Improvement:** Baseline took ~30ms, optimised version took ~20ms in simple 10000 loop benchmark.

---
*PR created automatically by Jules for task [1102401087745318462](https://jules.google.com/task/1102401087745318462) started by @tadanobutubutu*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured room management system to utilize cached lookups for structures and construction sites throughout planning operations, replacing direct query operations.

* **Tests**
  * Enhanced test framework with improved setup configurations, mock implementations, updated assertion formatting, comprehensive edge-case testing, and security scenario validation.

* **Chores**
  * Updated internal documentation and development utilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/437)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->