### PR TITLE
🎨 Palette: Make JSON stats block clickable to copy

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -1088,7 +1088,6 @@ export default function Dashboard() {
                                                         ? 'bounce 0.6s ease'
                                                         : 'shake 0.3s 3',
                                             }}
-                                            title="Progress gained since last update"
                                             aria-label={`${gclDelta > 0 ? 'Increased' : 'Decreased'} by ${Math.abs(gclDelta).toFixed(2)}% (${absoluteXpGain.toLocaleString()} XP)`}
                                             title={`Progress gained since last update: ${absoluteXpGain.toLocaleString()} XP`}
                                         >
@@ -1279,19 +1278,29 @@ export default function Dashboard() {
                                 {copied ? '✅ Copied!' : '📋 Copy JSON'}
                             </button>
                         </div>
+                        {/* 🎨 Palette: JSONブロックをクリック可能にし、コピー体験を向上させる */}
                         <pre
-                            aria-label="Screeps statistics JSON. Press 'C' to copy."
+                            onClick={handleCopy}
+                            onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && handleCopy()}
+                            aria-label={
+                                copied
+                                    ? 'Stats copied!'
+                                    : "Screeps statistics JSON. Click or press 'C' to copy."
+                            }
                             className="interactive-hint"
-                            title="Screeps statistics JSON (C to copy)"
+                            title={
+                                copied ? 'Copied!' : 'Screeps statistics JSON (Click or C to copy)'
+                            }
                             tabIndex={0}
                             style={{
-                                background: '#f8f8f8',
+                                background: copied ? '#e8f5e9' : '#f8f8f8',
                                 padding: '1rem',
                                 borderRadius: '4px',
                                 overflow: 'auto',
                                 maxHeight: '500px',
                                 margin: 0,
-                                border: '1px solid #eee',
+                                border: copied ? '1px solid #1e7e34' : '1px solid #eee',
+                                transition: 'all 0.2s ease-in-out',
                             }}
                         >
                             {JSON.stringify(stats, null, 2)}


### PR DESCRIPTION
### 💡 What
This PR enhances the Screeps Dashboard by making the raw JSON statistics block interactive. Users can now click directly on the JSON data to copy it to their clipboard.

### 🎯 Why
Previously, users had to click a small "Copy JSON" button at the top right of the data block. Making the entire block clickable follows modern UX patterns for code/data snippets, improving discoverability and ease of use, especially on mobile or for power users.

### ♿ Accessibility
- Added `onKeyDown` support for `Enter` and `Space` keys to allow keyboard users to trigger the copy action.
- Updated `aria-label` and `title` to explicitly mention "Click to copy".
- The `aria-label` dynamically updates to "Stats copied!" to provide screen reader feedback.

### 🛠️ Technical Changes
- Added `onClick` and `onKeyDown` handlers to the `<pre>` element.
- Implemented dynamic styling for the background (`#e8f5e9`) and border (`#1e7e34`) when the `copied` state is active.
- Fixed a duplicate `title` attribute on the GCL progress delta span that was causing build failures.
- Adhered to project guidelines by adding comments in Japanese.

---
*PR created automatically by Jules for task [2903081046167699329](https://jules.google.com/task/2903081046167699329) started by @tadanobutubutu*

## Summary by Sourcery

Make the JSON statistics block directly interactive for copying and clean up a duplicate title attribute causing build issues.

New Features:
- Allow clicking anywhere on the JSON statistics block, as well as using keyboard interaction, to trigger copying to the clipboard.
- Provide dynamic visual and accessible text feedback when the JSON statistics block has been copied.

Bug Fixes:
- Remove a duplicate title attribute on the GCL progress delta element to resolve build failures.