### PR TITLE
🧪 Add unit tests for towerManager.getStats

### DIFF
--- a/tests/towerManager.test.js
+++ b/tests/towerManager.test.js
@@ -171,4 +171,48 @@ describe('towerManager', () => {
             expect(mockTower.attack).not.toHaveBeenCalled();
         });
     });
+
+    describe('getStats', () => {
+        test('タワーがない場合は初期値を返す', () => {
+            cache.getMyStructures.mockReturnValue([]);
+            const stats = towerManager.getStats(mockRoom);
+            expect(stats).toEqual({
+                total: 0,
+                active: 0,
+                avgEnergy: 0,
+                lowEnergy: 0,
+            });
+        });
+
+        test('タワーの統計情報を正しく計算する', () => {
+            const tower1 = {
+                store: {
+                    [global.RESOURCE_ENERGY]: 800,
+                    getCapacity: jest.fn().mockReturnValue(1000),
+                }
+            };
+            const tower2 = {
+                store: {
+                    [global.RESOURCE_ENERGY]: 400,
+                    getCapacity: jest.fn().mockReturnValue(1000),
+                }
+            };
+            const tower3 = {
+                store: {
+                    [global.RESOURCE_ENERGY]: 0,
+                    getCapacity: jest.fn().mockReturnValue(1000),
+                }
+            };
+
+            cache.getMyStructures.mockReturnValue([tower1, tower2, tower3]);
+
+            const stats = towerManager.getStats(mockRoom);
+            expect(stats).toEqual({
+                total: 3,
+                active: 2,
+                avgEnergy: (0.8 + 0.4 + 0) / 3,
+                lowEnergy: 2,
+            });
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** This PR adds unit tests for the `getStats` function in `src/managers/towerManager.js`, addressing an untested part of the codebase.
📊 **Coverage:** The new tests cover:
- The edge case where there are no towers (returns a default stats object with all zeroes).
- A scenario with multiple towers with different energy levels (verifies correct calculation of `total`, `active`, `avgEnergy`, and `lowEnergy` based on the mocked `TOWER_ENERGY_PRIORITY`).
✨ **Result:** Test coverage and reliability of the `towerManager.js` module have been improved by validating the exact statistical output generated for dashboard and monitoring use cases.

---
*PR created automatically by Jules for task [12229668937178488677](https://jules.google.com/task/12229668937178488677) started by @tadanobutubutu*