### PR TITLE
🧹 Code Health: Refactor complex run method in role.medic.js

### DIFF
--- a/role.medic.js
+++ b/role.medic.js
@@ -3,6 +3,99 @@ const PATH_STYLE_HEAL = { visualizePathStyle: { stroke: '#00ff00' } };
 const PATH_STYLE_IDLE = { visualizePathStyle: { stroke: '#ffffff', opacity: 0.2 } };
 const PATH_STYLE_HARVEST = { visualizePathStyle: { stroke: '#ffaa00' } };
 
+function _updateState(creep) {
+    // State machine: Gather energy or Heal
+    if (creep.memory.healing && creep.store[RESOURCE_ENERGY] === 0) {
+        creep.memory.healing = false;
+        creep.say('⚡ harvest');
+    }
+    if (!creep.memory.healing && creep.store.getFreeCapacity() === 0) {
+        creep.memory.healing = true;
+        creep.say('💊 heal');
+    }
+}
+
+function _handleHealingMode(creep, injured) {
+    if (injured.length > 0) {
+        const target = _getHealTarget(creep, injured);
+        if (target) {
+            _performHeal(creep, target);
+        }
+    } else {
+        delete creep.memory.healTargetId;
+        _idle(creep);
+    }
+}
+
+function _handleGatheringMode(creep, sources, injured) {
+    const canHarvest = creep.getActiveBodyparts(WORK) > 0;
+    if (canHarvest && sources.length > 0) {
+        const target = _getHarvestTarget(creep, sources);
+        if (target) {
+            if (creep.harvest(target) === ERR_NOT_IN_RANGE) {
+                creep.moveTo(target, PATH_STYLE_HARVEST);
+            }
+        }
+    } else if (injured.length > 0) {
+        const target = _getHealTarget(creep, injured);
+        if (target && creep.store[RESOURCE_ENERGY] > 0) {
+            _performHeal(creep, target);
+        }
+    } else {
+        delete creep.memory.healTargetId;
+    }
+}
+
+function _getHealTarget(creep, injured) {
+    // ⚡ PERFORMANCE: Cache heal target ID and use closest by range
+    let target = Game.getObjectById(creep.memory.healTargetId);
+
+    // If target is invalid or fully healed, find a new one
+    if (!target || target.hits === target.hitsMax) {
+        target = creep.pos.findClosestByRange(injured);
+        if (target) {
+            creep.memory.healTargetId = target.id;
+        } else {
+            delete creep.memory.healTargetId;
+        }
+    }
+    return target;
+}
+
+function _getHarvestTarget(creep, sources) {
+    // ⚡ PERFORMANCE: Cache harvest target ID and use closest by range
+    let target = Game.getObjectById(creep.memory.harvestTargetId);
+
+    if (!target || target.energy === 0) {
+        target = creep.pos.findClosestByRange(sources);
+        if (target) {
+            creep.memory.harvestTargetId = target.id;
+        } else {
+            delete creep.memory.harvestTargetId;
+        }
+    }
+    return target;
+}
+
+function _performHeal(creep, target) {
+    if (creep.pos.isNearTo(target)) {
+        creep.heal(target);
+    } else {
+        creep.rangedHeal(target);
+        creep.moveTo(target, PATH_STYLE_HEAL);
+    }
+}
+
+function _idle(creep) {
+    // No one to heal: Move to idle position
+    const idlePos = creep.room.controller
+        ? creep.room.controller.pos
+        : new RoomPosition(25, 25, creep.room.name);
+    if (!creep.pos.inRangeTo(idlePos, 3)) {
+        creep.moveTo(idlePos, PATH_STYLE_IDLE);
+    }
+}
+
 const roleMedic = {
     run: function (creep) {
         creep.say('💊');
@@ -12,94 +105,12 @@ const roleMedic = {
         const injured = creep.room._injuredCreeps || [];
         const sources = creep.room._activeSources || [];
 
-        // State machine: Gather energy or Heal
-        if (creep.memory.healing && creep.store[RESOURCE_ENERGY] === 0) {
-            creep.memory.healing = false;
-            creep.say('⚡ harvest');
-        }
-        if (!creep.memory.healing && creep.store.getFreeCapacity() === 0) {
-            creep.memory.healing = true;
-            creep.say('💊 heal');
-        }
+        _updateState(creep);
 
         if (creep.memory.healing) {
-            if (injured.length > 0) {
-                // ⚡ PERFORMANCE: Cache heal target ID and use closest by range
-                let target = Game.getObjectById(creep.memory.healTargetId);
-
-                // If target is invalid or fully healed, find a new one
-                if (!target || target.hits === target.hitsMax) {
-                    target = creep.pos.findClosestByRange(injured);
-                    if (target) {
-                        creep.memory.healTargetId = target.id;
-                    } else {
-                        delete creep.memory.healTargetId;
-                    }
-                }
-
-                if (target) {
-                    if (creep.pos.isNearTo(target)) {
-                        creep.heal(target);
-                    } else {
-                        creep.rangedHeal(target);
-                        creep.moveTo(target, PATH_STYLE_HEAL);
-                    }
-                }
-            } else {
-                delete creep.memory.healTargetId;
-                // No one to heal: Move to idle position
-                const idlePos = creep.room.controller
-                    ? creep.room.controller.pos
-                    : new RoomPosition(25, 25, creep.room.name);
-                if (!creep.pos.inRangeTo(idlePos, 3)) {
-                    creep.moveTo(idlePos, PATH_STYLE_IDLE);
-                }
-            }
+            _handleHealingMode(creep, injured);
         } else {
-            // Gathering mode
-            const canHarvest = creep.getActiveBodyparts(WORK) > 0;
-            if (canHarvest && sources.length > 0) {
-                // ⚡ PERFORMANCE: Cache harvest target ID and use closest by range
-                let target = Game.getObjectById(creep.memory.harvestTargetId);
-
-                if (!target || target.energy === 0) {
-                    target = creep.pos.findClosestByRange(sources);
-                    if (target) {
-                        creep.memory.harvestTargetId = target.id;
-                    } else {
-                        delete creep.memory.harvestTargetId;
-                    }
-                }
-
-                if (target) {
-                    if (creep.harvest(target) === ERR_NOT_IN_RANGE) {
-                        creep.moveTo(target, PATH_STYLE_HARVEST);
-                    }
-                }
-            } else if (injured.length > 0) {
-                // ⚡ PERFORMANCE: Use heal target cache for secondary healing too
-                let target = Game.getObjectById(creep.memory.healTargetId);
-
-                if (!target || target.hits === target.hitsMax) {
-                    target = creep.pos.findClosestByRange(injured);
-                    if (target) {
-                        creep.memory.healTargetId = target.id;
-                    } else {
-                        delete creep.memory.healTargetId;
-                    }
-                }
-
-                if (target && creep.store[RESOURCE_ENERGY] > 0) {
-                    if (creep.pos.isNearTo(target)) {
-                        creep.heal(target);
-                    } else {
-                        creep.rangedHeal(target);
-                        creep.moveTo(target, PATH_STYLE_HEAL);
-                    }
-                }
-            } else {
-                delete creep.memory.healTargetId;
-            }
+            _handleGatheringMode(creep, sources, injured);
         }
     },
 };


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the overly complex `run` function inside `role.medic.js`. The logic has been broken down and abstracted into smaller internal functions on the `roleMedic` object.

💡 **Why:** By extracting segments of logic (such as managing healing vs gathering modes and target caching mechanisms) into named helper functions (e.g., `_updateState`, `_handleHealingMode`, `_getHealTarget`), the top-level `run` method is much clearer and the module as a whole is more maintainable.

✅ **Verification:** Verified by running the entire Jest test suite (`pnpm test`), passing all tests (including ensuring `tests/role.medic.test.js` covers the logic cleanly). Linting (`pnpm lint`) also returned without errors, enforcing syntax checks. 

✨ **Result:** The `run` logic is clean and compartmentalized without breaking behavior or altering runtime locations. Fixes #123

---
*PR created automatically by Jules for task [16746299755928333500](https://jules.google.com/task/16746299755928333500) started by @tadanobutubutu*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the medic role by splitting the complex `run` method into small helpers for state, healing, harvesting, and idling. Improves readability with no behavior change; fixes #123.

- **Refactors**
  - Extracted helpers: `_updateState`, `_handleHealingMode`, `_handleGatheringMode`, `_getHealTarget`, `_getHarvestTarget`, `_performHeal`, `_idle`.
  - Preserves target ID caching and room caches (`room._injuredCreeps`, `room._activeSources`) for performance.
  - Verified via test suite and linting.

<sup>Written for commit 89fc91eab7f8a38a8ddedcf970d5a89a9c46e649. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/526?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

