### PR TITLE
⚡ Bolt: Optimize pathfinder creep costs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -100,3 +100,14 @@ We hoisted the retrieval of construction sites outside the loop using `cache.get
 **Learning:** In rooms with many harvesters or during logic resets, `assignSource` can become a bottleneck if it re-calculates assignment counts per room on every call ((N \times M)$).
 **Action:** Implement a volatile per-tick cache for source assignments. Calculate counts once per room per tick ((N)$) and update the cache in-place for subsequent calls ((1)$). This reduces complexity to (N + M)$ for $ calls.
 **Impact:** Significantly reduces CPU spikes during high-frequency assignment events.
+
+## 2026-05-24 - Optimize Pathfinder Creep Costs with Centralized Cache
+
+**Learning:**
+In Screeps, pathfinding with `avoidCreeps: true` often triggers redundant `room.find(FIND_CREEPS)` calls across multiple pathfinding requests in the same tick. While caching `room.find(FIND_CREEPS)` centrally in `main.js` and reusing it in `src/utils/pathfinder.js` saves CPU, it is critical to use the full `FIND_CREEPS` result rather than just `FIND_MY_CREEPS` and `FIND_HOSTILE_CREEPS`. Omitting neutral or allied creeps leads to collisions, which trigger even more expensive engine-level path recalculations.
+
+**Action:**
+Centralize the `room.find(FIND_CREEPS)` call in the room-warming phase in `main.js` and store the result in a volatile property (e.g., `room._allCreeps`). In the pathfinder logic, prioritize this cached array to avoid multiple bridge crossings per tick.
+
+**Impact:**
+Reduces engine API calls from $ (where $ is the number of pathfinding calls with creep avoidance) to $ per room per tick. Standard `for` loops also provide a micro-optimization over `for...of` in the Screeps V8 environment.

--- a/main.js
+++ b/main.js
@@ -190,7 +190,10 @@ function initializeRoomBasicCache(room) {
     room._allStructures = allStructures;
     room._allStructuresTick = Game.time;
 
-    room._hostileCreeps = room.find(FIND_HOSTILE_CREEPS);
+    const allCreeps = room.find(FIND_CREEPS);
+    room._allCreeps = allCreeps;
+    room._allCreepsTick = Game.time;
+    room._hostileCreeps = allCreeps.filter((c) => !c.my);
     room._hostileCreepsTick = Game.time;
     room._activeSources = room.find(FIND_SOURCES_ACTIVE);
     room._activeSourcesTick = Game.time;

--- a/src/utils/pathfinder.js
+++ b/src/utils/pathfinder.js
@@ -134,8 +134,20 @@ function _applyConstructionSiteCosts (costs, room) {
  * @param {Room} room
  */
 function _applyCreepCosts (costs, room) {
+  // ⚡ PERFORMANCE OPTIMIZATION: Use pre-populated volatile room properties to avoid redundant room.find(FIND_CREEPS) call.
+  // main.js で収集済みのクリープを利用することで、エンジンへのクエリを削減する。
+  // FIND_CREEPS はすべてのクリープ（味方、敵、中立）を含むため、それらを網羅する。
+  if (room._allCreeps && room._allCreepsTick === Game.time) {
+    for (let i = 0; i < room._allCreeps.length; i++) {
+      const creep = room._allCreeps[i]
+      costs.set(creep.pos.x, creep.pos.y, 255)
+    }
+    return
+  }
+
   const creeps = room.find(FIND_CREEPS)
-  for (const creep of creeps) {
+  for (let i = 0; i < creeps.length; i++) {
+    const creep = creeps[i]
     costs.set(creep.pos.x, creep.pos.y, 255)
   }
 }

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -26,6 +26,7 @@ global.RESOURCE_ENERGY = 'energy';
 global.FIND_HOSTILE_CREEPS = 'findHostileCreeps';
 global.FIND_STRUCTURES = 'findStructures';
 global.FIND_MY_CREEPS = 'findMyCreeps';
+global.FIND_CREEPS = 'findCreeps';
 global.STRUCTURE_EXTENSION = 'extension';
 global.STRUCTURE_CONTAINER = 'container';
 global.STRUCTURE_SPAWN = 'spawn';


### PR DESCRIPTION
💡 What: Optimized the `_applyCreepCosts` function in `src/utils/pathfinder.js` to use a centralized per-tick cache of all creeps (`room._allCreeps`).

🎯 Why: Pathfinding with `avoidCreeps: true` was triggering redundant engine-level `room.find(FIND_CREEPS)` calls. Centralizing this search in `main.js` avoids multiple expensive bridge crossings and ensures that all creeps (including neutral and allied) are correctly treated as obstacles.

📊 Impact: Reduces engine API calls by $N-1$ per room per tick (where $N$ is the number of pathfinding requests with creep avoidance).

🔬 Measurement: Verified with `pnpm test` (38 tests passed, including pathfinder and main loop tests). Documented the pattern in the Bolt journal.

---
*PR created automatically by Jules for task [6348576324104375686](https://jules.google.com/task/6348576324104375686) started by @tadanobutubutu*

## Summary by Sourcery

Optimize pathfinder creep avoidance by reusing a centralized per-tick cache of room creeps.

Enhancements:
- Use a cached list of all room creeps in the pathfinder to avoid repeated room.find(FIND_CREEPS) calls and slightly optimize iteration.
- Populate volatile room-level caches for all creeps and hostile creeps during room initialization to support shared reuse across systems.
- Document the creep caching and pathfinding optimisation pattern in the Bolt journal.

Tests:
- Extend main loop tests to cover the new FIND_CREEPS usage and cached creep handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized pathfinding creep avoidance by caching per-room `FIND_CREEPS` results and reusing them in `_applyCreepCosts`. This cuts redundant engine calls and ensures all creeps are treated as obstacles.

- **Performance**
  - Centralized `room.find(FIND_CREEPS)` in `main.js`, cached on `room._allCreeps` per tick; pathfinder reuses it.
  - Reduced engine calls by N-1 per room per tick when `avoidCreeps: true`; replaced `for...of` with classic `for` loops for small gains.

- **Bug Fixes**
  - Obstacle set now includes all creeps (my, hostile, neutral); updated tests to mock `FIND_CREEPS`.

<sup>Written for commit 1274b9aa53c83a50b8ad2d9bf8d6016d19055ca7. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/506?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

