### PR TITLE
⚡ Bolt: optimize harvester energy delivery with caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -14,6 +14,14 @@ Instead of re-querying the game state, this pattern uses cached objects updated 
 **Takeaway:**
 Whenever a function is querying properties from `room.find`, check if the `src/utils/cache.js` has a wrapper function. Prefer using cached getter functions to minimize engine overhead.
 
+## 2025-05-15 - Optimize Harvester Energy Delivery with Caching
+
+**Learning:**
+Combining multiple `room.find` calls into a single cached function like `cache.getStructuresNeedingEnergy` significantly reduces CPU overhead. Furthermore, caching the target ID in `creep.memory` avoids redundant spatial searches and priority filtering on every tick while the target is still valid.
+
+**Action:**
+In high-frequency roles like Harvester, always look for opportunities to use consolidated cache getters and implement target ID persistence in memory.
+
 ## Bolt Memory Journal
 
 ### Optimization: Use getMyStructures Cache in Tower Manager

--- a/src/roles/harvester.js
+++ b/src/roles/harvester.js
@@ -146,8 +146,33 @@ function _findAvailableContainer(creep) {
  * @param {Creep} creep
  */
 function _deliver(creep) {
-    // 最優先: スポーン・エクステンションへの補充
-    const target = _findEnergyTarget(creep);
+    // ⚡ PERFORMANCE OPTIMIZATION: Cache the delivery target ID to avoid per-tick search
+    let target = null;
+    const targetId = creep.memory[MEMORY_KEYS.TARGET_ID];
+
+    if (targetId) {
+        target = Game.getObjectById(targetId);
+        // Valid target must still exist and have free capacity
+        if (
+            !target ||
+            !target.store ||
+            target.store.getFreeCapacity(RESOURCE_ENERGY) === 0 ||
+            (target.structureType === STRUCTURE_TOWER &&
+                target.store.getFreeCapacity(RESOURCE_ENERGY) <= 200 &&
+                creep.store[RESOURCE_ENERGY] > target.store.getFreeCapacity(RESOURCE_ENERGY))
+        ) {
+            target = null;
+            delete creep.memory[MEMORY_KEYS.TARGET_ID];
+        }
+    }
+
+    if (!target) {
+        target = _findEnergyTarget(creep);
+        if (target) {
+            creep.memory[MEMORY_KEYS.TARGET_ID] = target.id;
+        }
+    }
+
     if (!target) {
         // 納品先がなければアップグレードを補助
         _upgradeAsBackup(creep);
@@ -157,9 +182,12 @@ function _deliver(creep) {
     const result = creep.transfer(target, RESOURCE_ENERGY);
     if (result === ERR_NOT_IN_RANGE) {
         pathfinder.moveTo(creep, target, { range: 1 });
-    } else if (result === ERR_FULL) {
-        // 満杯なら次のターゲットを探す（キャッシュ無効化）
-        cache.invalidate(`need_energy_${creep.room.name}`);
+    } else if (result === OK || result === ERR_FULL) {
+        // 納品完了または満杯ならターゲットをクリア（次ティックで再検索）
+        delete creep.memory[MEMORY_KEYS.TARGET_ID];
+        if (result === ERR_FULL) {
+            cache.invalidate(`need_energy_${creep.room.name}`);
+        }
     }
 }
 
@@ -171,22 +199,23 @@ function _deliver(creep) {
 function _findEnergyTarget(creep) {
     const room = creep.room;
 
+    // ⚡ PERFORMANCE OPTIMIZATION: Use getStructuresNeedingEnergy cache to avoid redundant room.find calls.
+    // This combines spawns, extensions, and towers into a single cached search.
+    const needingEnergy = cache.getStructuresNeedingEnergy(room);
+
     // 1. スポーン・エクステンション
-    const spawnsAndExtensions = room.find(FIND_MY_STRUCTURES, {
-        filter: (s) =>
-            (s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION) &&
-            s.store.getFreeCapacity(RESOURCE_ENERGY) > 0,
-    });
+    const spawnsAndExtensions = needingEnergy.filter(
+        (s) => s.structureType === STRUCTURE_SPAWN || s.structureType === STRUCTURE_EXTENSION
+    );
 
     if (spawnsAndExtensions.length > 0) {
         return pathfinder.closest(creep.pos, spawnsAndExtensions);
     }
 
-    // 2. タワー
-    const towers = room.find(FIND_MY_STRUCTURES, {
-        filter: (s) =>
-            s.structureType === STRUCTURE_TOWER && s.store.getFreeCapacity(RESOURCE_ENERGY) > 200,
-    });
+    // 2. タワー (200以上の空き容量があるものを優先)
+    const towers = needingEnergy.filter(
+        (s) => s.structureType === STRUCTURE_TOWER && s.store.getFreeCapacity(RESOURCE_ENERGY) > 200
+    );
     if (towers.length > 0) {
         return pathfinder.closest(creep.pos, towers);
     }

--- a/tests/src.roles.harvester.test.js
+++ b/tests/src.roles.harvester.test.js
@@ -27,6 +27,7 @@ const mockCache = {
     getStorage: jest.fn(),
     assignSource: jest.fn(),
     invalidate: jest.fn(),
+    getStructuresNeedingEnergy: jest.fn(),
 };
 
 jest.mock('../src/utils/cache', () => mockCache, { virtual: true });
@@ -38,11 +39,13 @@ jest.mock(
     }),
     { virtual: true }
 );
-jest.mock('../src/utils/logger', () => ({ warn: jest.fn() }), { virtual: true });
+jest.mock('../src/utils/logger', () => ({ warn: jest.fn(), info: jest.fn(), error: jest.fn() }), {
+    virtual: true,
+});
 jest.mock(
     '../src/constants',
     () => ({
-        MEMORY_KEYS: { WORKING: 'working', SOURCE_ID: 'sourceId' },
+        MEMORY_KEYS: { WORKING: 'working', SOURCE_ID: 'sourceId', TARGET_ID: 'targetId' },
         ROLES: { HARVESTER: 'harvester' },
     }),
     { virtual: true }
@@ -82,14 +85,13 @@ describe('src/roles/harvester', () => {
             store: { getFreeCapacity: jest.fn().mockReturnValue(10) },
             structureType: global.STRUCTURE_SPAWN,
         };
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([target]);
         const creep = {
             memory: { working: true },
             store: { [global.RESOURCE_ENERGY]: 50, getCapacity: jest.fn().mockReturnValue(50) },
             say: jest.fn(),
             transfer: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
-            room: {
-                find: jest.fn().mockReturnValue([target]),
-            },
+            room: {},
             pos: { x: 0, y: 0 },
         };
         pathfinder.closest.mockReturnValue(target);
@@ -97,6 +99,32 @@ describe('src/roles/harvester', () => {
         harvester.run(creep);
 
         expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, target, { range: 1 });
+        expect(creep.memory.targetId).toBe('spawn1');
+    });
+
+    test('キャッシュされた納品先を再利用する', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        const target = {
+            id: 'spawn1',
+            store: { getFreeCapacity: jest.fn().mockReturnValue(10) },
+            structureType: global.STRUCTURE_SPAWN,
+        };
+        global.Game.getObjectById = jest.fn().mockReturnValue(target);
+
+        const creep = {
+            memory: { working: true, targetId: 'spawn1' },
+            store: { [global.RESOURCE_ENERGY]: 50, getCapacity: jest.fn().mockReturnValue(50) },
+            say: jest.fn(),
+            transfer: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
+            room: {},
+            pos: { x: 0, y: 0 },
+        };
+
+        harvester.run(creep);
+
+        expect(global.Game.getObjectById).toHaveBeenCalledWith('spawn1');
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, target, { range: 1 });
+        expect(mockCache.getStructuresNeedingEnergy).not.toHaveBeenCalled();
     });
 
     test('getBodyで適切な構成を返す', () => {
@@ -130,6 +158,7 @@ describe('src/roles/harvester', () => {
         mockCache.getDroppedResources.mockReturnValue([]);
         mockCache.getContainers.mockReturnValue([]);
         mockCache.getStorage.mockReturnValue(null);
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([]);
         const controller = {};
         const creep = {
             memory: { working: true },
@@ -139,7 +168,6 @@ describe('src/roles/harvester', () => {
             upgradeController: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
             room: {
                 controller,
-                find: jest.fn().mockReturnValue([]),
             },
             pos: {},
         };


### PR DESCRIPTION
💡 What: Optimized harvester energy delivery by using a consolidated cache for structures needing energy and implementing target ID persistence in creep memory.
🎯 Why: Multiple `room.find` calls in `_findEnergyTarget` were redundant and expensive. Caching the target ID avoids spatial searches and priority filtering on every tick while the target remains valid.
📊 Impact: Reduces `room.find(FIND_MY_STRUCTURES)` calls significantly and saves CPU cycles per harvester by bypassing search logic on most ticks.
🔬 Measurement: Verified with `tests/src.roles.harvester.test.js` showing 12/12 passes, including new caching and reuse scenarios.

---
*PR created automatically by Jules for task [17052500171713754162](https://jules.google.com/task/17052500171713754162) started by @tadanobutubutu*

## Summary by Sourcery

Optimize harvester energy delivery by caching target structures and reusing a consolidated room energy-needs cache.

Enhancements:
- Cache harvester delivery target IDs in creep memory to avoid redundant per-tick target searches.
- Use a consolidated getStructuresNeedingEnergy cache to select spawns, extensions, and towers needing energy instead of repeated room.find calls.

Documentation:
- Update the Bolt optimization journal with guidance on caching harvester delivery targets and using consolidated structure-energy caches.

Tests:
- Extend harvester role tests to cover cached target reuse and interactions with the new energy-needs cache.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes harvester energy delivery by caching target IDs and using a consolidated energy-needs cache. This cuts redundant `room.find` calls and saves CPU on most ticks.

- **Refactors**
  - Cache delivery target ID in `creep.memory` and reuse it until invalid; clear after successful transfer or if full.
  - Replace repeated `room.find` with `cache.getStructuresNeedingEnergy(room)` for spawns, extensions, and towers (towers only if free capacity > 200).
  - Invalidate `need_energy_<room>` cache when a target is full; extend tests to cover target reuse and update the optimization journal.

<sup>Written for commit 60e3d9d57334846e5a47ed1a219ac6908aa42a3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Harvester energy delivery has been optimized through intelligent target caching and memory persistence, significantly reducing redundant searches and improving efficiency across game ticks.

* **Tests**
  * Updated harvester delivery test suite to verify correct behavior of caching mechanisms and target reuse patterns.

* **Documentation**
  * Added optimization guidance for harvester energy delivery strategies and best practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/443)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->