### PR TITLE
🛡️ Sentinel: Dashboard Data Minimization and Hardening

### DIFF
--- a/dashboard/app/api/collect/route.ts
+++ b/dashboard/app/api/collect/route.ts
@@ -79,7 +79,12 @@ export async function GET(request: Request) {
       },
       power: Number(data.power) || 0,
       cpuUsed: Number(data.cpuUsed) || 0,
-      rooms: data.rooms && typeof data.rooms === "object" ? data.rooms : {},
+      // Security: Data minimization - only return room names as an array, limited to 100 entries.
+      // We don't need the full room objects which might contain sensitive metadata.
+      rooms:
+        data.rooms && typeof data.rooms === "object"
+          ? Object.keys(data.rooms).slice(0, 100)
+          : [],
     };
 
     if (supabase) {

--- a/dashboard/app/api/screeps/route.ts
+++ b/dashboard/app/api/screeps/route.ts
@@ -74,7 +74,12 @@ export async function GET(request: Request) {
         : undefined,
       power: Number(data.power) || 0,
       cpuUsed: Number(data.cpuUsed) || 0,
-      rooms: (data.rooms && typeof data.rooms === 'object') ? data.rooms : {},
+      // Security: Data minimization - only return room names as an array, limited to 100 entries.
+      // We don't need the full room objects which might contain sensitive metadata.
+      rooms:
+        data.rooms && typeof data.rooms === 'object'
+          ? Object.keys(data.rooms).slice(0, 100)
+          : [],
     };
 
     return NextResponse.json(filteredData);

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -6,7 +6,7 @@ type ScreepsStats = {
     power?: number;
     cpuUsed?: number;
     gcl?: { level: number; progress: number; progressTotal: number };
-    rooms?: Record<string, unknown>;
+    rooms?: string[] | Record<string, unknown>;
 };
 
 export default function Dashboard() {
@@ -30,8 +30,16 @@ export default function Dashboard() {
     const [summaryCopied, setSummaryCopied] = useState(false);
     const [isSummaryFocused, setIsSummaryFocused] = useState(false);
 
-    const roomCount = stats?.rooms ? Object.keys(stats.rooms).length : 0;
-    const prevRoomCount = prevStats?.rooms ? Object.keys(prevStats.rooms).length : 0;
+    const roomCount = stats?.rooms
+        ? Array.isArray(stats.rooms)
+            ? stats.rooms.length
+            : Object.keys(stats.rooms).length
+        : 0;
+    const prevRoomCount = prevStats?.rooms
+        ? Array.isArray(prevStats.rooms)
+            ? prevStats.rooms.length
+            : Object.keys(prevStats.rooms).length
+        : 0;
     const roomDelta = prevStats ? roomCount - prevRoomCount : 0;
 
     const gclPercent = stats?.gcl

--- a/tests/sentinel_dashboard_hardening.test.js
+++ b/tests/sentinel_dashboard_hardening.test.js
@@ -16,7 +16,11 @@ describe('Dashboard API Hardening', () => {
                 : undefined,
             power: Number(data.power) || 0,
             cpuUsed: Number(data.cpuUsed) || 0,
-            rooms: data.rooms && typeof data.rooms === 'object' ? data.rooms : {},
+            // Security: Data minimization - only return room names as an array, limited to 100 entries.
+            rooms:
+                data.rooms && typeof data.rooms === 'object'
+                    ? Object.keys(data.rooms).slice(0, 100)
+                    : [],
         };
     };
 
@@ -29,7 +33,10 @@ describe('Dashboard API Hardening', () => {
             },
             power: 100,
             cpuUsed: 15.5,
-            rooms: ['W1N1', 'W1N2'],
+            rooms: {
+                W1N1: { status: 'ok' },
+                W1N2: { status: 'ok' },
+            },
             email: 'user@example.com', // Sensitive PII
             id: '5f9b3a2b1c', // Internal ID
             token: 'secret_session_token', // Sensitive token
@@ -45,6 +52,7 @@ describe('Dashboard API Hardening', () => {
         });
         expect(result.power).toBe(100);
         expect(result.cpuUsed).toBe(15.5);
+        // Verify rooms is now an array of keys
         expect(result.rooms).toEqual(['W1N1', 'W1N2']);
 
         // Verify sensitive fields are removed
@@ -63,7 +71,7 @@ describe('Dashboard API Hardening', () => {
             },
             power: '100px',
             // cpuUsed missing
-            rooms: { W1N1: {} }, // Not an array
+            rooms: { W1N1: {} },
         };
 
         const result = filterScreepsResponse(malformedResponse);
@@ -75,7 +83,8 @@ describe('Dashboard API Hardening', () => {
         });
         expect(result.power).toBe(0); // NaN becomes 0
         expect(result.cpuUsed).toBe(0);
-        expect(result.rooms).toEqual({ W1N1: {} });
+        // Verify rooms is an array containing the key
+        expect(result.rooms).toEqual(['W1N1']);
     });
 
     test('should handle completely empty response', () => {
@@ -84,6 +93,19 @@ describe('Dashboard API Hardening', () => {
         expect(result.gcl).toBeUndefined();
         expect(result.power).toBe(0);
         expect(result.cpuUsed).toBe(0);
-        expect(result.rooms).toEqual({});
+        expect(result.rooms).toEqual([]);
+    });
+
+    test('should limit rooms array to 100 entries', () => {
+        const manyRooms = {};
+        for (let i = 0; i < 150; i++) {
+            manyRooms[`W${i}N${i}`] = { foo: 'bar' };
+        }
+
+        const result = filterScreepsResponse({ rooms: manyRooms });
+
+        expect(Array.isArray(result.rooms)).toBe(true);
+        expect(result.rooms.length).toBe(100);
+        expect(result.rooms[0]).toBe('W0N0');
     });
 });


### PR DESCRIPTION
### 🛡️ Sentinel: Data Minimization for Dashboard Room Stats

🚨 **Severity:** MEDIUM (Security Enhancement)

💡 **Vulnerability:** Unfiltered data exposure. Previously, the dashboard API routes returned the entire `rooms` object from the Screeps API, which could potentially contain sensitive metadata or internal state not required by the dashboard.

🎯 **Impact:** Potential leakage of non-public room information and resource exhaustion if a user has an extremely large number of rooms.

🔧 **Fix:**
- Implemented **Data Minimization** by transforming the `rooms` object into a simple array of room names (keys).
- Added a **Resource Limit** of 100 rooms per response.
- Updated the frontend `Dashboard.tsx` component to handle both the new array format and legacy object format for robust rendering.

✅ **Verification:**
- Successfully ran `pnpm test tests/sentinel_dashboard_hardening.test.js` (all tests passed).
- Successfully ran the full test suite (`pnpm test`).
- Verified dashboard build compatibility with `pnpm build`.
- Visually inspected the dashboard component structure.

---
*PR created automatically by Jules for task [2649149002855493438](https://jules.google.com/task/2649149002855493438) started by @tadanobutubutu*

## Summary by Sourcery

Harden the dashboard Screeps stats APIs by minimizing and constraining room data returned to the frontend while keeping the dashboard compatible with both old and new response formats.

Bug Fixes:
- Prevent potential exposure of full Screeps room objects by returning only room names from dashboard-related API responses.
- Guard against excessive payload sizes by limiting the number of room entries returned to 100.

Enhancements:
- Update the dashboard component to handle room data as either an array of names or a legacy room object and correctly compute room counts in both formats.

Tests:
- Extend dashboard hardening tests to validate room key extraction, array-based format, empty responses, and enforcement of the 100-room limit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Minimized dashboard API room data by returning only room names as an array with a 100-room cap to reduce sensitive exposure and heavy responses. Updated `Dashboard.tsx` to support the new array format and legacy object format; tests verify the limit and shape.

- **Migration**
  - API `rooms` is now a `string[]` of room names (max 100). Update any external clients that expect full room objects.
  - No changes needed for the dashboard; it handles both formats.

<sup>Written for commit f134f1999a48eec9aa3aa3b217210f900fa36073. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/533?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

