### PR TITLE
🧪 [testing improvement] Cover getTowersNeedingEnergy in towerManager

### DIFF
--- a/tests/src.roles.miner.test.js
+++ b/tests/src.roles.miner.test.js
@@ -20,6 +20,7 @@ global.ERR_NOT_IN_RANGE = -9;
 global.ERR_NOT_ENOUGH_ENERGY = -6;
 global.RESOURCE_ENERGY = 'energy';
 global.OK = 0;
+global.LOG_LEVEL = { DEBUG: 0, INFO: 1, WARN: 2, ERROR: 3, NONE: 4 };
 global.RoomPosition = function (x, y, roomName) {
     this.x = x;
     this.y = y;

--- a/tests/towerManager.test.js
+++ b/tests/towerManager.test.js
@@ -171,4 +171,55 @@ describe('towerManager', () => {
             expect(mockTower.attack).not.toHaveBeenCalled();
         });
     });
+
+    describe('getTowersNeedingEnergy', () => {
+        test('エネルギー比率が閾値未満のタワーを返す', () => {
+            const lowEnergyTower = {
+                id: 'tower_low',
+                store: {
+                    [global.RESOURCE_ENERGY]: 400,
+                    getCapacity: () => 1000,
+                },
+            };
+            const highEnergyTower = {
+                id: 'tower_high',
+                store: {
+                    [global.RESOURCE_ENERGY]: 600,
+                    getCapacity: () => 1000,
+                },
+            };
+            cache.getMyStructures.mockReturnValue([lowEnergyTower, highEnergyTower]);
+
+            const result = towerManager.getTowersNeedingEnergy(mockRoom);
+            expect(result).toHaveLength(1);
+            expect(result[0].id).toBe('tower_low');
+        });
+
+        test('すべてのタワーのエネルギー比率が閾値以上の場合は空配列を返す', () => {
+            const highEnergyTower1 = {
+                id: 'tower_high1',
+                store: {
+                    [global.RESOURCE_ENERGY]: 500,
+                    getCapacity: () => 1000,
+                },
+            };
+            const highEnergyTower2 = {
+                id: 'tower_high2',
+                store: {
+                    [global.RESOURCE_ENERGY]: 600,
+                    getCapacity: () => 1000,
+                },
+            };
+            cache.getMyStructures.mockReturnValue([highEnergyTower1, highEnergyTower2]);
+
+            const result = towerManager.getTowersNeedingEnergy(mockRoom);
+            expect(result).toHaveLength(0);
+        });
+
+        test('タワーが存在しない場合は空配列を返す', () => {
+            cache.getMyStructures.mockReturnValue([]);
+            const result = towerManager.getTowersNeedingEnergy(mockRoom);
+            expect(result).toHaveLength(0);
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `getTowersNeedingEnergy` function in `src/managers/towerManager.js` was previously untested. This function checks the energy ratio of towers and returns a list of towers that are below a certain threshold (`TOWER_ENERGY_PRIORITY`).

📊 **Coverage:** What scenarios are now tested
- Returning towers that have an energy ratio below the `TOWER_ENERGY_PRIORITY` threshold.
- Filtering out towers that have an energy ratio equal to or above the threshold.
- Returning an empty array when there are no towers in the room.

✨ **Result:** The improvement in test coverage
The test coverage for `towerManager.js` has been increased, ensuring that any future changes to energy requirements logic can be made safely without regressions.

---
*PR created automatically by Jules for task [5792576015861562849](https://jules.google.com/task/5792576015861562849) started by @tadanobutubutu*

## Summary by Sourcery

Add tests for towerManager energy handling and stabilize miner role tests by defining missing globals.

Tests:
- Add unit tests for getTowersNeedingEnergy to cover low-energy, sufficient-energy, and no-tower scenarios.
- Define global LOG_LEVEL in miner role tests to prevent undefined global errors during test execution.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `towerManager.getTowersNeedingEnergy` covering towers below threshold, at/above threshold, and no-tower cases. Also define `global.LOG_LEVEL` in miner tests to stabilize the test environment and prevent undefined errors.

<sup>Written for commit 34336ceca74138e2f97f19b1a6a8f0543c3fab34. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/530?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

