### PR TITLE
🎨 Palette: Add GCL Level Up estimation to dashboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,11 +1,14 @@
 ## 2025-05-15 - [GCL/Power Delta Tracking]
+
 **Learning:** Adding immediate visual feedback for incremental progress (like GCL/Power increases) significantly enhances the "living" feel of a dashboard. However, implementation must strictly adhere to React best practices—specifically, avoiding state updates within other state updater functions to prevent side effects and maintain predictable rendering behavior.
 **Action:** Always perform related state updates sequentially in the main logic flow rather than nested within functional updaters. Maintain surgical edits to stay within line count constraints and follow existing style and design patterns.
 
 ## 2025-05-16 - [Urgency Animations & Delta Feedback]
+
 **Learning:** Subtle, high-frequency animations (like `shake`) are more effective than slow animations (like `pulse`) for conveying critical status or urgency in compact UIs. Additionally, explicit delta indicators (e.g., `+1` for room gains) provide immediate "success feedback" that raw numbers lack, improving the user's sense of progress during brief dashboard checks.
 **Action:** Use `shake` for critical alerts and include numeric deltas for all key resources to emphasize recent changes.
 
 ## 2026-05-14 - [GCL Level Up Estimation]
+
 **Learning:** Providing actionable progress information, such as an "estimated time to level up," transforms raw data into meaningful feedback for long-term players. This enhancement leverages the rate of change between data syncs, making the dashboard feel more dynamic and helpful. Updating ARIA attributes (like `aria-valuetext`) ensures this "delightful" information is also accessible to screen reader users.
 **Action:** Always look for opportunities to derive "velocity" or "time-to-goal" metrics from static stats to improve user engagement and situational awareness.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-05-16 - [Urgency Animations & Delta Feedback]
 **Learning:** Subtle, high-frequency animations (like `shake`) are more effective than slow animations (like `pulse`) for conveying critical status or urgency in compact UIs. Additionally, explicit delta indicators (e.g., `+1` for room gains) provide immediate "success feedback" that raw numbers lack, improving the user's sense of progress during brief dashboard checks.
 **Action:** Use `shake` for critical alerts and include numeric deltas for all key resources to emphasize recent changes.
+
+## 2026-05-14 - [GCL Level Up Estimation]
+**Learning:** Providing actionable progress information, such as an "estimated time to level up," transforms raw data into meaningful feedback for long-term players. This enhancement leverages the rate of change between data syncs, making the dashboard feel more dynamic and helpful. Updating ARIA attributes (like `aria-valuetext`) ensures this "delightful" information is also accessible to screen reader users.
+**Action:** Always look for opportunities to derive "velocity" or "time-to-goal" metrics from static stats to improve user engagement and situational awareness.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -16,6 +16,7 @@ export default function Dashboard() {
     const [loading, setLoading] = useState(true);
     const [isRefreshing, setIsRefreshing] = useState(false);
     const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+    const [prevLastUpdated, setPrevLastUpdated] = useState<Date | null>(null);
     const [copied, setCopied] = useState(false);
     const [updated, setUpdated] = useState(false);
     const [isRefreshFocused, setIsRefreshFocused] = useState(false);
@@ -50,6 +51,32 @@ export default function Dashboard() {
         stats?.cpuUsed !== undefined && prevStats?.cpuUsed !== undefined
             ? stats.cpuUsed - prevStats.cpuUsed
             : 0;
+
+    const getTimeToLevel = useCallback(() => {
+        if (!stats?.gcl || !prevStats?.gcl || !lastUpdated || !prevLastUpdated) return null;
+        if (stats.gcl.level !== prevStats.gcl.level) return null;
+
+        const xpGain = stats.gcl.progress - prevStats.gcl.progress;
+        const timeDiff = lastUpdated.getTime() - prevLastUpdated.getTime();
+
+        if (xpGain <= 0 || timeDiff <= 0) return null;
+
+        const xpRemaining = stats.gcl.progressTotal - stats.gcl.progress;
+        const xpPerMs = xpGain / timeDiff;
+        return xpRemaining / xpPerMs;
+    }, [stats, prevStats, lastUpdated, prevLastUpdated]);
+
+    const formatDuration = (ms: number) => {
+        const seconds = Math.floor(ms / 1000);
+        const minutes = Math.floor(seconds / 60);
+        const hours = Math.floor(minutes / 60);
+        const days = Math.floor(hours / 24);
+
+        if (days > 0) return `${days}d ${hours % 24}h`;
+        if (hours > 0) return `${hours}h ${minutes % 60}m`;
+        if (minutes > 0) return `${minutes}m ${seconds % 60}s`;
+        return `${seconds}s`;
+    };
 
     const getStalenessInfo = useCallback(() => {
         if (updated) return { icon: '✅', color: '#1e7e34', label: 'Just updated' };
@@ -118,6 +145,7 @@ export default function Dashboard() {
                 if (!r.ok) throw new Error(`API error: ${r.status}`);
                 const data = await r.json();
                 setPrevStats(stats);
+                setPrevLastUpdated(lastUpdated);
                 setStats(data);
                 setLastUpdated(new Date());
                 setError(null);
@@ -132,7 +160,7 @@ export default function Dashboard() {
                 setIsRefreshing(false);
             }
         },
-        [stats]
+        [stats, lastUpdated]
     );
 
     useEffect(() => {
@@ -845,8 +873,8 @@ export default function Dashboard() {
                         aria-valuenow={Number(gclPercent.toFixed(2))}
                         aria-valuemin={0}
                         aria-valuemax={100}
-                        aria-valuetext={`${gclPercent.toFixed(2)}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}`}
-                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}`}
+                        aria-valuetext={`${gclPercent.toFixed(2)}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${getTimeToLevel() ? ` (est. ${formatDuration(getTimeToLevel()!)} to go)` : ''}`}
+                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${getTimeToLevel() ? ` (est. ${formatDuration(getTimeToLevel()!)} to go)` : ''}`}
                         style={{
                             width: '100%',
                             height: '12px',
@@ -892,7 +920,9 @@ export default function Dashboard() {
                     <div style={{ fontSize: '0.75rem', color: '#575757', textAlign: 'right' }}>
                         {stats.gcl.progress.toLocaleString()} /{' '}
                         {stats.gcl.progressTotal.toLocaleString()} (
-                        {(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} remaining)
+                        {(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} remaining
+                        {getTimeToLevel() && ` • est. ${formatDuration(getTimeToLevel()!)} to level`}
+                        )
                     </div>
                 </section>
             )}

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -921,7 +921,8 @@ export default function Dashboard() {
                         {stats.gcl.progress.toLocaleString()} /{' '}
                         {stats.gcl.progressTotal.toLocaleString()} (
                         {(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} remaining
-                        {getTimeToLevel() && ` • est. ${formatDuration(getTimeToLevel()!)} to level`}
+                        {getTimeToLevel() &&
+                            ` • est. ${formatDuration(getTimeToLevel()!)} to level`}
                         )
                     </div>
                 </section>


### PR DESCRIPTION
## **User description**
I have implemented a micro-UX improvement by adding a "Time to Level Up" estimation for the Global Control Level (GCL) in the Screeps Dashboard.

### 💡 What
- Calculated the XP gain rate between successful dashboard refreshes.
- Projected the time remaining until the next GCL level based on this rate.
- Displayed the human-readable duration (e.g., "3h 15m") in the GCL progress section.

### 🎯 Why
- Raw XP numbers and percentages provide the "where" but not the "how fast."
- Providing an estimate gives players immediate feedback on their current efficiency and makes the dashboard feel more like a living tool for long-term planning.

### ♿ Accessibility
- Updated the `aria-valuetext` and `title` attributes on the GCL progress bar to include the estimation, ensuring that users with screen readers or those using mouse-hover get the same actionable information.

### ✅ Verification
- Verified logic via local Next.js build.
- Conducted visual verification using a Playwright script with mocked API responses, confirming the calculation and UI rendering work as expected.
- Verified that the implementation follows React best practices (no nested state updates).

---
*PR created automatically by Jules for task [1843715835780065354](https://jules.google.com/task/1843715835780065354) started by @tadanobutubutu*


___

## **CodeAnt-AI Description**
**Show an estimated time to reach the next GCL level on the dashboard**

### What Changed
- The GCL progress area now shows an estimated time to level up when there is enough recent progress data
- The estimate is included in the visible progress summary and in hover/screen reader text
- If the level changes or there is not enough progress to calculate a pace, the dashboard falls back to showing the remaining XP only

### Impact
`✅ Clearer GCL progress`
`✅ Faster long-term planning`
`✅ More useful screen reader progress text`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added estimated time to reach the next GCL level, displayed in progress bars and tooltips.

* **Accessibility**
  * Enhanced progress bar descriptions with improved accessibility text and tooltip information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/442)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->