### PR TITLE
⚡ Bolt: Optimize dashboard performance with pre-warmed caches

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -30,3 +30,7 @@ In high-frequency roles like Harvester, always look for opportunities to use con
 - **What:** Replaced the engine-level `room.find(FIND_MY_STRUCTURES)` call with `cache.getMyStructures(room, STRUCTURE_RAMPART)` when searching for urgent rampart repair targets in `_selectRepairTarget`. We then manually apply the filtering using `.filter()` on the cached result.
 - **Why:** `room.find(FIND_MY_STRUCTURES)` loops through all owned structures and has significant overhead due to Screeps engine Proxy-to-Array conversions every tick. Fetching directly from the cache prevents redundant searches and engine calls, specifically benefiting multi-tower operations during high-RCL defenses where the array size and operation frequency grow.
 - **Performance Result:** Micro-benchmarks showed a large drop in time (420.6ms -> 56.4ms over 100k iterations) by iterating over JS objects instead of fetching via the mock room's `find` method, simulating the overhead reduction in game.
+
+## 2025-05-16 - Optimize Dashboard with Pre-Warmed Caches
+**Learning:** Redundant engine calls (like `room.find`) in UI/Dashboard components can be eliminated by centralizing data collection in a global tick loop and attaching results to volatile room properties.
+**Action:** Always check if the required data is already available as a volatile property (e.g., `_myStructures`, `_roleCounts`) before performing a new search or filter operation.

--- a/tests/utils.dashboard.test.js
+++ b/tests/utils.dashboard.test.js
@@ -12,6 +12,18 @@ describe('DashboardRenderer', () => {
 
         mockRoom = {
             find: jest.fn().mockReturnValue([]),
+            _myStructures: [],
+            _hostileCreeps: [],
+            _roleCounts: {
+                harvester: 0,
+                upgrader: 0,
+                builder: 0,
+                repairer: 0,
+                transporter: 0,
+                scout: 0,
+                medic: 0,
+                explorer: 0,
+            },
             energyAvailable: 1000,
             energyCapacityAvailable: 2000,
             storage: {

--- a/utils.dashboard.js
+++ b/utils.dashboard.js
@@ -17,60 +17,28 @@ const DashboardRenderer = {
     formatNumber,
 
     renderRoomDashboard(room) {
-        // ⚡ PERFORMANCE OPTIMIZATION: Use centralized room caches pre-warmed in main.js.
-        if (room._myCreepsTick !== Game.time) {
-            room._myCreeps = room.find(FIND_MY_CREEPS);
-            room._myCreepsTick = Game.time;
-        }
-        if (room._myStructuresTick !== Game.time) {
-            room._myStructures = room.find(FIND_MY_STRUCTURES);
-            room._myStructuresTick = Game.time;
-        }
-        if (room._hostileCreepsTick !== Game.time) {
-            room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
-            room._hostileCreepsTick = Game.time;
-        }
+        // ⚡ PERFORMANCE OPTIMIZATION: Leverage pre-warmed room caches from main.js.
+        // Redundant per-tick find() calls and role counting removed as they are handled globally.
+        const structures = room._myStructures || [];
+        const hostiles = room._hostileCreeps || [];
+        const roleCount = room._roleCounts || {};
 
-        const creeps = room._myCreeps;
-        const structures = room._myStructures;
-        const hostiles = room._hostileCreeps;
+        const energyAvailable = room.energyAvailable;
+        const energyCapacity = room.energyCapacityAvailable;
+        const storageEnergy = room.storage ? room.storage.store[RESOURCE_ENERGY] : 0;
+        const storageCapacity = room.storage ? room.storage.store.getCapacity(RESOURCE_ENERGY) : 0;
 
-        // ⚡ PERFORMANCE OPTIMIZATION: Use pre-calculated role counts from the global loop in main.js
-        // to avoid redundant O(N) counting per room in the dashboard.
-        let roleCount = room._roleCounts;
-        if (!roleCount) {
-            roleCount = {
-                harvester: 0,
-                upgrader: 0,
-                builder: 0,
-                repairer: 0,
-                transporter: 0,
-                scout: 0,
-                medic: 0,
-                explorer: 0,
-            };
-            for (let i = 0; i < creeps.length; i++) {
-                const role = creeps[i].memory.role;
-                if (roleCount[role] !== undefined) {
-                    roleCount[role]++;
-                }
-            }
-        }
-
-        const energyStats = {
-            available: room.energyAvailable,
-            capacity: room.energyCapacityAvailable,
-            storageEnergy: room.storage ? room.storage.store[RESOURCE_ENERGY] : 0,
-            storageCapacity: room.storage ? room.storage.store.getCapacity(RESOURCE_ENERGY) : 0,
-        };
+        const gclProgress = Game.gcl.progress;
+        const gclTotal = Game.gcl.progressTotal;
+        const gclPercent = Number(((gclProgress / gclTotal) * 100).toFixed(2));
 
         const info = {
             room: room.name,
             gcl: {
                 level: Game.gcl.level,
-                percent: Number(((Game.gcl.progress / Game.gcl.progressTotal) * 100).toFixed(2)),
-                progress: Game.gcl.progress,
-                progressTotal: Game.gcl.progressTotal,
+                percent: gclPercent,
+                progress: gclProgress,
+                progressTotal: gclTotal,
             },
             controller: room.controller
                 ? {
@@ -88,16 +56,12 @@ const DashboardRenderer = {
                 : null,
             hostiles: hostiles.length,
             structures: structures.length,
-            energy: `${formatNumber(energyStats.available)}/${formatNumber(energyStats.capacity)}`,
-            energyPercent: energyStats.capacity
-                ? Math.floor((energyStats.available / energyStats.capacity) * 100)
-                : 0,
-            energyAvailable: energyStats.available,
-            energyCapacity: energyStats.capacity,
-            storage: formatNumber(energyStats.storageEnergy),
-            storagePercent: energyStats.storageCapacity
-                ? Math.floor((energyStats.storageEnergy / energyStats.storageCapacity) * 100)
-                : 0,
+            energy: `${formatNumber(energyAvailable)}/${formatNumber(energyCapacity)}`,
+            energyPercent: energyCapacity ? Math.floor((energyAvailable / energyCapacity) * 100) : 0,
+            energyAvailable: energyAvailable,
+            energyCapacity: energyCapacity,
+            storage: formatNumber(storageEnergy),
+            storagePercent: storageCapacity ? Math.floor((storageEnergy / storageCapacity) * 100) : 0,
             creeps: roleCount,
             mode: adaptiveSystem.getModeName(Memory.adaptive?.currentMode ?? 2).toUpperCase(),
             bucket: Game.cpu.bucket,


### PR DESCRIPTION
Optimized the dashboard rendering in `utils.dashboard.js` to use pre-warmed room caches (`_myStructures`, `_hostileCreeps`, `_roleCounts`) initialized in `main.js`. This eliminates redundant per-tick `room.find()` calls and role counting loops, making the dashboard significantly more CPU-efficient. Unit tests have been updated to support these changes.

---
*PR created automatically by Jules for task [16618154312273219249](https://jules.google.com/task/16618154312273219249) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized dashboard rendering by using pre-warmed room caches from `main.js`. Removed per-tick `room.find()` calls and role counting in `utils.dashboard.js` to reduce CPU, especially in busy rooms.

- **Refactors**
  - Read from `room._myStructures`, `room._hostileCreeps`, and `room._roleCounts`; removed local caches and counting loops.
  - Computed GCL percent once with local variables to avoid repeated lookups.
  - Updated tests to seed cache fields and match the new flow.
  - Added a note in `.jules/bolt.md` on using volatile room props for UI paths.

<sup>Written for commit 89c11093fc83eb45e3cb491080b0f3b269afda5f. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/447?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

