### PR TITLE
🧹 Code Health: Remove commented-out code and dead variables in test file

### DIFF
--- a/tests/sentinel_console_injection.test.js
+++ b/tests/sentinel_console_injection.test.js
@@ -59,31 +59,6 @@ describe('Sentinel: logger console injection hardening', () => {
     });
 
     test('showDashboard() should escape HTML in log levels from history', () => {
-        // We can't easily log with a custom level via public API without it being checked,
-        // but we can assume history might be tampered with or have weird data.
-        // However, the internal _record function is what adds to history.
-        // Let's test if our fix handles malicious level strings in history.
-
-        // We can't directly access _history, but we can call a log method with a weird level
-        // if we use the generic log method.
-        const maliciousLevel = 'info] <img src=x onerror=alert(2)> [';
-        const message = 'test message';
-
-        logger.log = undefined; // Ensure we are using the one from the module if we had mocked it
-
-        // Re-require to get original module if needed, but here we just use what we have.
-        // src/utils/logger.js has debug, info, warn, error, success.
-        // They all call _record and then console.log.
-
-        // Let's use a "standard" way to get a weird level if possible.
-        // Actually, the log levels are restricted by the switch/if in those functions.
-        // But showDashboard uses entry.level from history.
-
-        // If I log an error with a custom object as "error", maybe? No.
-
-        // Let's just trust that if we escape entry.level, we are safe.
-        // To verify it, we can use a test that logs a "normal" level and check if it's still there.
-
         logger.info('test');
         jest.clearAllMocks();
         logger.showDashboard();

--- a/tests/sentinel_console_injection.test.js
+++ b/tests/sentinel_console_injection.test.js
@@ -4,65 +4,65 @@
  */
 
 // グローバル設定
-global.Game = { time: 100 };
-global.Memory = { logs: [] };
+global.Game = { time: 100 }
+global.Memory = { logs: [] }
 
 jest.mock(
-    '../src/constants',
-    () => ({
-        LOG_LEVEL: {
-            DEBUG: 0,
-            INFO: 1,
-            WARN: 2,
-            ERROR: 3,
-            NONE: 4,
-        },
-        DEFAULT_LOG_LEVEL: 1,
-    }),
-    { virtual: true }
-);
+  '../src/constants',
+  () => ({
+    LOG_LEVEL: {
+      DEBUG: 0,
+      INFO: 1,
+      WARN: 2,
+      ERROR: 3,
+      NONE: 4
+    },
+    DEFAULT_LOG_LEVEL: 1
+  }),
+  { virtual: true }
+)
 
-const logger = require('../src/utils/logger');
+const logger = require('../src/utils/logger')
 
 describe('Sentinel: logger console injection hardening', () => {
-    beforeEach(() => {
-        global.Memory = { logs: [] };
-        global.Game.time = 100;
-        console.log = jest.fn();
-        logger.setLevel(0);
-        logger.clear();
-        // Reset private history by calling clear
-        logger.resetStats();
-    });
+  beforeEach(() => {
+    global.Memory = { logs: [] }
+    global.Game.time = 100
+    console.log = jest.fn()
+    logger.setLevel(0)
+    logger.clear()
+    // Reset private history by calling clear
+    logger.resetStats()
+  })
 
-    test('success() should escape HTML in log messages', () => {
-        const maliciousMessage = '<img src=x onerror=alert(1)>';
-        logger.success(maliciousMessage);
+  test('success() should escape HTML in log messages', () => {
+    const maliciousMessage = '<img src=x onerror=alert(1)>'
+    logger.success(maliciousMessage)
 
-        expect(console.log).toHaveBeenCalledWith(expect.stringContaining('&lt;img'));
-        expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(maliciousMessage));
-    });
+    expect(console.log).toHaveBeenCalledWith(expect.stringContaining('&lt;img'))
+    expect(console.log).not.toHaveBeenCalledWith(expect.stringContaining(maliciousMessage))
+  })
 
-    test('showDashboard() should escape HTML in log messages from history', () => {
-        const maliciousMessage = '<script>alert("message")</script>';
-        logger.info(maliciousMessage);
+  test('showDashboard() should escape HTML in log messages from history', () => {
+    const maliciousMessage = '<script>alert("message")</script>'
+    logger.info(maliciousMessage)
 
-        // Clear console.log calls from logger.info
-        jest.clearAllMocks();
+    // Clear console.log calls from logger.info
+    jest.clearAllMocks()
 
-        logger.showDashboard();
+    logger.showDashboard()
 
-        const call = console.log.mock.calls.find((args) => args[0].includes('[T:100][info]'));
-        expect(call).toBeDefined();
-        expect(call[0]).not.toContain(maliciousMessage);
-        expect(call[0]).toContain('&lt;script&gt;');
-    });
+    const call = console.log.mock.calls.find((args) => args[0].includes('[T:100][info]'))
+    expect(call).toBeDefined()
+    expect(call[0]).not.toContain(maliciousMessage)
+    expect(call[0]).toContain('&lt;script&gt;')
+  })
 
-    test('showDashboard() should escape HTML in log levels from history', () => {
-        logger.info('test');
-        jest.clearAllMocks();
-        logger.showDashboard();
-        const call = console.log.mock.calls.find((args) => args[0].includes('[T:100][info]'));
-        expect(call).toBeDefined();
-    });
-});
+  test('showDashboard() should escape HTML in log levels from history', () => {
+    logger.info('test')
+    jest.clearAllMocks()
+    logger.showDashboard()
+    const call = console.log.mock.calls.find((args) => args[0].includes('[T:100][info]'))
+    expect(call).toBeDefined()
+  })
+})


### PR DESCRIPTION
🎯 **What:** Removed a large block of commented-out code and dead variables (`maliciousLevel`, `message`) in `tests/sentinel_console_injection.test.js`.
💡 **Why:** This improves the maintainability and readability of the codebase by eliminating unnecessary noise and abandoned thought processes.
✅ **Verification:** Ran the test suite using `npx jest --reporters default -- tests/sentinel_console_injection.test.js` to ensure the original test logic is preserved and still passes.
✨ **Result:** A much cleaner, more readable test file.

---
*PR created automatically by Jules for task [3947422203928295327](https://jules.google.com/task/3947422203928295327) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed commented-out code and unused variables (`maliciousLevel`, `message`) and formatted `tests/sentinel_console_injection.test.js` to match project style. No test logic changed; tests still pass.

<sup>Written for commit 163ee7f559bd4f0ec7227080fd5fd9f3988be326. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for logger console injection hardening to verify proper HTML escaping in console output and dashboard display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->