### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden logger initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,23 +1,19 @@
 ## 2026-05-16 - FIFO Cache Eviction
-
 **Vulnerability:** Cache Exhaustion DoS.
 **Learning:** Bypassing cache when full protects memory but can overwhelm the underlying data source (resource exhaustion) because all subsequent requests result in expensive 'fetcher' calls.
 **Prevention:** Implement FIFO eviction to maintain cache availability under load while respecting memory limits, ensuring new data can always be cached.
 
 ## 2026-05-17 - Partial Path Match Bypass
-
 **Vulnerability:** Path Traversal (Partial Match).
 **Learning:** Using `startsWith(baseDir)` for path validation can be bypassed if the base directory name is a prefix of a malicious sibling directory (e.g., `/app` matching `/app_danger`).
 **Prevention:** Ensure the base directory path ends with a path separator (e.g., `path.sep`) before performing the `startsWith` check to enforce strict directory boundary validation.
 
 ## 2026-05-18 - Pathfinder Cache Starvation DoS
-
 **Vulnerability:** Cache Starvation and CPU Exhaustion DoS.
 **Learning:** If a cache simply stops accepting new entries when full, it can enter a permanent state of cache misses for any new operations. In a resource-constrained environment like Screeps, this leads to repeated expensive re-computations (CPU exhaustion).
 **Prevention:** Implement a unified eviction policy (like FIFO) across all caching modules. Always attempt to cleanup expired entries before evicting. Ensure cache retrieval is robust against corrupted or non-numeric expiration values.
 
 ## 2026-05-23 - Log Level Bypass via Memory
-
 **Vulnerability:** Log Level Bypass (Missing Input Validation).
 **Learning:** Persistent state stored in `Memory` can be tampered with or become malformed. Direct assignment from `Memory` to internal configuration variables without validation can bypass security controls (e.g., log level gating).
 **Prevention:** Always validate values read from `Memory` before using them to set internal state. Use dedicated setter functions with type and boundary checks.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,19 +1,23 @@
 ## 2026-05-16 - FIFO Cache Eviction
+
 **Vulnerability:** Cache Exhaustion DoS.
 **Learning:** Bypassing cache when full protects memory but can overwhelm the underlying data source (resource exhaustion) because all subsequent requests result in expensive 'fetcher' calls.
 **Prevention:** Implement FIFO eviction to maintain cache availability under load while respecting memory limits, ensuring new data can always be cached.
 
 ## 2026-05-17 - Partial Path Match Bypass
+
 **Vulnerability:** Path Traversal (Partial Match).
 **Learning:** Using `startsWith(baseDir)` for path validation can be bypassed if the base directory name is a prefix of a malicious sibling directory (e.g., `/app` matching `/app_danger`).
 **Prevention:** Ensure the base directory path ends with a path separator (e.g., `path.sep`) before performing the `startsWith` check to enforce strict directory boundary validation.
 
 ## 2026-05-18 - Pathfinder Cache Starvation DoS
+
 **Vulnerability:** Cache Starvation and CPU Exhaustion DoS.
 **Learning:** If a cache simply stops accepting new entries when full, it can enter a permanent state of cache misses for any new operations. In a resource-constrained environment like Screeps, this leads to repeated expensive re-computations (CPU exhaustion).
 **Prevention:** Implement a unified eviction policy (like FIFO) across all caching modules. Always attempt to cleanup expired entries before evicting. Ensure cache retrieval is robust against corrupted or non-numeric expiration values.
 
 ## 2026-05-23 - Log Level Bypass via Memory
+
 **Vulnerability:** Log Level Bypass (Missing Input Validation).
 **Learning:** Persistent state stored in `Memory` can be tampered with or become malformed. Direct assignment from `Memory` to internal configuration variables without validation can bypass security controls (e.g., log level gating).
 **Prevention:** Always validate values read from `Memory` before using them to set internal state. Use dedicated setter functions with type and boundary checks.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** Cache Starvation and CPU Exhaustion DoS.
 **Learning:** If a cache simply stops accepting new entries when full, it can enter a permanent state of cache misses for any new operations. In a resource-constrained environment like Screeps, this leads to repeated expensive re-computations (CPU exhaustion).
 **Prevention:** Implement a unified eviction policy (like FIFO) across all caching modules. Always attempt to cleanup expired entries before evicting. Ensure cache retrieval is robust against corrupted or non-numeric expiration values.
+
+## 2026-05-23 - Log Level Bypass via Memory
+**Vulnerability:** Log Level Bypass (Missing Input Validation).
+**Learning:** Persistent state stored in `Memory` can be tampered with or become malformed. Direct assignment from `Memory` to internal configuration variables without validation can bypass security controls (e.g., log level gating).
+**Prevention:** Always validate values read from `Memory` before using them to set internal state. Use dedicated setter functions with type and boundary checks.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -374,10 +374,12 @@ function resetStats() {
 /**
  * ロガーを初期化する（各ティックの先頭で呼び出す）
  * Memory.logLevel が設定されていればそれを使用する
+ *
+ * Security: Uses setLevel() to ensure input from Memory is validated.
  */
 function init() {
     if (Memory.logLevel !== undefined && Memory.logLevel !== _level) {
-        _level = Memory.logLevel;
+        setLevel(Memory.logLevel);
     }
 }
 

--- a/tests/sentinel_log_level_bypass.test.js
+++ b/tests/sentinel_log_level_bypass.test.js
@@ -5,10 +5,14 @@
 global.Game = { time: 100 };
 global.Memory = {};
 
-jest.mock('../src/constants', () => ({
-    LOG_LEVEL: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, NONE: 4 },
-    DEFAULT_LOG_LEVEL: 1,
-}), { virtual: true });
+jest.mock(
+    '../src/constants',
+    () => ({
+        LOG_LEVEL: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, NONE: 4 },
+        DEFAULT_LOG_LEVEL: 1,
+    }),
+    { virtual: true }
+);
 
 const logger = require('../src/utils/logger');
 const { LOG_LEVEL } = require('../src/constants');

--- a/tests/sentinel_log_level_bypass.test.js
+++ b/tests/sentinel_log_level_bypass.test.js
@@ -1,0 +1,73 @@
+/**
+ * tests/sentinel_log_level_bypass.test.js
+ * Verification test for log level bypass fix in src/utils/logger.js
+ */
+
+// Global mock setup
+global.Game = { time: 100 };
+global.Memory = { logLevel: undefined };
+
+jest.mock(
+    '../src/constants',
+    () => ({
+        LOG_LEVEL: {
+            DEBUG: 0,
+            INFO: 1,
+            WARN: 2,
+            ERROR: 3,
+            NONE: 4,
+        },
+        DEFAULT_LOG_LEVEL: 1,
+    }),
+    { virtual: true }
+);
+
+const logger = require('../src/utils/logger');
+const { LOG_LEVEL } = require('../src/constants');
+
+describe('Sentinel: Log Level Bypass Verification', () => {
+    beforeEach(() => {
+        global.Memory = {};
+        global.Game.time = 100;
+        console.log = jest.fn();
+        logger.setLevel(LOG_LEVEL.INFO); // Reset to INFO
+    });
+
+    test('init() should default to INFO on invalid numeric Memory.logLevel', () => {
+        // -1 is invalid
+        global.Memory.logLevel = -1;
+
+        logger.init();
+
+        // Verify that debug log is NOT shown
+        logger.debug('This should be hidden');
+
+        expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
+        expect(console.log).not.toHaveBeenCalled();
+    });
+
+    test('init() should default to INFO on invalid string Memory.logLevel', () => {
+        global.Memory.logLevel = 'HACK';
+
+        logger.init();
+
+        logger.debug('Debug message');
+
+        expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
+        expect(console.log).not.toHaveBeenCalled();
+    });
+
+    test('init() should accept valid Memory.logLevel', () => {
+        global.Memory.logLevel = LOG_LEVEL.WARN;
+
+        logger.init();
+
+        logger.info('Info message');
+
+        expect(logger.getLevel()).toBe(LOG_LEVEL.WARN);
+        expect(console.log).not.toHaveBeenCalled();
+
+        logger.warn('Warning message');
+        expect(console.log).toHaveBeenCalled();
+    });
+});

--- a/tests/sentinel_log_level_bypass.test.js
+++ b/tests/sentinel_log_level_bypass.test.js
@@ -1,73 +1,38 @@
 /**
  * tests/sentinel_log_level_bypass.test.js
- * Verification test for log level bypass fix in src/utils/logger.js
+ * Verification for log level bypass fix in src/utils/logger.js
  */
-
-// Global mock setup
 global.Game = { time: 100 };
-global.Memory = { logLevel: undefined };
+global.Memory = {};
 
-jest.mock(
-    '../src/constants',
-    () => ({
-        LOG_LEVEL: {
-            DEBUG: 0,
-            INFO: 1,
-            WARN: 2,
-            ERROR: 3,
-            NONE: 4,
-        },
-        DEFAULT_LOG_LEVEL: 1,
-    }),
-    { virtual: true }
-);
+jest.mock('../src/constants', () => ({
+    LOG_LEVEL: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, NONE: 4 },
+    DEFAULT_LOG_LEVEL: 1,
+}), { virtual: true });
 
 const logger = require('../src/utils/logger');
 const { LOG_LEVEL } = require('../src/constants');
 
-describe('Sentinel: Log Level Bypass Verification', () => {
+describe('Sentinel: Log Level Bypass Fix', () => {
     beforeEach(() => {
         global.Memory = {};
-        global.Game.time = 100;
         console.log = jest.fn();
-        logger.setLevel(LOG_LEVEL.INFO); // Reset to INFO
+        logger.setLevel(LOG_LEVEL.INFO);
     });
 
-    test('init() should default to INFO on invalid numeric Memory.logLevel', () => {
-        // -1 is invalid
+    test('init() should default to INFO on invalid Memory.logLevel', () => {
         global.Memory.logLevel = -1;
-
         logger.init();
-
-        // Verify that debug log is NOT shown
-        logger.debug('This should be hidden');
-
         expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
-        expect(console.log).not.toHaveBeenCalled();
-    });
 
-    test('init() should default to INFO on invalid string Memory.logLevel', () => {
         global.Memory.logLevel = 'HACK';
-
         logger.init();
-
-        logger.debug('Debug message');
-
         expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
-        expect(console.log).not.toHaveBeenCalled();
     });
 
     test('init() should accept valid Memory.logLevel', () => {
         global.Memory.logLevel = LOG_LEVEL.WARN;
-
         logger.init();
-
-        logger.info('Info message');
-
         expect(logger.getLevel()).toBe(LOG_LEVEL.WARN);
-        expect(console.log).not.toHaveBeenCalled();
-
-        logger.warn('Warning message');
-        expect(console.log).toHaveBeenCalled();
     });
 });

--- a/tests/sentinel_log_level_bypass.test.js
+++ b/tests/sentinel_log_level_bypass.test.js
@@ -1,14 +1,22 @@
 /**
  * tests/sentinel_log_level_bypass.test.js
- * Verification for log level bypass fix in src/utils/logger.js
+ * Verification test for log level bypass fix in src/utils/logger.js
  */
+
+// Global mock setup
 global.Game = { time: 100 };
-global.Memory = {};
+global.Memory = { logLevel: undefined };
 
 jest.mock(
     '../src/constants',
     () => ({
-        LOG_LEVEL: { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, NONE: 4 },
+        LOG_LEVEL: {
+            DEBUG: 0,
+            INFO: 1,
+            WARN: 2,
+            ERROR: 3,
+            NONE: 4,
+        },
         DEFAULT_LOG_LEVEL: 1,
     }),
     { virtual: true }
@@ -17,26 +25,49 @@ jest.mock(
 const logger = require('../src/utils/logger');
 const { LOG_LEVEL } = require('../src/constants');
 
-describe('Sentinel: Log Level Bypass Fix', () => {
+describe('Sentinel: Log Level Bypass Verification', () => {
     beforeEach(() => {
         global.Memory = {};
+        global.Game.time = 100;
         console.log = jest.fn();
-        logger.setLevel(LOG_LEVEL.INFO);
+        logger.setLevel(LOG_LEVEL.INFO); // Reset to INFO
     });
 
-    test('init() should default to INFO on invalid Memory.logLevel', () => {
+    test('init() should default to INFO on invalid numeric Memory.logLevel', () => {
+        // -1 is invalid
         global.Memory.logLevel = -1;
-        logger.init();
-        expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
 
-        global.Memory.logLevel = 'HACK';
         logger.init();
+
+        // Verify that debug log is NOT shown
+        logger.debug('This should be hidden');
+
         expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
+        expect(console.log).not.toHaveBeenCalled();
+    });
+
+    test('init() should default to INFO on invalid string Memory.logLevel', () => {
+        global.Memory.logLevel = 'HACK';
+
+        logger.init();
+
+        logger.debug('Debug message');
+
+        expect(logger.getLevel()).toBe(LOG_LEVEL.INFO);
+        expect(console.log).not.toHaveBeenCalled();
     });
 
     test('init() should accept valid Memory.logLevel', () => {
         global.Memory.logLevel = LOG_LEVEL.WARN;
+
         logger.init();
+
+        logger.info('Info message');
+
         expect(logger.getLevel()).toBe(LOG_LEVEL.WARN);
+        expect(console.log).not.toHaveBeenCalled();
+
+        logger.warn('Warning message');
+        expect(console.log).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential log level bypass via malformed `Memory.logLevel`.
🎯 Impact: Unvalidated log levels could cause the logger to enter an inconsistent state, potentially leaking debug info or failing to log errors in a resource-constrained environment.
🔧 Fix: Updated `init()` in `src/utils/logger.js` to use `setLevel()` for proper input validation of `Memory.logLevel`.
✅ Verification: Added `tests/sentinel_log_level_bypass.test.js` to verify that invalid inputs default to INFO and valid inputs are accepted. All existing logger tests passed.

---
*PR created automatically by Jules for task [12114380678244248200](https://jules.google.com/task/12114380678244248200) started by @tadanobutubutu*

## Summary by Sourcery

Validate logger initialization against Memory.logLevel to prevent inconsistent log levels and add regression tests for the behavior.

Bug Fixes:
- Ensure logger.init() validates Memory.logLevel via the existing setLevel() logic to prevent invalid log level configurations from Memory.

Tests:
- Add sentinel_log_level_bypass.test.js to verify invalid Memory.logLevel values default to INFO and valid values are applied correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened logger initialization by validating `Memory.logLevel` via `setLevel()` to block malformed values and keep logs consistent. Adds regression tests and documents the mitigation in `.jules/sentinel.md`; fixes #775.

- **Bug Fixes**
  - `init()` now calls `setLevel(Memory.logLevel)` instead of assigning directly.
  - Added `tests/sentinel_log_level_bypass.test.js` to ensure invalid inputs default to INFO and valid levels are applied.

<sup>Written for commit 466c602f0addb66bd2212613c3e47cae1bfd5da0. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/490?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

