### PR TITLE
🧪 Add tests for initCreepMemory

### DIFF
--- a/tests/utils.memory.test.js
+++ b/tests/utils.memory.test.js
@@ -235,4 +235,59 @@ describe('utils.memory', () => {
         expect(utilsMemory.isSafeKey('__lookupGetter__')).toBe(false);
         expect(utilsMemory.isSafeKey('__lookupSetter__')).toBe(false);
     });
+
+    describe('initCreepMemory', () => {
+        let creep;
+
+        beforeEach(() => {
+            creep = { memory: {} };
+        });
+
+        test('initializes role and working state if undefined', () => {
+            utilsMemory.initCreepMemory(creep, 'harvester');
+            expect(creep.memory.role).toBe('harvester');
+            expect(creep.memory.working).toBe(false);
+        });
+
+        test('does not overwrite existing role or working state', () => {
+            creep.memory.role = 'builder';
+            creep.memory.working = true;
+            utilsMemory.initCreepMemory(creep, 'harvester');
+            expect(creep.memory.role).toBe('builder');
+            expect(creep.memory.working).toBe(true);
+        });
+
+        test('copies safe properties from extraData', () => {
+            utilsMemory.initCreepMemory(creep, 'harvester', { sourceId: 'abc', count: 5 });
+            expect(creep.memory.sourceId).toBe('abc');
+            expect(creep.memory.count).toBe(5);
+        });
+
+        test('does not overwrite existing properties in creep memory with extraData', () => {
+            creep.memory.sourceId = 'xyz';
+            utilsMemory.initCreepMemory(creep, 'harvester', { sourceId: 'abc' });
+            expect(creep.memory.sourceId).toBe('xyz');
+        });
+
+        test('blocks dangerous keys from extraData', () => {
+            const extraData = { validKey: 'value' };
+            Object.defineProperty(extraData, '__proto__', { value: 'danger', enumerable: true });
+            utilsMemory.initCreepMemory(creep, 'harvester', extraData);
+
+            // Should not copy __proto__ but validKey should be copied
+            expect(creep.memory.validKey).toBe('value');
+            expect(creep.memory.__proto__).not.toBe('danger');
+        });
+
+        test('does not copy inherited properties from extraData', () => {
+            const parent = { inheritedKey: 'inherited' };
+            const child = Object.create(parent);
+            child.ownKey = 'own';
+
+            utilsMemory.initCreepMemory(creep, 'harvester', child);
+
+            expect(creep.memory.ownKey).toBe('own');
+            expect(creep.memory.inheritedKey).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** This PR addresses a testing gap by adding comprehensive tests for the `initCreepMemory` function in `utils.memory.js`.
📊 **Coverage:** The new tests cover:
- Basic initialization of `role` and `working` state when they are undefined.
- Preservation of existing `role` and `working` properties.
- Merging of safe properties from `extraData` into `creep.memory`.
- Ensuring existing properties in `creep.memory` are not overwritten by `extraData`.
- Blocking of dangerous keys (e.g., `__proto__`) from being copied from `extraData`.
- Ensuring inherited properties from the `extraData`'s prototype chain are not copied.
✨ **Result:** Increased test coverage and confidence in the creep memory initialization logic, ensuring security and proper property assignments.

---
*PR created automatically by Jules for task [6659833736243030695](https://jules.google.com/task/6659833736243030695) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests for `initCreepMemory` in `utils.memory.js` to validate initialization, non-overwriting of existing fields, and safe merging of `extraData`. Improves coverage and prevents prototype pollution by blocking dangerous keys and inherited properties.

<sup>Written for commit a9dba014055618ab588ac9836ca7d4d27d41ba45. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/509?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for memory initialization functionality to ensure reliability and data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->