### PR TITLE
⚡ Bolt: Optimize assignSource with room-local creep iteration

### DIFF
--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -387,11 +387,12 @@ function assignSource(creep, room) {
         return null;
     }
 
-    // 各ソースに割り当てられているクリープ数をカウント
+    // ⚡ PERFORMANCE: Use room-local cache to avoid O(GlobalCreeps) iteration.
     const assignments = {};
-    for (const name in Game.creeps) {
-        const c = Game.creeps[name];
-        if (c.memory.sourceId && c.room.name === room.name) {
+    const creeps = getMyCreeps(room);
+    for (let i = 0; i < creeps.length; i++) {
+        const c = creeps[i];
+        if (c.memory.sourceId) {
             assignments[c.memory.sourceId] = (assignments[c.memory.sourceId] || 0) + 1;
         }
     }

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -11,6 +11,7 @@ global.FIND_CONSTRUCTION_SITES = 14;
 global.FIND_HOSTILE_CREEPS = 6;
 global.FIND_DROPPED_RESOURCES = 7;
 global.FIND_MY_SPAWNS = 8;
+global.FIND_MY_CREEPS = 102;
 global.STRUCTURE_SPAWN = 'spawn';
 global.STRUCTURE_EXTENSION = 'extension';
 global.STRUCTURE_TOWER = 'tower';
@@ -266,7 +267,11 @@ describe('cache', () => {
             };
             const mockRoom = {
                 name: 'W1N1',
-                find: jest.fn().mockReturnValue([{ id: 'source1' }]),
+                find: jest.fn().mockImplementation((type) => {
+                    if (type === FIND_SOURCES) return [{ id: 'source1' }];
+                    if (type === FIND_MY_CREEPS) return [];
+                    return [];
+                }),
             };
 
             const source = cache.assignSource(mockCreep, mockRoom);


### PR DESCRIPTION
### 💡 What
Optimized the `assignSource` function in `src/utils/cache.js` to use room-local creep data instead of global `Game.creeps` iteration.

### 🎯 Why
The previous implementation iterated over all creeps in the entire game (`Game.creeps`) for every call to `assignSource`, even when only creeps in a specific room were relevant. This led to $O(\text{GlobalCreeps})$ complexity per room, which doesn't scale well. By leveraging `getMyCreeps(room)`, the complexity is reduced to $O(\text{RoomCreeps})$.

### 📊 Impact
*   **Performance:** Significant CPU reduction in multi-room environments with high total creep counts.
*   **Scalability:** Ensures that source assignment remains efficient regardless of the total population size.

### 🔬 Measurement
*   Updated `tests/cache.test.js` to verify the new implementation.
*   Confirmed no regressions in `tests/src.roles.miner.test.js` and `tests/roomManager.test.js`.
*   Code reviewed and verified for correctness.

---
*PR created automatically by Jules for task [159731642417175146](https://jules.google.com/task/159731642417175146) started by @tadanobutubutu*

## Summary by Sourcery

Optimize source assignment to use room-local creep queries and update tests accordingly.

Enhancements:
- Use room-scoped creep retrieval in assignSource to reduce iteration overhead for source assignment.

Tests:
- Extend cache.assignSource tests to cover interactions with room-local creep queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized `assignSource` to iterate only room-local creeps via `getMyCreeps(room)` instead of global `Game.creeps`, reducing CPU in multi-room environments. Updated tests to validate the change.

<sup>Written for commit 3d5c6296bd300077e19fc49de2765f5ad1be8b52. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

