### PR TITLE
🛡️ Sentinel: Redact absolute paths from stack trace error messages

### DIFF
--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -309,7 +309,14 @@ function getSafeStack(stack, maxLines) {
     const lines = truncatedStack.split('\n');
     return lines
         .slice(0, maxLines || 5)
-        .map((line) => {
+        .map((line, index) => {
+            // Security: The first line often contains the error message, which may
+            // include internal paths (e.g., "Error: Cannot find module '/abs/path'").
+            // We redact absolute-looking paths from the message to prevent leakage.
+            if (index === 0) {
+                return line.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+            }
+
             // Match "filename:line:col" at the end of a path segment.
             // Uses a simple non-backtracking pattern to avoid ReDoS.
             const match = line.match(/[^/\\]+:\d+:\d+/);

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -119,7 +119,14 @@ module.exports = {
         return truncatedStack
             .split('\n')
             .slice(0, 5) // Security: Limit number of lines to prevent DoS
-            .map((line) => {
+            .map((line, index) => {
+                // Security: The first line often contains the error message, which may
+                // include internal paths (e.g., "Error: Cannot find module '/abs/path'").
+                // We redact absolute-looking paths from the message to prevent leakage.
+                if (index === 0) {
+                    return line.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+                }
+
                 // Match "filename:line:col" at the end of a path segment.
                 // Uses a simple non-backtracking pattern: match the last
                 // path component only, without nested quantifiers.


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Information Disclosure (Internal Path Leakage)
🎯 Impact: Absolute filesystem paths (Unix and Windows) could be leaked in logs through error messages in stack traces. This reveals the internal directory structure of the environment where the Screeps AI is running.
🔧 Fix: Updated `getSafeStack` in both logging modules (`src/utils/logger.js` and `utils.logging.js`) to redact absolute-looking paths from the first line of the stack trace using a non-backtracking regular expression.
✅ Verification: Created a reproduction test case that confirmed absolute paths are replaced with `[REDACTED]`. Verified that existing logging unit tests still pass.

---
*PR created automatically by Jules for task [14804987298249017641](https://jules.google.com/task/14804987298249017641) started by @tadanobutubutu*

## Summary by Sourcery

Bug Fixes:
- Prevent leakage of internal absolute paths in the first line of stack trace error messages by redacting path-like substrings in both logging utilities.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts absolute filesystem paths from the first line of stack traces to prevent leaking internal directory structure in logs. Updates `getSafeStack` in both logger utilities with a safe, non-backtracking regex.

- **Bug Fixes**
  - Replace absolute-looking Unix/Windows paths in the first stack line with "[REDACTED]" while keeping frame parsing intact.
  - Verified with a reproduction test; existing logging tests still pass.

<sup>Written for commit c6de127f09f83ae9fc417b23076091ec2faa0ea8. Summary will update on new commits. <a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/536?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

