### PR TITLE
🎨 Palette: Add GCL progress forecast to dashboard

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -726,6 +726,10 @@ export default function Dashboard() {
 
             {stats?.gcl && (() => {
                 const xpPerHour = getXpPerHour();
+                const predictedPercent =
+                    xpPerHour && stats.gcl.progressTotal
+                        ? (xpPerHour / stats.gcl.progressTotal) * 100
+                        : 0;
                 const timeToLevel = getTimeToLevel();
                 const formattedXpPerHour = xpPerHour
                     ? xpPerHour >= 1000000000
@@ -912,8 +916,8 @@ export default function Dashboard() {
                         aria-valuenow={Number(gclPercent.toFixed(2))}
                         aria-valuemin={0}
                         aria-valuemax={100}
-                        aria-valuetext={`${gclPercent.toFixed(2)}% complete, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
-                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
+                        aria-valuetext={`${gclPercent.toFixed(2)}% complete${predictedPercent > 0 ? ` (+${predictedPercent.toFixed(2)}% forecast/h)` : ''}, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
+                        title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}${predictedPercent > 0 ? `\nForecast: +${predictedPercent.toFixed(2)}% in 1h` : ''}`}
                         style={{
                             width: '100%',
                             height: '12px',
@@ -953,8 +957,29 @@ export default function Dashboard() {
                                         ? '#FFD700'
                                         : '#006699',
                                 transition: 'width 0.5s ease-in-out',
+                                position: 'relative',
+                                zIndex: 2,
                             }}
                         />
+                        {predictedPercent > 0 && stats.gcl.progress < stats.gcl.progressTotal && (
+                            <div
+                                title={`Forecast: +${predictedPercent.toFixed(2)}% in 1h`}
+                                style={{
+                                    left: `${gclPercent}%`,
+                                    width: `${Math.min(predictedPercent, 100 - gclPercent)}%`,
+                                    height: '100%',
+                                    position: 'absolute',
+                                    background:
+                                        stats.gcl.progress >= stats.gcl.progressTotal
+                                            ? '#FFD700'
+                                            : '#006699',
+                                    opacity: 0.3,
+                                    animation: 'pulse 2s infinite',
+                                    zIndex: 1,
+                                    transition: 'all 0.5s ease-in-out',
+                                }}
+                            />
+                        )}
                     </div>
                     <div style={{ fontSize: '0.75rem', color: '#575757', textAlign: 'right' }}>
                         {stats.gcl.progress.toLocaleString()} /{' '}


### PR DESCRIPTION
Add a pulsing "forecast" bar to the GCL progress indicator in the dashboard to visualize projected progress for the next hour. This improvement includes updated ARIA attributes and tooltips for better accessibility.

---
*PR created automatically by Jules for task [10896439754704483824](https://jules.google.com/task/10896439754704483824) started by @tadanobutubutu*

## Summary by Sourcery

Add a forecast view to the GCL progress indicator on the dashboard, including accessibility and tooltip updates to surface projected progress.

New Features:
- Visualize forecasted GCL progress for the next hour as an overlaid bar on the existing progress indicator.

Enhancements:
- Expose hourly GCL progress forecasts in ARIA labels and tooltips to improve accessibility and clarity of the progress indicator.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pulsing forecast overlay to the GCL progress bar on the dashboard to show projected gain in the next hour. Improves accessibility with ARIA and tooltip updates that include the forecast.

- **New Features**
  - Adds a semi-transparent, pulsing overlay ahead of current GCL progress to visualize next-hour forecast.
  - Updates ARIA valuetext and tooltips to include forecast percent alongside remaining XP and time estimates.

<sup>Written for commit 021c3f04c55e9b106351d0f43026eb42c1b94e9f. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

