### PR TITLE
🧪 [testing improvement] Add tests for updateWorkingState in utils.memory

### DIFF
--- a/tests/utils.memory.test.js
+++ b/tests/utils.memory.test.js
@@ -120,7 +120,7 @@ describe('utils.memory', () => {
             utilsMemory.memoize(fn, 'key' + i, 100);
         }
         expect(callCount).toBe(50);
-        expect(Memory.cache.key0).toBeDefined();
+        expect(Memory.cache['key0']).toBeDefined();
 
         // Add one more entry
         const result = utilsMemory.memoize(fn, 'oneMoreKey', 100);
@@ -128,8 +128,8 @@ describe('utils.memory', () => {
         expect(callCount).toBe(51);
 
         // Security: Verify FIFO eviction (key0 should be gone, oneMoreKey should be present)
-        expect(Memory.cache.oneMoreKey).toBeDefined();
-        expect(Memory.cache.key0).toBeUndefined();
+        expect(Memory.cache['oneMoreKey']).toBeDefined();
+        expect(Memory.cache['key0']).toBeUndefined();
         expect(Object.keys(Memory.cache).length).toBe(50);
     });
 

--- a/tests/utils.memory.test.js
+++ b/tests/utils.memory.test.js
@@ -120,7 +120,7 @@ describe('utils.memory', () => {
             utilsMemory.memoize(fn, 'key' + i, 100);
         }
         expect(callCount).toBe(50);
-        expect(Memory.cache['key0']).toBeDefined();
+        expect(Memory.cache.key0).toBeDefined();
 
         // Add one more entry
         const result = utilsMemory.memoize(fn, 'oneMoreKey', 100);
@@ -128,8 +128,8 @@ describe('utils.memory', () => {
         expect(callCount).toBe(51);
 
         // Security: Verify FIFO eviction (key0 should be gone, oneMoreKey should be present)
-        expect(Memory.cache['oneMoreKey']).toBeDefined();
-        expect(Memory.cache['key0']).toBeUndefined();
+        expect(Memory.cache.oneMoreKey).toBeDefined();
+        expect(Memory.cache.key0).toBeUndefined();
         expect(Object.keys(Memory.cache).length).toBe(50);
     });
 

--- a/tests/utils.memory.test.js
+++ b/tests/utils.memory.test.js
@@ -235,4 +235,60 @@ describe('utils.memory', () => {
         expect(utilsMemory.isSafeKey('__lookupGetter__')).toBe(false);
         expect(utilsMemory.isSafeKey('__lookupSetter__')).toBe(false);
     });
+
+    describe('updateWorkingState', () => {
+        let mockCreep;
+
+        beforeEach(() => {
+            mockCreep = {
+                memory: {
+                    working: false,
+                },
+                store: {
+                    getFreeCapacity: jest.fn(),
+                    getUsedCapacity: jest.fn(),
+                },
+            };
+        });
+
+        test('transitions to working when free capacity is 0', () => {
+            mockCreep.memory.working = false;
+            mockCreep.store.getFreeCapacity.mockReturnValue(0);
+
+            const result = utilsMemory.updateWorkingState(mockCreep);
+
+            expect(result).toBe(true);
+            expect(mockCreep.memory.working).toBe(true);
+        });
+
+        test('transitions to not working when used capacity is 0', () => {
+            mockCreep.memory.working = true;
+            mockCreep.store.getUsedCapacity.mockReturnValue(0);
+
+            const result = utilsMemory.updateWorkingState(mockCreep);
+
+            expect(result).toBe(false);
+            expect(mockCreep.memory.working).toBe(false);
+        });
+
+        test('remains working when used capacity is > 0', () => {
+            mockCreep.memory.working = true;
+            mockCreep.store.getUsedCapacity.mockReturnValue(10);
+
+            const result = utilsMemory.updateWorkingState(mockCreep);
+
+            expect(result).toBe(true);
+            expect(mockCreep.memory.working).toBe(true);
+        });
+
+        test('remains not working when free capacity is > 0', () => {
+            mockCreep.memory.working = false;
+            mockCreep.store.getFreeCapacity.mockReturnValue(10);
+
+            const result = utilsMemory.updateWorkingState(mockCreep);
+
+            expect(result).toBe(false);
+            expect(mockCreep.memory.working).toBe(false);
+        });
+    });
 });


### PR DESCRIPTION
## **User description**
🎯 **What:** The `updateWorkingState` function in `utils.memory.js` was previously untested, leaving a small but critical gap in test coverage since it relies heavily on mutating `creep.memory`.
📊 **Coverage:** Four specific test cases are now included inside a new `updateWorkingState` describe block within `tests/utils.memory.test.js`, testing each possible state transition logic: transitioning to working, transitioning to not working, and remaining in each state according to used and free capacity.
✨ **Result:** Test coverage improved across the `utils.memory.js` file, resulting in 31 passing unit tests inside this suite without regression on the rest of the 660 test suites.

---
*PR created automatically by Jules for task [2337707666284065128](https://jules.google.com/task/2337707666284065128) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test suite for `updateWorkingState` in `utils.memory` covering all transitions (0 free -> working, 0 used -> not working, unchanged otherwise), plus dot-notation assertions for `Memory.cache`.

<sup>Written for commit 790edb916a4f28c25df9942879f2f792a6137ced. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/525?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add coverage for creep working-state updates

### What Changed
- Added tests for all `updateWorkingState` outcomes
- Verifies a creep switches to working when free capacity reaches 0
- Verifies a creep switches to not working when used capacity reaches 0
- Verifies the working state stays unchanged in both normal cases

### Impact
`✅ Fewer regressions in creep state updates`
`✅ Safer memory-state behavior`
`✅ More reliable unit coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
