### PR TITLE
⚡ Bolt: Optimize Rainbow Trail for stationary creeps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -34,3 +34,7 @@ In high-frequency roles like Harvester, always look for opportunities to use con
 ## 2025-05-16 - Optimize Dashboard with Pre-Warmed Caches
 **Learning:** Redundant engine calls (like `room.find`) in UI/Dashboard components can be eliminated by centralizing data collection in a global tick loop and attaching results to volatile room properties.
 **Action:** Always check if the required data is already available as a volatile property (e.g., `_myStructures`, `_roleCounts`) before performing a new search or filter operation.
+
+## 2025-05-17 - Visual Draining for Stationary Objects
+**Learning:** High-frequency visual effects (like trails) should only update their state when the subject moves. For stationary subjects, draining the state (e.g., shifting out old positions) allows the effect to naturally fade and eventually skip the entire drawing loop, saving significant CPU on `RoomVisual` calls.
+**Action:** In VFX modules, implement movement-based state updates and early returns for empty states to minimize redundant per-tick engine overhead.

--- a/visual.effects.js
+++ b/visual.effects.js
@@ -274,7 +274,6 @@ const visualEffects = {
             _trailCache.delete(creep.id);
             return;
         }
-        const visual = getVisual(creep.room.name);
 
         // ⚡ PERFORMANCE: Migrate from Memory to volatile cache if existing data is found.
         if (creep.memory.trailPositions) {
@@ -288,12 +287,27 @@ const visualEffects = {
             _trailCache.set(creep.id, positions);
         }
 
-        positions.push({ x: creep.pos.x, y: creep.pos.y });
+        // ⚡ PERFORMANCE: Only update the trail if the creep has actually moved or if we need to drain the trail.
+        // This avoids redundant pushes and allows the trail to catch up to stationary creeps.
+        const lastPos = positions.length > 0 ? positions[positions.length - 1] : null;
+        const hasMoved = !lastPos || lastPos.x !== creep.pos.x || lastPos.y !== creep.pos.y;
 
-        if (positions.length > 10) {
+        if (hasMoved) {
+            positions.push({ x: creep.pos.x, y: creep.pos.y });
+            if (positions.length > 10) {
+                positions.shift();
+            }
+        } else if (positions.length > 0) {
+            // Stationary: Drain the trail to avoid static visuals and reduce redundant loop iterations.
             positions.shift();
         }
 
+        // ⚡ PERFORMANCE: Skip drawing loop entirely if no positions remain.
+        if (positions.length === 0) {
+            return;
+        }
+
+        const visual = getVisual(creep.room.name);
         for (let i = 0; i < positions.length; i++) {
             const trailPos = positions[i];
             visual.circle(trailPos.x, trailPos.y, {


### PR DESCRIPTION
### 💡 What: The optimization implemented
Optimized the `rainbowTrail` visual effect in `visual.effects.js` by making it movement-aware and implementing a "draining" mechanism for stationary creeps.

### 🎯 Why: The performance problem it solves
Previously, the `rainbowTrail` would continuously draw a 10-point trail even for stationary creeps, resulting in redundant `RoomVisual` draw calls and object allocations every tick.

### 📊 Impact: Expected performance improvement
Reduces per-tick CPU overhead for stationary creeps by skipping visual drawing once the trail has drained (after 10 ticks of inactivity). For a bot with many stationary units, this significantly lowers total `RoomVisual` CPU usage.

### 🔬 Measurement: How to verify the improvement
Verified by running `npx jest tests/src.roles.behavior.test.js` and confirmed the logic correctness in `visual.effects.js`. In-game, stationary creeps will have their rainbow trails disappear after 10 ticks instead of persisting forever.

---
*PR created automatically by Jules for task [9872752695070978812](https://jules.google.com/task/9872752695070978812) started by @tadanobutubutu*

## Summary by Sourcery

Optimize the rainbowTrail visual effect to be movement-aware and avoid unnecessary rendering for stationary creeps.

Enhancements:
- Update rainbowTrail logic to only extend the trail when creeps move and gradually drain trails for stationary creeps, skipping drawing when no trail remains.

Documentation:
- Add a Bolt engineering note describing movement-based visual draining and early-return patterns for high-frequency visual effects.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize the rainbowTrail effect to update only on movement and drain when creeps are stationary, then skip drawing once the trail empties. This cuts redundant `RoomVisual` calls and lowers per-tick CPU for idle units.

- **Refactors**
  - Update `visual.effects.js` to push a new position only on movement; otherwise shift to drain (max length 10).
  - Early-return when the trail is empty to avoid `getVisual` and draw loops.
  - Add `.jules/bolt.md` note documenting movement-based VFX and draining pattern.

<sup>Written for commit 885acf56e966293f3924f8016a24d3698673c809. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/453?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

