### PR TITLE
🧹 Code Health: Remove commented-out code in security.dos.test.js

### DIFF
--- a/tests/security.dos.test.js
+++ b/tests/security.dos.test.js
@@ -132,9 +132,6 @@ describe('Security: DoS Protections', () => {
             // This should not crash and should ideally skip 'constructor' if we add the protection
             const result = memVis.showTopMemoryUsers();
 
-            // Currently, it will include 'constructor' if it's enumerable.
-            // If it's NOT enumerable, for-in might still pick it up in some environments or
-            // if it's explicitly added to the object.
             const constructorEntry = result.find((item) => item.name === 'constructor');
             expect(constructorEntry).toBeUndefined();
         });


### PR DESCRIPTION
🎯 **What:** Removed a block of commented-out text in `tests/security.dos.test.js` that was flagged by automated tools.
💡 **Why:** Improves codebase cleanliness and resolves automated code health warnings regarding commented-out code.
✅ **Verification:** Ran `npx jest --reporters default -- tests/security.dos.test.js` to ensure tests still pass.
✨ **Result:** Cleaner test file without false-positive linting warnings.

---
*PR created automatically by Jules for task [12467518045037360599](https://jules.google.com/task/12467518045037360599) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed commented-out lines from `tests/security.dos.test.js` to clean up the test file and clear lint warnings. No behavior changes; tests pass (verified with `npx jest --reporters default -- tests/security.dos.test.js`).

<sup>Written for commit 6dfc48c12a176bc1eb2d0d4469f4a81d942cb8a1. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/461?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

