### PR TITLE
🎨 Palette: Improve dashboard interactivity and feedback consistency

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+# Palette Journal - Critical UX Learnings
+
+This journal tracks critical UX and accessibility learnings from working on the Screeps AI codebase.
+
+## 2025-05-27 - Improving Discoverability of Interactive Status Indicators
+**Learning:** Status indicators that also serve as triggers for actions (like "Last Sync" triggering a refresh) are often perceived as static text by users and screen readers if they lack proper semantic roles and visual cues.
+**Action:** Always use semantic elements (or appropriate ARIA roles), `cursor: pointer`, and clear focus indicators (like consistent focus rings) for any status display that allows user interaction.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -29,6 +29,8 @@ export default function Dashboard() {
     const [roomCopied, setRoomCopied] = useState(false);
     const [summaryCopied, setSummaryCopied] = useState(false);
     const [isSummaryFocused, setIsSummaryFocused] = useState(false);
+    const [isRoomFocused, setIsRoomFocused] = useState(false);
+    const [isSyncFocused, setIsSyncFocused] = useState(false);
 
     const roomCount = stats?.rooms
         ? Array.isArray(stats.rooms)
@@ -54,6 +56,14 @@ export default function Dashboard() {
         : stats?.gcl && prevStats?.gcl
           ? gclPercent - prevGclPercent
           : 0;
+
+    const absoluteXpGain =
+        stats?.gcl && prevStats?.gcl
+            ? leveledUp
+                ? prevStats.gcl.progressTotal - prevStats.gcl.progress + stats.gcl.progress
+                : stats.gcl.progress - prevStats.gcl.progress
+            : 0;
+
     const powerDelta =
         stats?.power !== undefined && prevStats?.power !== undefined
             ? stats.power - prevStats.power
@@ -454,6 +464,8 @@ export default function Dashboard() {
                     {stats?.rooms && (
                         <button
                             onClick={handleCopyRooms}
+                            onFocus={() => setIsRoomFocused(true)}
+                            onBlur={() => setIsRoomFocused(false)}
                             className="interactive-hint"
                             style={{
                                 fontSize: '0.9rem',
@@ -468,6 +480,10 @@ export default function Dashboard() {
                                 cursor: 'pointer',
                                 transition: 'all 0.2s ease-in-out',
                                 animation: roomCopied ? 'bounce 0.6s ease' : 'none',
+                                boxShadow: isRoomFocused
+                                    ? `0 0 0 2px #ffffff, 0 0 0 4px ${roomCopied ? '#1e7e34' : '#006699'}`
+                                    : 'none',
+                                outline: 'none',
                             }}
                             aria-label={
                                 roomCopied
@@ -517,18 +533,30 @@ export default function Dashboard() {
                         </button>
                     )}
                     {lastUpdated && (
-                        <span
+                        <button
+                            onClick={() => fetchStats(true)}
+                            onFocus={() => setIsSyncFocused(true)}
+                            onBlur={() => setIsSyncFocused(false)}
                             className="interactive-hint"
                             style={{
                                 fontSize: '0.8rem',
                                 color: getStalenessInfo().color,
+                                background: 'transparent',
+                                border: 'none',
+                                borderRadius: '4px',
+                                padding: '0.2rem 0.4rem',
                                 display: 'flex',
                                 alignItems: 'center',
                                 gap: '0.25rem',
+                                cursor: 'pointer',
+                                transition: 'all 0.2s ease-in-out',
+                                boxShadow: isSyncFocused
+                                    ? `0 0 0 2px #ffffff, 0 0 0 4px ${getStalenessInfo().color}`
+                                    : 'none',
+                                outline: 'none',
                             }}
-                            aria-label={`Last sync: ${timeAgo} (${getStalenessInfo().label}). Exact time: ${lastUpdated.toLocaleString()}`}
-                            title={lastUpdated.toLocaleString()}
-                            tabIndex={0}
+                            aria-label={`Last sync: ${timeAgo} (${getStalenessInfo().label}). Click to refresh. Exact time: ${lastUpdated.toLocaleString()}`}
+                            title={`Click to refresh (R). Exact time: ${lastUpdated.toLocaleString()}`}
                         >
                             <span
                                 role="img"
@@ -543,7 +571,7 @@ export default function Dashboard() {
                                 {getStalenessInfo().icon}
                             </span>
                             Last sync: <time dateTime={lastUpdated?.toISOString()}>{timeAgo}</time>
-                        </span>
+                        </button>
                     )}
                     <button
                         onClick={handleResetSecret}
@@ -1061,7 +1089,8 @@ export default function Dashboard() {
                                                         : 'shake 0.3s 3',
                                             }}
                                             title="Progress gained since last update"
-                                            aria-label={`${gclDelta > 0 ? 'Increased' : 'Decreased'} by ${Math.abs(gclDelta).toFixed(2)}%`}
+                                            aria-label={`${gclDelta > 0 ? 'Increased' : 'Decreased'} by ${Math.abs(gclDelta).toFixed(2)}% (${absoluteXpGain.toLocaleString()} XP)`}
+                                            title={`Progress gained since last update: ${absoluteXpGain.toLocaleString()} XP`}
                                         >
                                             ({gclDelta > 0 ? '+' : ''}
                                             {gclDelta.toFixed(2)}%)
@@ -1078,8 +1107,8 @@ export default function Dashboard() {
                                 aria-valuenow={Number(gclPercent.toFixed(2))}
                                 aria-valuemin={0}
                                 aria-valuemax={100}
-                                aria-valuetext={`${gclPercent.toFixed(2)}% complete${predictedPercent > 0 ? ` (+${predictedPercent.toFixed(2)}% forecast/h)` : ''}, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}`}
-                                title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}${predictedPercent > 0 ? `\nForecast: +${predictedPercent.toFixed(2)}% in 1h` : ''}`}
+                                aria-valuetext={`${gclPercent.toFixed(2)}% complete${predictedPercent > 0 ? ` (+${predictedPercent.toFixed(2)}% forecast/h)` : ''}, ${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}${absoluteXpGain > 0 ? ` (+${absoluteXpGain.toLocaleString()} XP recently)` : ''}`}
+                                title={`${(stats.gcl.progressTotal - stats.gcl.progress).toLocaleString()} XP remaining to level ${stats.gcl.level + 1}${formattedXpPerHour ? ` (${formattedXpPerHour})` : ''}${timeToLevel ? ` (est. ${formatDuration(timeToLevel)} to go)` : ''}${predictedPercent > 0 ? `\nForecast: +${predictedPercent.toFixed(2)}% in 1h` : ''}${absoluteXpGain > 0 ? `\nRecent gain: +${absoluteXpGain.toLocaleString()} XP` : ''}`}
                                 style={{
                                     width: '100%',
                                     height: '12px',


### PR DESCRIPTION
💡 What: This PR improves the interactivity and information density of the Screeps Dashboard.
- Converts the static "Last sync" display into a clickable button to refresh stats.
- Adds focus handling and visual focus rings to interactive elements.
- Enhances GCL progress feedback by showing absolute XP gain since the last update.

🎯 Why: To make the dashboard more intuitive for power users and more accessible for screen reader and keyboard users.

♿ Accessibility: Added ARIA labels, roles, and focus indicators to ensure all interactive elements are discoverable and usable.

---
*PR created automatically by Jules for task [4825824510074369941](https://jules.google.com/task/4825824510074369941) started by @tadanobutubutu*

## Summary by Sourcery

Improve dashboard interactivity and accessibility for status indicators and GCL progress feedback.

New Features:
- Allow the Last sync status indicator to trigger a stats refresh when clicked.
- Surface absolute GCL XP gain since the previous update in the progress feedback.

Enhancements:
- Add keyboard focus handling and visible focus rings to room copy and sync controls for better discoverability.
- Refine ARIA labels and titles on GCL progress elements to include recent XP gain context.

Documentation:
- Introduce a Palette UX journal documenting accessibility and interaction design learnings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Screeps Dashboard more interactive and accessible by turning “Last sync” into a refresh button, adding consistent focus states, and showing absolute GCL XP gains. This improves discoverability for keyboard and screen reader users and gives clearer progress feedback.

- New Features
  - “Last sync” is now a button that refreshes stats, with clear title and ARIA text.
  - Visible focus rings and focus handling for Rooms copy and Last Sync controls.
  - GCL progress shows absolute XP gained since last update in labels and tooltips.
  - Added a palette journal entry (`.jules/palette.md`) documenting the interactive status pattern.

<sup>Written for commit aae5ced5765a952eb13697e199ba034db8b3b69e. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/535?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added accessibility best practices documentation covering interactive status indicators.

* **Bug Fixes**
  * Improved keyboard navigation with enhanced focus indicators on dashboard controls.
  * Enhanced screen reader support by including XP gain details in progress bar announcements.
  * Improved sync/refresh control with better accessibility labels and semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tadanobutubutu/screeps/pull/535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->