### PR TITLE
🛡️ Sentinel: [security improvement] Implement FIFO eviction in pathfinder cache

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Path Traversal (Partial Match).
 **Learning:** Using `startsWith(baseDir)` for path validation can be bypassed if the base directory name is a prefix of a malicious sibling directory (e.g., `/app` matching `/app_danger`).
 **Prevention:** Ensure the base directory path ends with a path separator (e.g., `path.sep`) before performing the `startsWith` check to enforce strict directory boundary validation.
+
+## 2026-05-18 - Pathfinder Cache Starvation DoS
+**Vulnerability:** Cache Starvation and CPU Exhaustion DoS.
+**Learning:** If a cache simply stops accepting new entries when full, it can enter a permanent state of cache misses for any new operations. In a resource-constrained environment like Screeps, this leads to repeated expensive re-computations (CPU exhaustion).
+**Prevention:** Implement a unified eviction policy (like FIFO) across all caching modules. Always attempt to cleanup expired entries before evicting. Ensure cache retrieval is robust against corrupted or non-numeric expiration values.

--- a/src/utils/pathfinder.js
+++ b/src/utils/pathfinder.js
@@ -168,7 +168,7 @@ function buildCostMatrix (roomName, options) {
     const entry = Object.prototype.hasOwnProperty.call(cache, cacheKey)
       ? cache[cacheKey]
       : undefined
-    if (entry && entry.expires > Game.time) {
+    if (entry && typeof entry.expires === 'number' && entry.expires > Game.time) {
       return entry.data
     }
   }
@@ -194,12 +194,23 @@ function buildCostMatrix (roomName, options) {
 
 
   if (opts.useCache && isSafeKey(cacheKey)) {
-    // Security: Cap the number of cache entries to prevent Memory DoS
-    if (Object.keys(cache).length < MAX_CACHE_ENTRIES) {
-      cache[cacheKey] = {
-        data: costs,
-        expires: Game.time + CACHE_TTL.PATH
+    // Security: Cap the number of cache entries to prevent Memory DoS.
+    // If full, attempt to cleanup expired entries.
+    if (Object.keys(cache).length >= MAX_CACHE_ENTRIES) {
+      cacheUtils.cleanup()
+      // If still full, implement FIFO eviction by deleting the oldest entry.
+      // This ensures the cache remains available for new, potentially more relevant data.
+      if (Object.keys(cache).length >= MAX_CACHE_ENTRIES) {
+        const keys = Object.keys(cache)
+        if (keys.length > 0) {
+          delete cache[keys[0]]
+        }
       }
+    }
+
+    cache[cacheKey] = {
+      data: costs,
+      expires: Game.time + CACHE_TTL.PATH
     }
   }
 
@@ -428,7 +439,7 @@ function estimateDistance (origin, goal) {
 
   if (isSafeKey(key)) {
     const entry = Object.prototype.hasOwnProperty.call(cache, key) ? cache[key] : undefined
-    if (entry && entry.expires > Game.time) {
+    if (entry && typeof entry.expires === 'number' && entry.expires > Game.time) {
       return entry.data
     }
   }
@@ -437,12 +448,23 @@ function estimateDistance (origin, goal) {
   const dist = result.incomplete ? Infinity : result.path.length
 
   if (isSafeKey(key)) {
-    // Security: Cap the number of cache entries to prevent Memory DoS
-    if (Object.keys(cache).length < MAX_CACHE_ENTRIES) {
-      cache[key] = {
-        data: dist,
-        expires: Game.time + CACHE_TTL.PATH
+    // Security: Cap the number of cache entries to prevent Memory DoS.
+    // If full, attempt to cleanup expired entries.
+    if (Object.keys(cache).length >= MAX_CACHE_ENTRIES) {
+      cacheUtils.cleanup()
+      // If still full, implement FIFO eviction by deleting the oldest entry.
+      // This ensures the cache remains available for new, potentially more relevant data.
+      if (Object.keys(cache).length >= MAX_CACHE_ENTRIES) {
+        const keys = Object.keys(cache)
+        if (keys.length > 0) {
+          delete cache[keys[0]]
+        }
       }
+    }
+
+    cache[key] = {
+      data: dist,
+      expires: Game.time + CACHE_TTL.PATH
     }
   }
 

--- a/tests/security.pathfinder.test.js
+++ b/tests/security.pathfinder.test.js
@@ -104,10 +104,10 @@ describe('Security: Pathfinder Hardening', () => {
             expect(pathfinder.isSafeKey(longKey)).toBe(false);
         });
 
-        test('buildCostMatrix should enforce MAX_CACHE_ENTRIES limit', () => {
+        test('buildCostMatrix should implement FIFO eviction when full', () => {
             // Fill cache to limit (100)
             for (let i = 0; i < 100; i++) {
-                global.cache[`key${i}`] = { data: {}, expires: 10 };
+                global.cache[`key${i}`] = { data: {}, expires: Game.time + 10 };
             }
             expect(Object.keys(global.cache).length).toBe(100);
 
@@ -118,22 +118,30 @@ describe('Security: Pathfinder Hardening', () => {
 
             // Cache size should still be 100
             expect(Object.keys(global.cache).length).toBe(100);
-            expect(global.cache[`cm_${roomName}_0`]).toBeUndefined();
+            // Oldest key should be gone
+            expect(global.cache['key0']).toBeUndefined();
+            // New key should be present
+            expect(global.cache[`cm_${roomName}_0`]).toBeDefined();
         });
 
-        test('estimateDistance should enforce MAX_CACHE_ENTRIES limit', () => {
+        test('estimateDistance should implement FIFO eviction when full', () => {
             // Fill cache to limit (100)
             for (let i = 0; i < 100; i++) {
-                global.cache[`key${i}`] = { data: {}, expires: 10 };
+                global.cache[`key${i}`] = { data: {}, expires: Game.time + 10 };
             }
 
             const origin = { x: 1, y: 1, roomName: 'W1N1' };
             const goal = { x: 5, y: 5, roomName: 'W1N1' };
+            const key = `path_${origin.roomName}_${origin.x}_${origin.y}_${goal.roomName}_${goal.x}_${goal.y}`;
 
             pathfinder.estimateDistance(origin, goal);
 
             // Cache size should still be 100
             expect(Object.keys(global.cache).length).toBe(100);
+            // Oldest key should be gone
+            expect(global.cache['key0']).toBeUndefined();
+            // New key should be present
+            expect(global.cache[key]).toBeDefined();
         });
     });
 

--- a/tests/security.pathfinder_eviction.test.js
+++ b/tests/security.pathfinder_eviction.test.js
@@ -1,0 +1,131 @@
+/**
+ * tests/security.pathfinder_eviction.test.js
+ * Specific tests for FIFO eviction logic in src/utils/pathfinder.js
+ */
+
+global.Game = { time: 100 };
+global.FIND_STRUCTURES = 1;
+global.FIND_CONSTRUCTION_SITES = 111;
+global.FIND_CREEPS = 3;
+global.STRUCTURE_ROAD = 'road';
+
+class MockCostMatrix {
+    set() {}
+    get() {}
+}
+
+global.PathFinder = {
+    CostMatrix: MockCostMatrix,
+    search: jest.fn().mockReturnValue({ incomplete: false, path: [] })
+};
+
+// Mock dependencies
+jest.mock('../src/constants', () => ({
+    PATHFINDER_DEFAULTS: { ROAD_COST: 1 },
+    CACHE_TTL: { PATH: 50 }
+}), { virtual: true });
+
+const cacheUtils = require('../src/utils/cache');
+jest.mock('../src/utils/cache', () => ({
+    getStructures: jest.fn().mockReturnValue([]),
+    getConstructionSites: jest.fn().mockReturnValue([]),
+    cleanup: jest.fn()
+}));
+
+const pathfinder = require('../src/utils/pathfinder');
+
+describe('Security: Pathfinder FIFO Eviction', () => {
+    beforeEach(() => {
+        global.cache = {};
+        jest.clearAllMocks();
+        global.Game.time = 100;
+        global.Game.rooms = {};
+    });
+
+    describe('buildCostMatrix eviction', () => {
+        test('should evict oldest entry when cache is full', () => {
+            // Fill cache to 100 entries
+            for (let i = 0; i < 100; i++) {
+                global.cache[`key_${i}`] = { data: 'old_data_' + i, expires: 200 };
+            }
+
+            const roomName = 'W1N1';
+            global.Game.rooms[roomName] = { find: jest.fn().mockReturnValue([]) };
+
+            pathfinder.buildCostMatrix(roomName);
+
+            // Oldest key should be deleted
+            expect(global.cache['key_0']).toBeUndefined();
+            // New entry should be added
+            expect(global.cache[`cm_${roomName}_0`]).toBeDefined();
+            // Total size should still be 100
+            expect(Object.keys(global.cache).length).toBe(100);
+        });
+
+        test('should cleanup expired entries before FIFO eviction', () => {
+            // Fill cache with 99 active and 1 expired entry
+            for (let i = 0; i < 99; i++) {
+                global.cache[`key_${i}`] = { data: 'active', expires: 200 };
+            }
+            global.cache['expired_key'] = { data: 'expired', expires: 50 }; // Game.time is 100
+
+            // Mock cleanup to actually remove the expired entry
+            cacheUtils.cleanup.mockImplementation(() => {
+                delete global.cache['expired_key'];
+                return 1;
+            });
+
+            const roomName = 'W2N2';
+            global.Game.rooms[roomName] = { find: jest.fn().mockReturnValue([]) };
+
+            pathfinder.buildCostMatrix(roomName);
+
+            // cleanup() should have been called
+            expect(cacheUtils.cleanup).toHaveBeenCalled();
+            // Expired key should be gone
+            expect(global.cache['expired_key']).toBeUndefined();
+            // NO FIFO eviction should have happened because cleanup freed space
+            expect(global.cache['key_0']).toBeDefined();
+            // New entry should be added
+            expect(global.cache[`cm_${roomName}_0`]).toBeDefined();
+            expect(Object.keys(global.cache).length).toBe(100);
+        });
+    });
+
+    describe('estimateDistance eviction', () => {
+        test('should evict oldest entry when cache is full', () => {
+            // Fill cache to 100 entries
+            for (let i = 0; i < 100; i++) {
+                global.cache[`key_${i}`] = { data: 10, expires: 200 };
+            }
+
+            const origin = { x: 1, y: 1, roomName: 'W3N3' };
+            const goal = { x: 10, y: 10, roomName: 'W3N3' };
+            const expectedKey = `path_W3N3_1_1_W3N3_10_10`;
+
+            pathfinder.estimateDistance(origin, goal);
+
+            // Oldest key should be deleted
+            expect(global.cache['key_0']).toBeUndefined();
+            // New entry should be added
+            expect(global.cache[expectedKey]).toBeDefined();
+            expect(Object.keys(global.cache).length).toBe(100);
+        });
+    });
+
+    describe('Robust Type Checking', () => {
+        test('should ignore entries with non-numeric expires', () => {
+            const roomName = 'W4N4';
+            const cacheKey = `cm_${roomName}_0`;
+            global.cache[cacheKey] = { data: 'corrupted', expires: 'forever' };
+
+            global.Game.rooms[roomName] = { find: jest.fn().mockReturnValue([]) };
+
+            const result = pathfinder.buildCostMatrix(roomName);
+
+            // Should have ignored the corrupted entry and returned a new CostMatrix
+            expect(result).toBeInstanceOf(MockCostMatrix);
+            expect(result).not.toBe('corrupted');
+        });
+    });
+});


### PR DESCRIPTION
🛡️ Sentinel: [security improvement] Implement FIFO eviction in pathfinder cache

### Evaluation of the Solution

#### Core Functionality
- **FIFO Eviction:** The patch successfully implements a First-In-First-Out (FIFO) eviction strategy. When the cache reaches `MAX_CACHE_ENTRIES`, it first attempts to remove expired entries using `cacheUtils.cleanup()`. if the cache is still full, it removes the oldest entry. This ensures the cache remains available for new, potentially more relevant data rather than simply stopping caching when full.
- **Type Safety:** The addition of `typeof entry.expires === 'number'` is a significant improvement. It prevents potential bugs or exploitation where corrupted or maliciously injected cache entries with non-numeric `expires` values might bypass expiration logic due to JavaScript type coercion.

#### Completeness
- The patch covers both `buildCostMatrix` and `estimateDistance`, which are the two primary caching points in the pathfinder utility.
- Comprehensive security tests have been added and updated.

#### Verification
- Ran all 67 test suites (634 tests total), all passed.
- New tests specifically verify FIFO eviction and cleanup prioritization.


---
*PR created automatically by Jules for task [1711028543052529773](https://jules.google.com/task/1711028543052529773) started by @tadanobutubutu*

## Summary by Sourcery

Implement FIFO-based eviction and stricter expiration handling in the pathfinder cache to prevent cache starvation and improve security.

Bug Fixes:
- Ensure pathfinder cache entries with non-numeric expiration values are ignored instead of bypassing expiration checks.
- Prevent cache starvation and CPU exhaustion by allowing new pathfinder cache entries even when the cache is full via eviction.

Enhancements:
- Adopt a FIFO eviction policy for the pathfinder cost matrix and distance estimation caches, cleaning up expired entries before evicting the oldest entry.
- Document the cache starvation vulnerability and its prevention strategy in the Sentinel security notes.

Tests:
- Add dedicated tests verifying FIFO eviction behavior and cleanup prioritization in the pathfinder cache.
- Update existing security tests to assert correct FIFO eviction and presence of newly cached entries when the cache is full.