### PR TITLE
🛡️ Sentinel: Fix malicious level string test in history

### DIFF
--- a/tests/sentinel_console_injection.test.js
+++ b/tests/sentinel_console_injection.test.js
@@ -59,35 +59,24 @@ describe('Sentinel: logger console injection hardening', () => {
     });
 
     test('showDashboard() should escape HTML in log levels from history', () => {
-        // We can't easily log with a custom level via public API without it being checked,
-        // but we can assume history might be tampered with or have weird data.
-        // However, the internal _record function is what adds to history.
-        // Let's test if our fix handles malicious level strings in history.
+        const maliciousLevel = '<script>alert("level")</script>';
 
-        // We can't directly access _history, but we can call a log method with a weird level
-        // if we use the generic log method.
-        const maliciousLevel = 'info] <img src=x onerror=alert(2)> [';
-        const message = 'test message';
+        // Populate history with a standard log
+        logger.info('test message');
 
-        logger.log = undefined; // Ensure we are using the one from the module if we had mocked it
+        // Mutate the history entry to contain a malicious level string
+        const history = logger.getHistory(1);
+        expect(history.length).toBe(1);
+        history[0].level = maliciousLevel;
 
-        // Re-require to get original module if needed, but here we just use what we have.
-        // src/utils/logger.js has debug, info, warn, error, success.
-        // They all call _record and then console.log.
-
-        // Let's use a "standard" way to get a weird level if possible.
-        // Actually, the log levels are restricted by the switch/if in those functions.
-        // But showDashboard uses entry.level from history.
-
-        // If I log an error with a custom object as "error", maybe? No.
-
-        // Let's just trust that if we escape entry.level, we are safe.
-        // To verify it, we can use a test that logs a "normal" level and check if it's still there.
-
-        logger.info('test');
         jest.clearAllMocks();
         logger.showDashboard();
-        const call = console.log.mock.calls.find((args) => args[0].includes('[T:100][info]'));
+
+        const call = console.log.mock.calls.find((args) =>
+            args[0].includes('&lt;script&gt;alert(&quot;level&quot;)&lt;/script&gt;')
+        );
+
         expect(call).toBeDefined();
+        expect(call[0]).not.toContain(maliciousLevel);
     });
 });


### PR DESCRIPTION
This pull request replaces an unverified exploratory comment block in the test suite with a concrete implementation that explicitly injects malicious payloads into the logger history to assert that `logger.showDashboard()` robustly escapes HTML. This fulfills the requirement to verify handling of tampered level strings within internal states.

---
*PR created automatically by Jules for task [2840412158173759827](https://jules.google.com/task/2840412158173759827) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the placeholder test with a concrete test that injects a malicious HTML level into logger history and verifies `logger.showDashboard()` escapes it. Improves regression coverage for console injection via tampered level strings.

<sup>Written for commit de2c18c58b37bfe3ddca5ae4b8ae367137b856a5. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/460?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced security test coverage for dashboard output to ensure proper escaping of potentially malicious content in display rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->