### PR TITLE
Fix: use computed property names for ENERGY_WITHDRAW_THRESHOLD keys

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,9 @@
 **Vulnerability:** Log-Level Bypass (Information Leakage / DoS).
 **Learning:** Directly assigning user-controlled values from `Memory` to internal state variables (like `_level`) without validation can bypass security logic if the values are malformed (e.g., negative values, strings, or `null`). In JavaScript, unvalidated values can satisfy or break logic gates (e.g., a negative log level satisfying `val > LOG_LEVEL.DEBUG`, or `undefined > 0` evaluating to `false`), causing the logger to fail open or behave unexpectedly.
 **Prevention:** Always use validated setters (like `setLevel()`) when initializing state from `Memory` or other persistent storage. Ensure setters perform strict type checking and range validation, falling back to safe defaults for any invalid input.
+
+## 2026-05-25 - Object Key Lookup with Screeps Constants
+
+**Vulnerability:** Incorrect Key Lookup / Prototype Pollution / Missing Features.
+**Learning:** Using Screeps constants like `STRUCTURE_CONTAINER` directly as keys in object literals (e.g., `CONTAINER: 100`) creates a key named literally "CONTAINER", not the value of the constant (`"container"`). This leads to runtime failures during property lookups (e.g., `ENERGY_WITHDRAW_THRESHOLD[structureType]`) because the actual structure type strings from the game engine don't match the hardcoded strings in the object. This is an application logic flaw. Using computed property names (`[STRUCTURE_CONTAINER]: 100`) evaluates the constant correctly.
+**Prevention:** Use computed property names `[CONSTANT_NAME]: value` when defining lookup maps that are intended to be indexed by dynamic engine values or constants to guarantee accurate property resolution.

--- a/src/constants.js
+++ b/src/constants.js
@@ -255,7 +255,6 @@ const CACHE_TTL = {
 
 /** 修復対象となるHP率の閾値 */
 // Security: Use Object.create(null) to avoid prototype pollution issues.
-// Fix: Use computed property names with Screeps constants for correct lookups.
 const REPAIR_THRESHOLD = Object.assign(Object.create(null), {
     [STRUCTURE_ROAD]: 0.5,
     [STRUCTURE_CONTAINER]: 0.5,
@@ -301,9 +300,9 @@ const TOWER_ENERGY_PRIORITY = 0.5;
 
 /** コンテナ・ストレージからエネルギーを引き出す閾値 */
 const ENERGY_WITHDRAW_THRESHOLD = {
-    CONTAINER: 100,
-    STORAGE: 10000,
-    LINK: 200,
+    [STRUCTURE_CONTAINER]: 100,
+    [STRUCTURE_STORAGE]: 10000,
+    [STRUCTURE_LINK]: 200,
 };
 
 // ============================================================


### PR DESCRIPTION
Removed an outdated comment `// Fix: Use computed property names with Screeps constants for correct lookups.` from `src/constants.js` around line 258, as the `REPAIR_THRESHOLD` object already implements this fix properly using computed property names like `[STRUCTURE_ROAD]`. I also found the `ENERGY_WITHDRAW_THRESHOLD` object had this exact bug where constants were not computed property names. I have applied the fix to this object by correctly utilizing `[STRUCTURE_CONTAINER]`, `[STRUCTURE_STORAGE]`, and `[STRUCTURE_LINK]`. Added the relevant learning into the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [5650552563943582412](https://jules.google.com/task/5650552563943582412) started by @tadanobutubutu*