### PR TITLE
🎨 Palette: GCL Velocity tracking & Level Up delight

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,8 @@
 
 **Learning:** Providing actionable progress information, such as an "estimated time to level up," transforms raw data into meaningful feedback for long-term players. This enhancement leverages the rate of change between data syncs, making the dashboard feel more dynamic and helpful. Updating ARIA attributes (like `aria-valuetext`) ensures this "delightful" information is also accessible to screen reader users.
 **Action:** Always look for opportunities to derive "velocity" or "time-to-goal" metrics from static stats to improve user engagement and situational awareness.
+
+## 2026-05-15 - [XP Velocity & Tab Feedback]
+
+**Learning:** Actionable progress metrics like XP/h and "time to goal" significantly enhance user engagement by providing velocity context. Synchronizing the dashboard state (Level Up, Copied) with the browser tab (Title and Favicon) provides high-value feedback for users multi-tasking across tabs. Using local variables in the render body for derived metrics used in both JSX and ARIA attributes ensures efficiency without redundant hook calls.
+**Action:** Always derive velocity metrics from sync deltas and reflect critical state changes in the tab title/favicon for a "living" application feel.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -52,19 +52,27 @@ export default function Dashboard() {
             ? stats.cpuUsed - prevStats.cpuUsed
             : 0;
 
-    const getTimeToLevel = useCallback(() => {
+    const getXpPerHour = useCallback(() => {
         if (!stats?.gcl || !prevStats?.gcl || !lastUpdated || !prevLastUpdated) return null;
-        if (stats.gcl.level !== prevStats.gcl.level) return null;
-
-        const xpGain = stats.gcl.progress - prevStats.gcl.progress;
         const timeDiff = lastUpdated.getTime() - prevLastUpdated.getTime();
+        if (timeDiff <= 0) return null;
 
-        if (xpGain <= 0 || timeDiff <= 0) return null;
+        const xpGain = leveledUp
+            ? prevStats.gcl.progressTotal - prevStats.gcl.progress + stats.gcl.progress
+            : stats.gcl.progress - prevStats.gcl.progress;
+
+        if (xpGain <= 0) return null;
+        return (xpGain / timeDiff) * 3600000;
+    }, [stats, prevStats, lastUpdated, prevLastUpdated, leveledUp]);
+
+    const getTimeToLevel = useCallback(() => {
+        if (!stats?.gcl || !lastUpdated || !prevLastUpdated) return null;
+        const xpPerHour = getXpPerHour();
+        if (!xpPerHour) return null;
 
         const xpRemaining = stats.gcl.progressTotal - stats.gcl.progress;
-        const xpPerMs = xpGain / timeDiff;
-        return xpRemaining / xpPerMs;
-    }, [stats, prevStats, lastUpdated, prevLastUpdated]);
+        return (xpRemaining / xpPerHour) * 3600000;
+    }, [stats, getXpPerHour, lastUpdated, prevLastUpdated]);
 
     const formatDuration = (ms: number) => {
         const seconds = Math.floor(ms / 1000);
@@ -237,6 +245,12 @@ export default function Dashboard() {
         } else if (error) {
             title = '⚠️ Error';
             emoji = '⚠️';
+        } else if (copied) {
+            title = '📋 Copied';
+            emoji = '📋';
+        } else if (leveledUp) {
+            title = '🦋 LEVEL UP!';
+            emoji = '🦋';
         } else if (updated) {
             title = '✅ Updated';
             emoji = '✅';
@@ -262,7 +276,7 @@ export default function Dashboard() {
         if (link) {
             link.href = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>${emoji}</text></svg>`;
         }
-    }, [loading, isRefreshing, updated, stats, timeAgo, error, getStalenessInfo]);
+    }, [loading, isRefreshing, updated, leveledUp, copied, stats, timeAgo, error, getStalenessInfo]);
 
     return (
         <main
@@ -290,12 +304,12 @@ export default function Dashboard() {
                             display: 'inline-block',
                             animation: isRefreshing
                                 ? 'spin 1s linear infinite'
-                                : updated
+                                : updated || leveledUp
                                   ? 'bounce 0.6s ease'
                                   : 'none',
                         }}
                     >
-                        🐛
+                        {leveledUp ? '🦋' : '🐛'}
                     </span>{' '}
                     Screeps Dashboard
                 </h1>
@@ -698,7 +712,20 @@ export default function Dashboard() {
                 </div>
             )}
 
-            {stats?.gcl && (
+            {stats?.gcl && (() => {
+                const xpPerHour = getXpPerHour();
+                const timeToLevel = getTimeToLevel();
+                const formattedXpPerHour = xpPerHour
+                    ? xpPerHour >= 1000000000
+                        ? `${(xpPerHour / 1000000000).toFixed(2)}B XP/h`
+                        : xpPerHour >= 1000000
+                          ? `${(xpPerHour / 1000000).toFixed(1)}M XP/h`
+                          : xpPerHour >= 1000
+                            ? `${(xpPerHour / 1000).toFixed(1)}K XP/h`
+                            : `${Math.round(xpPerHour)} XP/h`
+                    : null;
+
+                return (
                 <section
                     style={{
                         marginBottom: '1.5rem',
@@ -873,8 +900,8 @@ export default function Dashboard() {
                         aria-valuenow={Number(gclPercent.toFixed(2))}
                         aria-valuemin={0}
                         aria-valuemax={100}
-                        aria-valuetext={`${gclPercent.toFixed(2)}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${getTimeToLevel() ? ` (est. ${formatDuration(getTimeToLevel()!)} to go)` : ''}`}
-                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${getTimeToLevel() ? ` (est. ${formatDuration(getTimeToLevel()!)} to go)` : ''}`}
+                        aria-valuetext={`${gclPercent.toFixed(2)}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
+                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
                         style={{
                             width: '100%',
                             height: '12px',
@@ -921,12 +948,13 @@ export default function Dashboard() {
                         {stats.gcl.progress.toLocaleString()} /{' '}
                         {stats.gcl.progressTotal.toLocaleString()} (
                         {(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} remaining
-                        {getTimeToLevel() &&
-                            ` • est. ${formatDuration(getTimeToLevel()!)} to level`}
+                        {formattedXpPerHour && ` • ${formattedXpPerHour}`}
+                        {timeToLevel && ` • est. ${formatDuration(timeToLevel)} to level`}
                         )
                     </div>
                 </section>
-            )}
+                );
+            })()}
 
             <section
                 style={{


### PR DESCRIPTION
### 🎨 Palette: GCL Velocity tracking & Level Up delight

#### 💡 What
- **XP Velocity:** Added real-time XP/hour tracking and an improved "time to level" estimation that correctly handles transitions across GCL level-ups.
- **Visual Delight:** Implemented a "metamorphosis" effect where the header emoji changes from 🐛 to 🦋 and triggers a bounce animation when a level-up is detected.
- **Tab Sync:** The browser tab title and favicon now dynamically reflect the dashboard state, including "🦋 LEVEL UP!", "📋 Copied", and critical staleness alerts.
- **Performance:** Refactored the GCL stats section to use local variables, avoiding redundant hook calls for derived metrics.

#### 🎯 Why
Raw statistics lack context regarding progress velocity. By providing XP/h and time estimates, users gain a better understanding of their AI's performance. The visual feedback provides subtle "success hits" that make the dashboard feel more interactive and alive.

#### ♿ Accessibility
- Updated the GCL progress bar's `aria-valuetext` and `title` attributes to include XP/hour velocity and estimated time remaining.
- Maintained strict color contrast ratios (>4.5:1) for all new status indicators.

#### 📸 Verification
Verified via a Playwright script that mocks a GCL level-up transition, confirming:
1. XP/h calculation accuracy.
2. 🦋 metamorphosis in the header.
3. "LEVEL UP!" badge visibility.
4. Correct tab title/favicon updates.
5. Compact formatting for large XP rates.

---
*PR created automatically by Jules for task [9437245528741820756](https://jules.google.com/task/9437245528741820756) started by @tadanobutubutu*

## Summary by Sourcery

Add XP velocity tracking and richer feedback around GCL level progression, while synchronizing dashboard state with the browser tab and improving accessibility text.

New Features:
- Introduce XP/hour computation that correctly handles GCL level-up transitions and drives an estimated time-to-level metric.
- Display formatted XP/hour and time-to-level alongside GCL progress, including compact units for large XP rates.
- Synchronize browser tab title and favicon emoji with dashboard states such as copy success and GCL level-up, and animate the header emoji from 🐛 to 🦋 on level-up.

Enhancements:
- Refactor GCL progress rendering to reuse locally computed XP velocity and time-to-level values across visual and ARIA representations for better efficiency and consistency.

Documentation:
- Extend the Palette documentation with a new entry describing XP velocity, tab feedback, and best practices for deriving velocity metrics and reflecting state in tab chrome.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time XP/hour and accurate time-to-level for GCL, plus a playful 🐛→🦋 level-up animation with tab title/favicon updates for clearer feedback. Also improves accessibility and reduces redundant renders.

- **New Features**
  - Track XP/hour and estimate time-to-level, including across level transitions.
  - Level-up “metamorphosis” with bounce; tab title and favicon reflect "🦋 LEVEL UP!", "📋 Copied", and staleness alerts.
  - Progress bar `aria-valuetext` and `title` include XP/h and time remaining; compact K/M/B formatting for large rates.

- **Refactors**
  - Introduced `getXpPerHour` and updated `getTimeToLevel`; compute derived metrics once with local variables.
  - Synced title/favicon effect dependencies to include `leveledUp` and `copied` for consistent updates.

<sup>Written for commit b0fc0b2cc2dd13abd0800abcbd721f3dc1864b3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

