### PR TITLE
🧪 [testing improvement] Add tests for getBody function in miner role

### DIFF
--- a/pr_title_body.txt
+++ b/pr_title_body.txt
@@ -1,11 +1,5 @@
-🧹 Code Health: Refactor categorizeRoomStructures to use helper functions
+🧪 [testing improvement] Add tests for getBody function in miner role
 
-🎯 **What:** The  function in  was too long and complex. It was refactored by breaking down the loop contents into smaller, distinct helper functions: , , and .
-
-💡 **Why:** This improves maintainability and readability by keeping the core loop clean and moving specific logic into clearly named functions.
-
-✅ **Verification:** Verified changes visually with  and ran the full test suite via
-> screeps-ai@1.0.0 test /app
-> jest and formatting via main.js 186ms (unchanged). Pre-commit checks (including ESLint) all pass.
-
-✨ **Result:** The  function is now cleaner, smaller, and easier to understand, without introducing any changes in behavior.
+🎯 **What:** The `getBody` function in `src/roles/miner.js` lacked test coverage despite being a pure and deterministic function. The testing gap is now addressed.
+📊 **Coverage:** Added tests to cover all 5 boundaries/conditions based on `energy` amounts: 650+, 550+, 450+, 250+, and <250. This guarantees the correct body arrays are returned correctly.
+✨ **Result:** Test coverage for `getBody` function in `miner.js` is now at 100%.

--- a/tests/src.roles.miner.test.js
+++ b/tests/src.roles.miner.test.js
@@ -2,6 +2,7 @@
  * src/roles/miner.js のユニットテスト
  */
 
+global.LOG_LEVEL = { ERROR: 1, WARN: 2, INFO: 3, DEBUG: 4 };
 global.Game = { creeps: {} };
 global.Memory = {};
 global.WORK = 'work';
@@ -29,7 +30,7 @@ global.RoomPosition = function (x, y, roomName) {
 };
 
 const mockCache = {
-    getSources: jest.fn(),
+    getSources: jest.fn().mockReturnValue([]),
     getContainers: jest.fn(),
     isSafeKey: jest.fn().mockReturnValue(true),
 };
@@ -245,5 +246,52 @@ describe('src/roles/miner', () => {
         miner.run(creep);
 
         expect(logger.error).toHaveBeenCalledWith(`[${creep.name}] マイナーエラー`, error);
+    });
+
+    describe('getBody', () => {
+        test('エネルギー650以上の場合、完全最適化ボディを返す', () => {
+            const expected = [
+                global.WORK,
+                global.WORK,
+                global.WORK,
+                global.WORK,
+                global.WORK,
+                global.CARRY,
+                global.MOVE,
+            ];
+            expect(miner.getBody(650)).toEqual(expected);
+            expect(miner.getBody(700)).toEqual(expected);
+        });
+
+        test('エネルギー550以上650未満の場合、WORK4つのボディを返す', () => {
+            const expected = [
+                global.WORK,
+                global.WORK,
+                global.WORK,
+                global.WORK,
+                global.CARRY,
+                global.MOVE,
+            ];
+            expect(miner.getBody(550)).toEqual(expected);
+            expect(miner.getBody(649)).toEqual(expected);
+        });
+
+        test('エネルギー450以上550未満の場合、WORK3つのボディを返す', () => {
+            const expected = [global.WORK, global.WORK, global.WORK, global.CARRY, global.MOVE];
+            expect(miner.getBody(450)).toEqual(expected);
+            expect(miner.getBody(549)).toEqual(expected);
+        });
+
+        test('エネルギー250以上450未満の場合、WORK2つのボディを返す', () => {
+            const expected = [global.WORK, global.WORK, global.MOVE];
+            expect(miner.getBody(250)).toEqual(expected);
+            expect(miner.getBody(449)).toEqual(expected);
+        });
+
+        test('エネルギー250未満の場合、最小ボディを返す', () => {
+            const expected = [global.WORK, global.MOVE];
+            expect(miner.getBody(200)).toEqual(expected);
+            expect(miner.getBody(249)).toEqual(expected);
+        });
     });
 });


### PR DESCRIPTION
🎯 **What:** The `getBody` function in `src/roles/miner.js` lacked test coverage despite being a pure and deterministic function. The testing gap is now addressed.
📊 **Coverage:** Added tests to cover all 5 boundaries/conditions based on `energy` amounts: 650+, 550+, 450+, 250+, and <250. This guarantees the correct body arrays are returned correctly.
✨ **Result:** Test coverage for `getBody` function in `miner.js` is now at 100%.

---
*PR created automatically by Jules for task [967526577004322878](https://jules.google.com/task/967526577004322878) started by @tadanobutubutu*

## Summary by Sourcery

Improve test coverage for the miner role by adding unit tests for the getBody function and adjusting test scaffolding.

Tests:
- Add unit tests covering all energy boundary conditions for miner.getBody to validate returned body configurations.
- Initialize global LOG_LEVEL and default mockCache.getSources return value in the miner test setup to stabilize tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `getBody` in `src/roles/miner.js`, covering all energy thresholds (>=650, >=550, >=450, >=250, <250) to verify the returned body arrays; closes #123. Tests set default `LOG_LEVEL` and mock cache sources for deterministic results.

<sup>Written for commit ad7cc180d6a0e4b12cc1a20d30406c1ef2dc6f76. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/529?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

