### PR TITLE
🛡️ Sentinel: Harden logger utility against crashes and bypasses

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -128,6 +128,13 @@ function _createCircularReplacer() {
 function _safeStringify(obj, maxLength = 500) {
     try {
         const str = JSON.stringify(obj, _createCircularReplacer());
+        // Security: JSON.stringify returns undefined for functions or undefined,
+        // so we must handle it to avoid "Cannot read properties of undefined (reading 'substring')"
+        // セキュリティ：JSON.stringifyは関数やundefinedに対してundefinedを返すため、
+        // .substring()の呼び出しでエラーが発生しないよう制御する必要があります。
+        if (str === undefined) {
+            return 'undefined';
+        }
         return str.substring(0, maxLength);
     } catch (e) {
         return '[Unstringifiable Object]';
@@ -143,7 +150,16 @@ function _safeStringify(obj, maxLength = 500) {
  * @param {number} level - LOG_LEVEL 定数のいずれか
  */
 function setLevel(level) {
-    _level = level;
+    // Security: Validate level to prevent bypassing checks with invalid types (e.g., undefined)
+    // セキュリティ：無効な型（undefinedなど）によってチェックがバイパスされるのを防ぐため、レベルを検証します。
+    const numericLevel = Number(level);
+    const validLevels = Object.values(LOG_LEVEL);
+    if (Number.isInteger(numericLevel) && validLevels.includes(numericLevel)) {
+        _level = numericLevel;
+    } else {
+        // Fallback to INFO on invalid input
+        _level = LOG_LEVEL.INFO;
+    }
 }
 
 /**

--- a/tests/security_logger_robustness.test.js
+++ b/tests/security_logger_robustness.test.js
@@ -1,0 +1,41 @@
+/**
+ * tests/security_logger_robustness.test.js
+ * Hardening tests for src/utils/logger.js
+ */
+
+const logger = require('../src/utils/logger');
+
+describe('src/utils/logger robustness', () => {
+    beforeEach(() => {
+        global.Game = { time: 100 };
+        global.Memory = {};
+        // Mock console.log to avoid cluttering test output
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        logger.setLevel(logger.LOG_LEVEL.INFO);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('_safeStringify should not throw on functions', () => {
+        // This previously threw because JSON.stringify returns undefined
+        expect(() => logger.info('test', () => {})).not.toThrow();
+    });
+
+    test('setLevel should not allow invalid levels that bypass checks', () => {
+        // Set level to undefined
+        logger.setLevel(undefined);
+
+        // Should fallback to INFO (1)
+        expect(logger.getLevel()).toBe(logger.LOG_LEVEL.INFO);
+
+        // Set to string that can be parsed as number
+        logger.setLevel("2");
+        expect(logger.getLevel()).toBe(logger.LOG_LEVEL.WARN);
+
+        // Set to invalid number
+        logger.setLevel(99);
+        expect(logger.getLevel()).toBe(logger.LOG_LEVEL.INFO);
+    });
+});


### PR DESCRIPTION
### 🛡️ Sentinel: Security Improvement

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Potential runtime crash (DoS) and log level bypass.
🎯 **Impact:** 
1. If a developer accidentally attempts to log a function or `undefined` as a data object, the entire AI script would crash with a `TypeError: Cannot read properties of undefined (reading 'substring')`. In Screeps, this halts the entire bot's execution for the tick.
2. If `setLevel` is called with an invalid type (like `undefined`), subsequent log level checks (e.g., `_level > LOG_LEVEL.INFO`) would evaluate to `false` because `undefined > 1` is false, potentially causing sensitive logs to be emitted when they should be suppressed, or vice versa.

🔧 **Fix:**
- Added a guard in `_safeStringify` to handle cases where `JSON.stringify` returns `undefined`.
- Implemented strict validation in `setLevel` to ensure the log level is a valid integer from the `LOG_LEVEL` map, with a fallback to `INFO`.
- Added localized Japanese comments as per `AGENTS.md` guidelines.

✅ **Verification:**
- New test suite `tests/security_logger_robustness.test.js` passed.
- Full project test suite (68 suites) passed.
- Code review performed and approved (#Correct#).

---
*PR created automatically by Jules for task [12924859607580097594](https://jules.google.com/task/12924859607580097594) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the logger to prevent crashes when logging functions/undefined and to block log level bypass via invalid inputs. This keeps the bot stable and ensures log filtering works correctly.

- **Bug Fixes**
  - `_safeStringify`: handle `undefined` result from `JSON.stringify` and avoid `.substring` errors.
  - `setLevel`: validate against `LOG_LEVEL`, coerce numeric strings, and fallback to `INFO` on invalid input.
  - Added `tests/security_logger_robustness.test.js` covering both cases.

<sup>Written for commit 1709477c91776f7d104cf54e2669d9dcf73057f2. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

