### PR TITLE
Fix Game.map.describeExits() null return issue

### DIFF
--- a/role.scout.js
+++ b/role.scout.js
@@ -2,6 +2,7 @@
  * Security: Limits for memory-intensive structures to prevent Memory DoS.
  * Screeps memory is limited to 2MB; unbounded objects can crash the AI.
  */
+/* global ERR_NO_PATH, ERR_INVALID_ARGS, FIND_DROPPED_RESOURCES */
 const MAX_VISITED_ROOMS = 100;
 
 // ⚡ PERFORMANCE: Hoisted constant path styles to reduce per-tick object allocation.
@@ -10,7 +11,7 @@ const PATH_STYLE_SCOUT = { visualizePathStyle: { stroke: '#ffffff', opacity: 0.2
 const roleScout = {
     run: function (creep) {
         if (!creep.memory.targetRoom) {
-            // Fix: Game.map.describeExits() can return null
+            // Note: Game.map.describeExits() can return null
             const exits = Game.map.describeExits(creep.room.name);
 
             if (exits && Object.keys(exits).length > 0) {


### PR DESCRIPTION
Resolves the task to handle the case where Game.map.describeExits() might return null in role.scout.js. The code already correctly handled this, so the task was completed by updating the comment and fixing ESLint errors.

---
*PR created automatically by Jules for task [2299361559303154410](https://jules.google.com/task/2299361559303154410) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that Game.map.describeExits() can return null in role.scout and adds ESLint global definitions. No functional changes.

<sup>Written for commit 5fe5691af8fa1ee915d4df76d576eb1662a90d65. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/469?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

