### PR TITLE
🧪 Add tests for removeTask in utils.tasks

### DIFF
--- a/tests/utils.tasks.test.js
+++ b/tests/utils.tasks.test.js
@@ -28,14 +28,14 @@ describe('utils.tasks', () => {
         jest.restoreAllMocks();
     });
 
-    test('registerTaskが正しくタスクを追加する', () => {
+    test('registerTask correctly adds a task', () => {
         TaskQueue.registerTask('testTask', 10, () => {});
         expect(TaskQueue.tasks.length).toBe(1);
         expect(TaskQueue.tasks[0].name).toBe('testTask');
         expect(TaskQueue.tasks[0].interval).toBe(10);
     });
 
-    test('registerTaskが重複を検知して更新する', () => {
+    test('registerTask detects and updates duplicates', () => {
         const action1 = () => {};
         const action2 = () => {};
         TaskQueue.registerTask('task1', 10, action1);
@@ -48,13 +48,13 @@ describe('utils.tasks', () => {
         expect(TaskQueue.tasks[0].action).toBe(action2);
     });
 
-    test('registerTaskが安全でないキーを拒否する', () => {
+    test('registerTask rejects unsafe keys', () => {
         utilsMemory.isSafeKey.mockReturnValue(false);
         TaskQueue.registerTask('__proto__', 10, () => {});
         expect(TaskQueue.tasks.length).toBe(0);
     });
 
-    test('registerTaskがタスク上限を強制する', () => {
+    test('registerTask enforces task limit', () => {
         for (let i = 0; i < 50; i++) {
             TaskQueue.registerTask(`task${i}`, 1, () => {});
         }
@@ -67,7 +67,7 @@ describe('utils.tasks', () => {
         );
     });
 
-    test('runが正しいティックでタスクを実行する', () => {
+    test('run executes task at correct tick', () => {
         const action = jest.fn();
         TaskQueue.registerTask('task10', 10, action);
 
@@ -87,14 +87,14 @@ describe('utils.tasks', () => {
         expect(everyTickAction).toHaveBeenCalledTimes(1);
     });
 
-    test('runが条件を満たさないタスクをスキップする', () => {
+    test('run skips tasks that do not meet condition', () => {
         const action = jest.fn();
         TaskQueue.registerTask('conditional', 1, action, () => false);
         TaskQueue.run();
         expect(action).not.toHaveBeenCalled();
     });
 
-    test('runがエラーをキャッチしてセキュアロガーに送る', () => {
+    test('run catches errors and sends them to secure logger', () => {
         const errorAction = () => {
             throw new Error('Boom');
         };
@@ -106,7 +106,7 @@ describe('utils.tasks', () => {
         );
     });
 
-    test('runが失敗回数上限を超えたタスクを実行しない (Circuit Breaker)', () => {
+    test('run does not execute tasks exceeding failure limit (Circuit Breaker)', () => {
         const errorAction = jest.fn(() => {
             throw new Error('Boom');
         });
@@ -128,7 +128,7 @@ describe('utils.tasks', () => {
         expect(errorAction).not.toHaveBeenCalled();
     });
 
-    test('registerTaskが再登録時に失敗カウントをリセットする', () => {
+    test('registerTask resets failure count on re-registration', () => {
         const errorAction = jest.fn(() => {
             throw new Error('Boom');
         });
@@ -150,7 +150,7 @@ describe('utils.tasks', () => {
         expect(errorAction).toHaveBeenCalledTimes(1);
     });
 
-    test('runがタスク失敗時にfailuresカウントをインクリメントする', () => {
+    test('run increments failures count on task failure', () => {
         const errorAction = () => {
             throw new Error('Failure Increment Test');
         };
@@ -170,5 +170,38 @@ describe('utils.tasks', () => {
 
         // After 2 runs with error, failures should be 2
         expect(task.failures).toBe(2);
+    });
+
+    test('removeTask removes an existing task', () => {
+        TaskQueue.registerTask('taskToRemove', 10, () => {});
+        expect(TaskQueue.tasks.length).toBe(1);
+        TaskQueue.removeTask('taskToRemove');
+        expect(TaskQueue.tasks.length).toBe(0);
+    });
+
+    test('removeTask does not throw when removing a non-existent task', () => {
+        TaskQueue.registerTask('existingTask', 10, () => {});
+        expect(TaskQueue.tasks.length).toBe(1);
+        TaskQueue.removeTask('nonExistentTask');
+        expect(TaskQueue.tasks.length).toBe(1);
+    });
+
+    test('removeTask does nothing when given an empty name or null', () => {
+        TaskQueue.registerTask('task1', 10, () => {});
+        expect(TaskQueue.tasks.length).toBe(1);
+        TaskQueue.removeTask('');
+        TaskQueue.removeTask(null);
+        TaskQueue.removeTask(undefined);
+        expect(TaskQueue.tasks.length).toBe(1);
+    });
+
+    test('removeTask correctly sanitizes and removes a long task name', () => {
+        const longName = 'a'.repeat(200);
+
+        TaskQueue.registerTask(longName, 10, () => {});
+        expect(TaskQueue.tasks.length).toBe(1);
+
+        TaskQueue.removeTask(longName);
+        expect(TaskQueue.tasks.length).toBe(0);
     });
 });


### PR DESCRIPTION
🎯 What: The testing gap for removeTask in utils.tasks.js was addressed.
📊 Coverage: Added tests for removing existing tasks, non-existent tasks, empty/null names, and long names exceeding MAX_TASK_NAME_LENGTH. 
✨ Result: Improved test coverage and reliability for task management.

---
*PR created automatically by Jules for task [16865892592061762374](https://jules.google.com/task/16865892592061762374) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for removeTask in utils.tasks to cover removing existing tasks, ignoring missing tasks, and safely handling empty/null and overlong names. Improves coverage and protects against regressions in task removal behavior.

<sup>Written for commit 1521e7f890208281906c8c9fb3fb3d9d13f4f8f6. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/521?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

