### PR TITLE
🧪 [Add error test for task failures]

### DIFF
--- a/tests/utils.tasks.test.js
+++ b/tests/utils.tasks.test.js
@@ -149,4 +149,26 @@ describe('utils.tasks', () => {
         TaskQueue.run();
         expect(errorAction).toHaveBeenCalledTimes(1);
     });
+
+    test('runがタスク失敗時にfailuresカウントをインクリメントする', () => {
+        const errorAction = () => {
+            throw new Error('Failure Increment Test');
+        };
+        TaskQueue.registerTask('failTask', 1, errorAction);
+
+        const task = TaskQueue.tasks.find((t) => t.name === 'failTask');
+
+        // Initial failures should be 0 (as initialized in registerTask)
+        expect(task.failures).toBe(0);
+
+        TaskQueue.run();
+
+        // After 1 run with error, failures should be 1
+        expect(task.failures).toBe(1);
+
+        TaskQueue.run();
+
+        // After 2 runs with error, failures should be 2
+        expect(task.failures).toBe(2);
+    });
 });


### PR DESCRIPTION
🎯 **What:** Adds missing test for task error failure count incrementation in `tests/utils.tasks.test.js`
📊 **Coverage:** The `catch (e)` block in `TaskQueue.run()` is now fully covered, including the failures incrementation logic.
✨ **Result:** Test coverage for the task queue reliability is improved.

---
*PR created automatically by Jules for task [38793277889529971](https://jules.google.com/task/38793277889529971) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test that verifies `TaskQueue.run()` increments a task’s `failures` count when the task throws, fully covering the error path.
Improves task queue reliability coverage.

<sup>Written for commit 57915f3a7282ba8706aa6847b6cfd186d3985ccb. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/468?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

