### PR TITLE
🛡️ Sentinel: [security improvement] Implement FIFO eviction in utils.memory memoize

### DIFF
--- a/tests/security.aggregation.test.js
+++ b/tests/security.aggregation.test.js
@@ -33,6 +33,8 @@ describe('Security: Aggregation Hardening', () => {
         global.TOUGH = 'tough';
         global.RESOURCE_ENERGY = 'energy';
         global.STRUCTURE_TOWER = 'tower';
+        global.FIND_MY_CREEPS = 6;
+        global.FIND_MY_SPAWNS = 7;
 
         jest.resetModules();
     });

--- a/tests/spawnManager.test.js
+++ b/tests/spawnManager.test.js
@@ -100,6 +100,8 @@ describe('spawnManager', () => {
     global.FIND_CONSTRUCTION_SITES = 111
     global.FIND_MY_SPAWNS = 112
     global.FIND_SOURCES = 105
+    global.FIND_HOSTILE_CREEPS = 103
+    global.FIND_MY_CREEPS = 102
   })
   let mockSpawn
   let mockRoom

--- a/tests/src.roles.behavior.test.js
+++ b/tests/src.roles.behavior.test.js
@@ -42,6 +42,12 @@ global.RoomPosition = function (x, y, roomName) {
     this.getRangeTo = () => 0;
 };
 
+global.FIND_SOURCES = 105;
+global.FIND_HOSTILE_CREEPS = 103;
+global.FIND_MY_CREEPS = 102;
+global.FIND_MY_SPAWNS = 101;
+global.LOG_LEVEL = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 };
+
 jest.mock(
     '../src/utils/cache',
     () => ({

--- a/tests/src.roles.defender.test.js
+++ b/tests/src.roles.defender.test.js
@@ -62,8 +62,11 @@ const defender = require('../src/roles/defender');
 
 describe('src/roles/defender', () => {
     beforeEach(() => {
-        global.LOG_LEVEL = { ERROR: 3 };
+        global.LOG_LEVEL = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3 };
         global.FIND_HOSTILE_CREEPS = 103;
+        global.ATTACK = 'attack';
+        global.RANGED_ATTACK = 'ranged_attack';
+        global.CLAIM = 'claim';
     });
     beforeEach(() => {
         jest.clearAllMocks();

--- a/tests/utils.memory.test.js
+++ b/tests/utils.memory.test.js
@@ -108,7 +108,7 @@ describe('utils.memory', () => {
         expect(callCount).toBe(1);
     });
 
-    test('memoize enforces MAX_CACHE_ENTRIES', () => {
+    test('memoize enforces MAX_CACHE_ENTRIES with FIFO eviction', () => {
         let callCount = 0;
         const fn = () => {
             callCount++;
@@ -120,12 +120,17 @@ describe('utils.memory', () => {
             utilsMemory.memoize(fn, 'key' + i, 100);
         }
         expect(callCount).toBe(50);
+        expect(Memory.cache['key0']).toBeDefined();
 
         // Add one more entry
         const result = utilsMemory.memoize(fn, 'oneMoreKey', 100);
         expect(result).toBe('result');
         expect(callCount).toBe(51);
-        expect(Memory.cache['oneMoreKey']).toBeUndefined();
+
+        // Security: Verify FIFO eviction (key0 should be gone, oneMoreKey should be present)
+        expect(Memory.cache['oneMoreKey']).toBeDefined();
+        expect(Memory.cache['key0']).toBeUndefined();
+        expect(Object.keys(Memory.cache).length).toBe(50);
     });
 
     test('memoize uses default TTL', () => {

--- a/utils.memory.js
+++ b/utils.memory.js
@@ -135,7 +135,17 @@ module.exports = {
 
         // Security: Cap the number of cache entries to prevent Memory DoS
         if (!cached && Object.keys(Memory.cache).length >= MAX_CACHE_ENTRIES) {
-            return fn();
+            // Attempt to cleanup expired entries first
+            this.cleanCache();
+
+            // If still full, implement FIFO eviction by deleting the oldest entry.
+            // This ensures the cache remains available for new, potentially more relevant data.
+            if (Object.keys(Memory.cache).length >= MAX_CACHE_ENTRIES) {
+                const keys = Object.keys(Memory.cache);
+                if (keys.length > 0) {
+                    delete Memory.cache[keys[0]];
+                }
+            }
         }
 
         const result = fn();


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Cache Starvation and CPU Exhaustion DoS in `utils.memory.js`.
🎯 **Impact:** When the memoization cache reaches its limit (50 entries), it enters a permanent state of cache misses for any new operations. In the resource-constrained Screeps environment, this results in repeated expensive re-computations every tick, potentially leading to CPU exhaustion.
🔧 **Fix:** Refactored the `memoize` function to first attempt a proactive `cleanCache()` when full. If the cache remains at capacity, it now implements a FIFO eviction policy by deleting the oldest entry before inserting the new one.
✅ **Verification:** Updated `tests/utils.memory.test.js` to explicitly verify FIFO eviction. Successfully ran the full test suite (69 suites, 649 tests) with 100% pass rate. Required minor "infrastructure" fixes to several test files to provide missing global constants (e.g., `FIND_MY_CREEPS`) used by the logging and caching systems.

---
*PR created automatically by Jules for task [17035310511005442316](https://jules.google.com/task/17035310511005442316) started by @tadanobutubutu*

## Summary by Sourcery

Implement FIFO eviction in the memory memoization cache to prevent cache starvation and ensure continued caching under capacity limits.

Bug Fixes:
- Ensure the memoization cache evicts the oldest entry when full so new values can still be cached instead of falling back to permanent cache misses.

Enhancements:
- Improve memoization cache maintenance by proactively cleaning expired entries before performing FIFO eviction when at capacity.
- Standardize and extend global Screeps constants in test setups to support logging and caching behaviors.

Tests:
- Extend utils.memory memoization tests to verify FIFO eviction behavior and cache size enforcement.
- Update multiple role, security, and spawn manager tests to define required global constants and keep the test suite passing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds FIFO eviction and proactive cleanup to `utils.memory`’s `memoize` so the cache stays usable at capacity and avoids CPU spikes from repeated recomputes. Updates tests to assert eviction behavior and adds missing Screeps globals used by the suites.

- **Bug Fixes**
  - On insert when full, run `cleanCache()`; if still full, evict the oldest entry (FIFO).
  - Keeps the cache capped at 50 entries while allowing new keys to be cached.

- **Tests**
  - Adds FIFO eviction and size-invariant checks in `tests/utils.memory.test.js`.
  - Defines required Screeps globals in several test files to stabilize runs.

<sup>Written for commit a8b38302b27b72d3592adaafac54db3432ac8b4b. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

