### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Sensitive Data Exposure in Logs

### DIFF
--- a/scripts/supabase-keepalive.js
+++ b/scripts/supabase-keepalive.js
@@ -35,7 +35,26 @@ async function keepAlive() {
     }
 
     console.log('SUCCESS: Supabase への ping が成功しました');
-    console.log('データ:', JSON.stringify(data));
+
+    // 安全なフィールドのみを抽出してログに出力
+    const safeData = Array.isArray(data)
+        ? data.map((item) => ({
+              id: item.id,
+              pinged_at: item.pinged_at,
+              source: item.source,
+          }))
+        : data
+          ? {
+                id: data.id,
+                pinged_at: data.pinged_at,
+                source: data.source,
+            }
+          : null;
+    console.log('データ:', JSON.stringify(safeData));
 }
 
-keepAlive();
+if (require.main === module) {
+    keepAlive();
+}
+
+module.exports = { keepAlive };

--- a/tests/sentinel_supabase_keepalive.test.js
+++ b/tests/sentinel_supabase_keepalive.test.js
@@ -1,0 +1,69 @@
+// Mock process.env before requiring the script
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'dummy_key';
+
+// Mock the supabase client
+jest.mock('@supabase/supabase-js', () => {
+    return {
+        createClient: jest.fn(() => ({
+            from: jest.fn(() => ({
+                upsert: jest.fn().mockResolvedValue({
+                    data: [
+                        {
+                            id: 1,
+                            pinged_at: '2023-01-01T00:00:00.000Z',
+                            source: 'github-actions',
+                            sensitive_token: 'secret123',
+                            password_hash: 'hash456',
+                        },
+                    ],
+                    error: null,
+                }),
+            })),
+        })),
+    };
+});
+
+describe('Supabase Keepalive Security Tests', () => {
+    let originalConsoleLog;
+    let consoleLogMock;
+
+    beforeAll(() => {
+        originalConsoleLog = console.log;
+    });
+
+    beforeEach(() => {
+        consoleLogMock = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleLogMock.mockRestore();
+    });
+
+    afterAll(() => {
+        console.log = originalConsoleLog;
+    });
+
+    it('should not log sensitive fields from the data object', async () => {
+        // Require the script dynamically to ensure mocks are applied
+        const { keepAlive } = require('../scripts/supabase-keepalive.js');
+
+        await keepAlive();
+
+        // Find the log call that outputs the data
+        const dataLogCall = consoleLogMock.mock.calls.find((call) => call[0] === 'データ:');
+        expect(dataLogCall).toBeDefined();
+
+        const loggedDataString = dataLogCall[1];
+        const loggedData = JSON.parse(loggedDataString);
+
+        // Assert that the safe fields are present
+        expect(loggedData[0]).toHaveProperty('id', 1);
+        expect(loggedData[0]).toHaveProperty('pinged_at', '2023-01-01T00:00:00.000Z');
+        expect(loggedData[0]).toHaveProperty('source', 'github-actions');
+
+        // Assert that sensitive fields are NOT present
+        expect(loggedData[0]).not.toHaveProperty('sensitive_token');
+        expect(loggedData[0]).not.toHaveProperty('password_hash');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the potential exposure of sensitive data in logs by using `JSON.stringify(data)` directly from the Supabase API response in `scripts/supabase-keepalive.js`.

⚠️ **Risk:** The potential impact if left unfixed is that if the `keepalive_log` table structure changes to include sensitive fields, or if unexpected data is returned by Supabase, this information would be printed to system/CI logs, causing a data leak.

🛡️ **Solution:** The script now maps over the `data` response and only extracts known, safe fields (`id`, `pinged_at`, `source`) to an explicitly structured `safeData` object before logging. It also modifies the script to safely export the `keepAlive` function for testing and adds robust Jest test coverage to verify this behavior.

---
*PR created automatically by Jules for task [2952890556138381807](https://jules.google.com/task/2952890556138381807) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sensitive data from leaking to logs in the Supabase keepalive script by logging only whitelisted fields. Also exports `keepAlive` and adds tests to prevent regressions.

- **Bug Fixes**
  - Log only `id`, `pinged_at`, and `source` by mapping API `data` to a `safeData` object before `JSON.stringify`.
  - Export `keepAlive` and run it only when executed directly; added Jest test mocking `@supabase/supabase-js` to ensure sensitive fields are never logged.

<sup>Written for commit 0fc8665d0daf16806ffd42f4bd6a5774bfa1dc76. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/516?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

