### PR TITLE
🧪 [testing improvement] Add test cases for empty returns in findTowerTargets

### DIFF
--- a/.Jules/test.md
+++ b/.Jules/test.md
@@ -1,0 +1,4 @@
+- **Issue:** Untested error paths in `findTowerTargets` in `utils.defense` where `room.find` could potentially return an empty array, leading to errors when attempting to access index 0.
+- **Fix:** Added two test cases in `tests/utils.defense.test.js` to ensure the application of defensive coding paths handles arrays without items appropriately. We validated that the function will not throw errors when given an empty return, and handles missing tower targets properly (i.e. does not call `attack` or `repair`). Tests explicitly mock `options.filter` to correctly match implementation structure.
+- **Tools used:** `pnpm test`, `jest`, `eslint`, `prettier`.
+- **Pre-commit:** Code was formatted, linted, and tests were passed successfully. No regressions occurred.

--- a/tests/utils.defense.test.js
+++ b/tests/utils.defense.test.js
@@ -97,4 +97,35 @@ describe('utils.defense', () => {
         expect(status.ramparts).toBe(1);
         expect(status.underAttack).toBe(false);
     });
+
+    test('findTowerTargetsが空配列を返されたときにエラーを投げない', () => {
+        const room = {
+            find: jest.fn().mockReturnValue([]),
+        };
+
+        expect(() => {
+            DefenseManager.findTowerTargets(room);
+        }).not.toThrow();
+    });
+
+    test('findTowerTargetsがtowerはあるがターゲットがないときに何もしない', () => {
+        const mockTower = { structureType: STRUCTURE_TOWER, attack: jest.fn(), repair: jest.fn() };
+        const room = {
+            find: jest.fn().mockImplementation((type, options) => {
+                if (type === FIND_MY_STRUCTURES) {
+                    // Note: FIND_STRUCTURES is also 20 in this file
+                    let items = [mockTower];
+                    if (options && options.filter) {
+                        return items.filter(options.filter);
+                    }
+                    return items;
+                }
+                return [];
+            }),
+        };
+
+        DefenseManager.findTowerTargets(room);
+        expect(mockTower.attack).not.toHaveBeenCalled();
+        expect(mockTower.repair).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
🎯 **What:** This PR addresses untested paths in `utils.defense.js`'s `findTowerTargets` function where empty array returns from `room.find` were not previously tested.
📊 **Coverage:** Covered scenarios include when no items are returned (all `room.find` queries return an empty array) to ensure no errors are thrown, and when towers are found but no valid targets exist (no `attack` or `repair` methods invoked). Tests explicitly mock the `options.filter` method to ensure correct alignment with production code.
✨ **Result:** Improved test coverage and reliability for defense target selection by validating zero-index access checks (`length > 0`) are handled properly without side effects. Tests for `utils.defense.js` pass cleanly with no regressions in the larger suite.

---
*PR created automatically by Jules for task [3885021495600839946](https://jules.google.com/task/3885021495600839946) started by @tadanobutubutu*