### PR TITLE
⚡ Bolt: optimize tower manager by leveraging room cache

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -38,3 +38,16 @@ In high-frequency roles like Harvester, always look for opportunities to use con
 ## 2025-05-17 - Visual Draining for Stationary Objects
 **Learning:** High-frequency visual effects (like trails) should only update their state when the subject moves. For stationary subjects, draining the state (e.g., shifting out old positions) allows the effect to naturally fade and eventually skip the entire drawing loop, saving significant CPU on `RoomVisual` calls.
 **Action:** In VFX modules, implement movement-based state updates and early returns for empty states to minimize redundant per-tick engine overhead.
+
+## 2025-05-18 - Optimize Tower Manager with Room Cache
+
+**Learning:**
+Tower management can be a significant CPU sink in high-RCL rooms due to frequent `room.find` calls for each tower. By replacing `room.find(FIND_MY_CREEPS)` and `room.find(FIND_STRUCTURES)` with their cached equivalents (`cache.getMyCreeps` and `cache.getStructures`), we eliminate redundant engine-level searches.
+
+**Action:**
+Always leverage the centralized `src/utils/cache.js` for common room searches, especially in manager modules that iterate over multiple structures (like towers) or run every tick.
+
+**Impact:**
+- Reduces engine-level API calls by 1 + N$ per room per tick (where $ is the number of towers).
+- Replaces expensive C++/JS bridge crossings with pure JS array filtering.
+- Estimated CPU saving: 0.1 - 0.5 CPU per room depending on the number of structures and towers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4301,6 +4301,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
       "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/src/managers/towerManager.js
+++ b/src/managers/towerManager.js
@@ -9,20 +9,20 @@
  * タワーのエネルギー管理も行い、エネルギー補充の優先度を制御する。
  */
 
-'use strict'
+'use strict';
 
-const cache = require('../utils/cache')
-const pathfinder = require('../utils/pathfinder')
-const logger = require('../utils/logger')
+const cache = require('../utils/cache');
+const pathfinder = require('../utils/pathfinder');
+const logger = require('../utils/logger');
 const {
-  TOWER_ATTACK_PRIORITY_HP,
-  TOWER_REPAIR_THRESHOLD,
-  TOWER_REPAIR_STOP_THRESHOLD,
-  TOWER_HEAL_THRESHOLD,
-  TOWER_ENERGY_PRIORITY,
-  REPAIR_THRESHOLD,
-  WALL_HP_TARGET
-} = require('../constants')
+    TOWER_ATTACK_PRIORITY_HP,
+    TOWER_REPAIR_THRESHOLD,
+    TOWER_REPAIR_STOP_THRESHOLD,
+    TOWER_HEAL_THRESHOLD,
+    TOWER_ENERGY_PRIORITY,
+    REPAIR_THRESHOLD,
+    WALL_HP_TARGET,
+} = require('../constants');
 
 // ============================================================
 // メイン制御
@@ -32,22 +32,27 @@ const {
  * ルーム内の全タワーを制御する
  * @param {Room} room
  */
-function run (room) {
-  try {
-    const towers = cache.getMyStructures(room, STRUCTURE_TOWER)
-    if (towers.length === 0) return
+function run(room) {
+    try {
+        const towers = cache.getMyStructures(room, STRUCTURE_TOWER);
+        if (towers.length === 0) {
+            return;
+        }
 
-    const enemies = cache.getEnemies(room)
-    const myCreeps = room.find(FIND_MY_CREEPS)
-    const injuredCreeps = myCreeps.filter((c) => c.hits < c.hitsMax * TOWER_HEAL_THRESHOLD)
+        const enemies = cache.getEnemies(room);
+        // ⚡ PERFORMANCE OPTIMIZATION: Use getMyCreeps cache to avoid redundant room.find calls.
+        const myCreeps = cache.getMyCreeps(room);
+        const injuredCreeps = myCreeps.filter((c) => c.hits < c.hitsMax * TOWER_HEAL_THRESHOLD);
 
-    for (const tower of towers) {
-      if (tower.store[RESOURCE_ENERGY] < 10) continue
-      _runTower(tower, enemies, injuredCreeps, room)
+        for (const tower of towers) {
+            if (tower.store[RESOURCE_ENERGY] < 10) {
+                continue;
+            }
+            _runTower(tower, enemies, injuredCreeps, room);
+        }
+    } catch (e) {
+        logger.error('[TowerManager] タワーエラー', e);
     }
-  } catch (e) {
-    logger.error('[TowerManager] タワーエラー', e)
-  }
 }
 
 // ============================================================
@@ -61,10 +66,14 @@ function run (room) {
  * @param {Creep[]} injuredCreeps
  * @param {Room} room
  */
-function _runTower (tower, enemies, injuredCreeps, room) {
-  if (_tryAttack(tower, enemies)) return
-  if (_tryHeal(tower, injuredCreeps)) return
-  _tryRepair(tower, room)
+function _runTower(tower, enemies, injuredCreeps, room) {
+    if (_tryAttack(tower, enemies)) {
+        return;
+    }
+    if (_tryHeal(tower, injuredCreeps)) {
+        return;
+    }
+    _tryRepair(tower, room);
 }
 
 /**
@@ -73,15 +82,17 @@ function _runTower (tower, enemies, injuredCreeps, room) {
  * @param {Creep[]} enemies
  * @returns {boolean} 攻撃を実行したかどうか
  */
-function _tryAttack (tower, enemies) {
-  if (enemies.length === 0) return false
-  const target = _selectAttackTarget(tower, enemies)
-  if (target) {
-    tower.attack(target)
-    _showAttackVisual(tower, target)
-    return true
-  }
-  return false
+function _tryAttack(tower, enemies) {
+    if (enemies.length === 0) {
+        return false;
+    }
+    const target = _selectAttackTarget(tower, enemies);
+    if (target) {
+        tower.attack(target);
+        _showAttackVisual(tower, target);
+        return true;
+    }
+    return false;
 }
 
 /**
@@ -90,15 +101,17 @@ function _tryAttack (tower, enemies) {
  * @param {Creep[]} injuredCreeps
  * @returns {boolean} 回復を実行したかどうか
  */
-function _tryHeal (tower, injuredCreeps) {
-  if (injuredCreeps.length === 0) return false
-  const target = _selectHealTarget(tower, injuredCreeps)
-  if (target) {
-    tower.heal(target)
-    _showHealVisual(tower, target)
-    return true
-  }
-  return false
+function _tryHeal(tower, injuredCreeps) {
+    if (injuredCreeps.length === 0) {
+        return false;
+    }
+    const target = _selectHealTarget(tower, injuredCreeps);
+    if (target) {
+        tower.heal(target);
+        _showHealVisual(tower, target);
+        return true;
+    }
+    return false;
 }
 
 /**
@@ -107,17 +120,19 @@ function _tryHeal (tower, injuredCreeps) {
  * @param {Room} room
  * @returns {boolean} 修復を実行したかどうか
  */
-function _tryRepair (tower, room) {
-  const energyRatio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY)
-  if (energyRatio <= TOWER_ENERGY_PRIORITY) return false
+function _tryRepair(tower, room) {
+    const energyRatio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY);
+    if (energyRatio <= TOWER_ENERGY_PRIORITY) {
+        return false;
+    }
 
-  const repairTarget = _selectRepairTarget(tower, room)
-  if (repairTarget) {
-    tower.repair(repairTarget)
-    _showRepairVisual(tower, repairTarget)
-    return true
-  }
-  return false
+    const repairTarget = _selectRepairTarget(tower, room);
+    if (repairTarget) {
+        tower.repair(repairTarget);
+        _showRepairVisual(tower, repairTarget);
+        return true;
+    }
+    return false;
 }
 
 // ============================================================
@@ -131,35 +146,37 @@ function _tryRepair (tower, room) {
  * @param {Creep[]} enemies
  * @returns {Creep|null}
  */
-function _selectAttackTarget (tower, enemies) {
-  if (enemies.length === 0) return null
-
-  // HPが閾値以下の敵を最優先
-  const criticalEnemies = enemies.filter((e) => e.hits <= TOWER_ATTACK_PRIORITY_HP)
-  if (criticalEnemies.length > 0) {
-    return pathfinder.closest(tower.pos, criticalEnemies)
-  }
-
-  // コントローラーに最も近い敵（占領脅威）を優先
-  const controller = tower.room.controller
-  if (controller) {
-    const claimers = enemies.filter((e) => e.getActiveBodyparts(CLAIM) > 0)
-    if (claimers.length > 0) {
-      return pathfinder.closest(controller.pos, claimers)
+function _selectAttackTarget(tower, enemies) {
+    if (enemies.length === 0) {
+        return null;
     }
-  }
 
-  // 攻撃系パーツを持つ敵を優先
-  const attackers = enemies.filter(
-    (e) => e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0
-  )
-  if (attackers.length > 0) {
-    // HPが最も低い攻撃者
-    return attackers.reduce((a, b) => (a.hits < b.hits ? a : b))
-  }
+    // HPが閾値以下の敵を最優先
+    const criticalEnemies = enemies.filter((e) => e.hits <= TOWER_ATTACK_PRIORITY_HP);
+    if (criticalEnemies.length > 0) {
+        return pathfinder.closest(tower.pos, criticalEnemies);
+    }
 
-  // 一般的な敵はHPが最も低いものを選択
-  return enemies.reduce((a, b) => (a.hits < b.hits ? a : b))
+    // コントローラーに最も近い敵（占領脅威）を優先
+    const controller = tower.room.controller;
+    if (controller) {
+        const claimers = enemies.filter((e) => e.getActiveBodyparts(CLAIM) > 0);
+        if (claimers.length > 0) {
+            return pathfinder.closest(controller.pos, claimers);
+        }
+    }
+
+    // 攻撃系パーツを持つ敵を優先
+    const attackers = enemies.filter(
+        (e) => e.getActiveBodyparts(ATTACK) > 0 || e.getActiveBodyparts(RANGED_ATTACK) > 0
+    );
+    if (attackers.length > 0) {
+        // HPが最も低い攻撃者
+        return attackers.reduce((a, b) => (a.hits < b.hits ? a : b));
+    }
+
+    // 一般的な敵はHPが最も低いものを選択
+    return enemies.reduce((a, b) => (a.hits < b.hits ? a : b));
 }
 
 // ============================================================
@@ -173,9 +190,11 @@ function _selectAttackTarget (tower, enemies) {
  * @param {Creep[]} injured
  * @returns {Creep|null}
  */
-function _selectHealTarget (tower, injured) {
-  if (injured.length === 0) return null
-  return injured.reduce((a, b) => (a.hits / a.hitsMax < b.hits / b.hitsMax ? a : b))
+function _selectHealTarget(tower, injured) {
+    if (injured.length === 0) {
+        return null;
+    }
+    return injured.reduce((a, b) => (a.hits / a.hitsMax < b.hits / b.hitsMax ? a : b));
 }
 
 // ============================================================
@@ -189,35 +208,40 @@ function _selectHealTarget (tower, injured) {
  * @param {Room} room
  * @returns {Structure|null}
  */
-function _selectRepairTarget (tower, room) {
-  // ランパートの緊急修復
-  const rcl = room.controller ? room.controller.level : 1
-  const wallTarget = WALL_HP_TARGET[rcl] || WALL_HP_TARGET[1]
+function _selectRepairTarget(tower, room) {
+    // ランパートの緊急修復
+    const rcl = room.controller ? room.controller.level : 1;
+    const wallTarget = WALL_HP_TARGET[rcl] || WALL_HP_TARGET[1];
 
-  const ramparts = cache.getMyStructures(room, STRUCTURE_RAMPART)
-  const urgentRamparts = ramparts.filter((s) => s.hits < Math.min(wallTarget * 0.1, 5000))
-  if (urgentRamparts.length > 0) {
-    return urgentRamparts.reduce((a, b) => (a.hits < b.hits ? a : b))
-  }
-
-  // 道路・コンテナの修復
-  const damaged = room.find(FIND_STRUCTURES, {
-    filter: (s) => {
-      if (s.structureType === STRUCTURE_WALL) return false
-      if (s.structureType === STRUCTURE_RAMPART) return false
-      const threshold = REPAIR_THRESHOLD[s.structureType] || REPAIR_THRESHOLD.OTHER
-      return s.hits < s.hitsMax * threshold
+    const ramparts = cache.getMyStructures(room, STRUCTURE_RAMPART);
+    const urgentRamparts = ramparts.filter((s) => s.hits < Math.min(wallTarget * 0.1, 5000));
+    if (urgentRamparts.length > 0) {
+        return urgentRamparts.reduce((a, b) => (a.hits < b.hits ? a : b));
     }
-  })
 
-  if (damaged.length === 0) return null
+    // 道路・コンテナの修復
+    // ⚡ PERFORMANCE OPTIMIZATION: Use getStructures cache to avoid redundant room.find(FIND_STRUCTURES) calls.
+    const damaged = cache.getStructures(room).filter((s) => {
+        if (s.structureType === STRUCTURE_WALL) {
+            return false;
+        }
+        if (s.structureType === STRUCTURE_RAMPART) {
+            return false;
+        }
+        const threshold = REPAIR_THRESHOLD[s.structureType] || REPAIR_THRESHOLD.OTHER;
+        return s.hits < s.hitsMax * threshold;
+    });
 
-  // 最も損傷率が高い構造物
-  return damaged.reduce((a, b) => {
-    const ra = a.hits / a.hitsMax
-    const rb = b.hits / b.hitsMax
-    return ra < rb ? a : b
-  })
+    if (damaged.length === 0) {
+        return null;
+    }
+
+    // 最も損傷率が高い構造物
+    return damaged.reduce((a, b) => {
+        const ra = a.hits / a.hitsMax;
+        const rb = b.hits / b.hitsMax;
+        return ra < rb ? a : b;
+    });
 }
 
 // ============================================================
@@ -229,19 +253,19 @@ function _selectRepairTarget (tower, room) {
  * @param {StructureTower} tower
  * @param {Creep} target
  */
-function _showAttackVisual (tower, target) {
-  tower.room.visual.line(tower.pos, target.pos, {
-    color: '#ff4444',
-    width: 0.3,
-    opacity: 0.7
-  })
-  tower.room.visual.circle(target.pos, {
-    radius: 0.5,
-    fill: 'transparent',
-    stroke: '#ff4444',
-    strokeWidth: 0.2,
-    opacity: 0.8
-  })
+function _showAttackVisual(tower, target) {
+    tower.room.visual.line(tower.pos, target.pos, {
+        color: '#ff4444',
+        width: 0.3,
+        opacity: 0.7,
+    });
+    tower.room.visual.circle(target.pos, {
+        radius: 0.5,
+        fill: 'transparent',
+        stroke: '#ff4444',
+        strokeWidth: 0.2,
+        opacity: 0.8,
+    });
 }
 
 /**
@@ -249,17 +273,17 @@ function _showAttackVisual (tower, target) {
  * @param {StructureTower} tower
  * @param {Creep} target
  */
-function _showHealVisual (tower, target) {
-  tower.room.visual.line(tower.pos, target.pos, {
-    color: '#00ff88',
-    width: 0.2,
-    opacity: 0.5
-  })
-  tower.room.visual.circle(target.pos, {
-    radius: 0.4,
-    fill: '#00ff88',
-    opacity: 0.2
-  })
+function _showHealVisual(tower, target) {
+    tower.room.visual.line(tower.pos, target.pos, {
+        color: '#00ff88',
+        width: 0.2,
+        opacity: 0.5,
+    });
+    tower.room.visual.circle(target.pos, {
+        radius: 0.4,
+        fill: '#00ff88',
+        opacity: 0.2,
+    });
 }
 
 /**
@@ -267,13 +291,13 @@ function _showHealVisual (tower, target) {
  * @param {StructureTower} tower
  * @param {Structure} target
  */
-function _showRepairVisual (tower, target) {
-  tower.room.visual.line(tower.pos, target.pos, {
-    color: '#ffaa00',
-    width: 0.15,
-    opacity: 0.4,
-    lineStyle: 'dotted'
-  })
+function _showRepairVisual(tower, target) {
+    tower.room.visual.line(tower.pos, target.pos, {
+        color: '#ffaa00',
+        width: 0.15,
+        opacity: 0.4,
+        lineStyle: 'dotted',
+    });
 }
 
 // ============================================================
@@ -286,12 +310,12 @@ function _showRepairVisual (tower, target) {
  * @param {Room} room
  * @returns {StructureTower[]} エネルギー補充が必要なタワー一覧
  */
-function getTowersNeedingEnergy (room) {
-  const towers = cache.getMyStructures(room, STRUCTURE_TOWER)
-  return towers.filter(
-    (t) =>
-      t.store[RESOURCE_ENERGY] / t.store.getCapacity(RESOURCE_ENERGY) < TOWER_ENERGY_PRIORITY
-  )
+function getTowersNeedingEnergy(room) {
+    const towers = cache.getMyStructures(room, STRUCTURE_TOWER);
+    return towers.filter(
+        (t) =>
+            t.store[RESOURCE_ENERGY] / t.store.getCapacity(RESOURCE_ENERGY) < TOWER_ENERGY_PRIORITY
+    );
 }
 
 // ============================================================
@@ -303,49 +327,55 @@ function getTowersNeedingEnergy (room) {
  * @param {Room} room
  * @returns {Object}
  */
-function getStats (room) {
-  const towers = cache.getMyStructures(room, STRUCTURE_TOWER)
-  const stats = {
-    total: towers.length,
-    active: 0,
-    avgEnergy: 0,
-    lowEnergy: 0
-  }
+function getStats(room) {
+    const towers = cache.getMyStructures(room, STRUCTURE_TOWER);
+    const stats = {
+        total: towers.length,
+        active: 0,
+        avgEnergy: 0,
+        lowEnergy: 0,
+    };
 
-  if (towers.length === 0) return stats
+    if (towers.length === 0) {
+        return stats;
+    }
 
-  let totalEnergy = 0
-  for (const tower of towers) {
-    const ratio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY)
-    totalEnergy += ratio
-    if (ratio < TOWER_ENERGY_PRIORITY) stats.lowEnergy++
-    if (tower.store[RESOURCE_ENERGY] > 0) stats.active++
-  }
-  stats.avgEnergy = totalEnergy / towers.length
+    let totalEnergy = 0;
+    for (const tower of towers) {
+        const ratio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY);
+        totalEnergy += ratio;
+        if (ratio < TOWER_ENERGY_PRIORITY) {
+            stats.lowEnergy++;
+        }
+        if (tower.store[RESOURCE_ENERGY] > 0) {
+            stats.active++;
+        }
+    }
+    stats.avgEnergy = totalEnergy / towers.length;
 
-  return stats
+    return stats;
 }
 
 /**
  * タワー統計をルームビジュアルに表示する
  * @param {Room} room
  */
-function showDashboard (room) {
-  const towers = cache.getMyStructures(room, STRUCTURE_TOWER)
-  for (const tower of towers) {
-    const ratio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY)
-    const color = ratio > 0.7 ? '#00ff88' : ratio > 0.4 ? '#ffaa00' : '#ff4444'
-    tower.room.visual.text(`🏰 ${Math.floor(ratio * 100)}%`, tower.pos.x, tower.pos.y - 1, {
-      color,
-      font: 0.4,
-      align: 'center'
-    })
-  }
+function showDashboard(room) {
+    const towers = cache.getMyStructures(room, STRUCTURE_TOWER);
+    for (const tower of towers) {
+        const ratio = tower.store[RESOURCE_ENERGY] / tower.store.getCapacity(RESOURCE_ENERGY);
+        const color = ratio > 0.7 ? '#00ff88' : ratio > 0.4 ? '#ffaa00' : '#ff4444';
+        tower.room.visual.text(`🏰 ${Math.floor(ratio * 100)}%`, tower.pos.x, tower.pos.y - 1, {
+            color,
+            font: 0.4,
+            align: 'center',
+        });
+    }
 }
 
 module.exports = {
-  run,
-  getTowersNeedingEnergy,
-  getStats,
-  showDashboard
-}
+    run,
+    getTowersNeedingEnergy,
+    getStats,
+    showDashboard,
+};

--- a/tests/towerManager.test.js
+++ b/tests/towerManager.test.js
@@ -44,6 +44,8 @@ jest.mock(
     () => ({
         getEnemies: jest.fn(),
         getMyStructures: jest.fn(),
+        getMyCreeps: jest.fn(),
+        getStructures: jest.fn(),
     }),
     { virtual: true }
 );
@@ -73,6 +75,11 @@ describe('towerManager', () => {
             find: jest.fn().mockReturnValue([]),
             controller: { level: 1 },
         };
+
+        cache.getMyCreeps.mockReturnValue([]);
+        cache.getStructures.mockReturnValue([]);
+        cache.getEnemies.mockReturnValue([]);
+        cache.getMyStructures.mockReturnValue([]);
 
         mockTower = {
             id: 'tower1',
@@ -127,11 +134,7 @@ describe('towerManager', () => {
                 hitsMax: 100,
                 pos: { x: 26, y: 26 },
             };
-            mockRoom.find.mockImplementation((type) => {
-                if (type === FIND_MY_CREEPS) return [mockCreep];
-                if (type === FIND_HOSTILE_CREEPS) return [];
-                return [];
-            });
+            cache.getMyCreeps.mockReturnValue([mockCreep]);
             cache.getEnemies.mockReturnValue([]);
             cache.getMyStructures.mockReturnValue([mockTower]);
 
@@ -148,13 +151,8 @@ describe('towerManager', () => {
                 hitsMax: 5000,
                 pos: { x: 26, y: 26 },
             };
-            mockRoom.find.mockImplementation((type) => {
-                if (type === FIND_MY_CREEPS) return [];
-                if (type === FIND_HOSTILE_CREEPS) return [];
-                if (type === FIND_STRUCTURES) return [mockStructure];
-                if (type === FIND_MY_STRUCTURES) return [];
-                return [];
-            });
+            cache.getMyCreeps.mockReturnValue([]);
+            cache.getStructures.mockReturnValue([mockStructure]);
             cache.getEnemies.mockReturnValue([]);
             cache.getMyStructures.mockReturnValue([mockTower]);
             mockTower.store[global.RESOURCE_ENERGY] = 600;


### PR DESCRIPTION
💡 What: Optimized `src/managers/towerManager.js` by replacing expensive Screeps engine-level `room.find` calls with centralized cached alternatives from `src/utils/cache.js`.

🎯 Why: Every `room.find` call in Screeps involves an expensive bridge crossing between the JavaScript VM and the underlying C++ engine. The `towerManager` was performing these searches for every tower in the room every tick, leading to significant CPU overhead, especially in rooms with many structures and towers.

📊 Impact: 
- Reduces expensive engine-level API calls by $1 + N$ per room per tick (where $N$ is the number of towers).
- Replaces backend O(N) searches with O(1) cache lookups followed by native JS array filtering.
- Estimated CPU saving: 0.1 - 0.5 CPU per room depending on structural complexity and tower count.

🔬 Measurement: Verified that the logic remains correct via `tests/towerManager.test.js`. Performance gains are inherent to the Screeps engine architecture when avoiding `room.find`.

🧹 Other changes: 
- Updated `tests/towerManager.test.js` to mock the new cache methods.
- Applied `prettier` to `src/managers/towerManager.js` to ensure clean indentation and consistent style.
- Updated `.jules/bolt.md` with critical learnings.

---
*PR created automatically by Jules for task [5498556415405645470](https://jules.google.com/task/5498556415405645470) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `towerManager` by replacing `room.find` with cached lookups (`cache.getMyCreeps`, `cache.getStructures`), reducing engine calls and lowering CPU per tick. Expect ~0.1–0.5 CPU saved per room depending on tower count and structure density.

- **Refactors**
  - Switched to `cache.getMyCreeps(room)` and `cache.getStructures(room)` (JS filtering in `_selectRepairTarget`) to avoid `room.find`.
  - Continued using `cache.getEnemies(room)` to prevent redundant lookups.
  - Updated `tests/towerManager.test.js` to mock new cache methods.
  - Formatted `src/managers/towerManager.js` with Prettier and added notes to `.jules/bolt.md`.

<sup>Written for commit cdf034ead5e7225ee934dd7c8209b1b14644ce3b. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/457?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

