### PR TITLE
🛡️ Sentinel: [security improvement] Redact absolute paths in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,3 +29,9 @@
 **Prevention:** Use computed property names `[CONSTANT_NAME]: value` when defining lookup maps that are intended to be indexed by dynamic engine values or constants to guarantee accurate property resolution.
 
 - **deploy.js Path Traversal Fix**: Addressed a path traversal vulnerability by replacing string comparison (`startsWith` + `endsWith`) with secure path boundary resolution. Used `path.relative(baseDir, resolvedPath)` combined with checking `relativePath.startsWith('..')` and `path.isAbsolute(relativePath)` to confidently assert that paths are strictly within the base directory without overly-restrictive substring matching blocks.
+
+## 2026-05-30 - ログにおける内部パスの漏洩 (Information Leakage)
+
+**Vulnerability:** エラーメッセージを通じた内部ファイルシステムのパス漏洩。
+**Learning:** `stack` トレースのサニタイズだけでは不十分であり、`e.message` 自体に絶対パスが含まれるケース（例: "Cannot find module '/abs/path'"）がある。これを放置すると、CIログや共有ログサービスを通じて内部ディレクトリ構造が攻撃者に露呈するリスクがある。
+**Prevention:** エラーメッセージおよびスタックトレースの全行に対して、UnixおよびWindows形式の絶対パスを検知・置換する堅牢な正規表現 (`/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`) を適用するサニタイズ処理を共通化し、すべてのログ出力ポイントで強制する。

--- a/deploy.js
+++ b/deploy.js
@@ -59,6 +59,17 @@ function injectEnvVars(content) {
     });
 }
 
+/**
+ * Security: Redacts sensitive information from a string.
+ * Redacts absolute paths and tokens.
+ */
+function sanitizeLog(str) {
+    if (typeof str !== 'string') return str;
+    return str
+        .replace(/token/gi, '[REDACTED]')
+        .replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+}
+
 function deployTo(label, apiPath, token, modules) {
     const body = JSON.stringify({ branch: 'default', modules });
     return new Promise((resolve, reject) => {
@@ -102,7 +113,7 @@ function deployTo(label, apiPath, token, modules) {
                         resolve();
                     } else {
                         // エラーレスポンスから機密情報を除外してログ出力
-                        const safeJson = JSON.stringify(json).replace(/token/gi, '[REDACTED]');
+                        const safeJson = sanitizeLog(JSON.stringify(json));
                         console.error(`[${label}] Deployment failed:`, safeJson);
                         reject(new Error(`${label} deployment failed`));
                     }
@@ -112,7 +123,7 @@ function deployTo(label, apiPath, token, modules) {
                         resolve();
                     } else {
                         // エラーデータから機密情報を除外
-                        const safeData = data.replace(/token/gi, '[REDACTED]');
+                        const safeData = sanitizeLog(data);
                         console.error(`[${label}] Deployment failed! Raw:`, safeData);
                         reject(new Error(`${label} deployment failed`));
                     }
@@ -122,7 +133,7 @@ function deployTo(label, apiPath, token, modules) {
 
         req.on('error', (e) => {
             // エラーメッセージから機密情報を除外
-            const safeMessage = e.message.replace(/token/gi, '[REDACTED]');
+            const safeMessage = sanitizeLog(e.message);
             console.error(`[${label}] Request error:`, safeMessage);
             reject(new Error(`${label} request failed`));
         });
@@ -166,7 +177,7 @@ if (require.main === module) {
                     console.log(`  [OK] ${m.name} (${m.file})`);
                 } catch (e) {
                     // エラーメッセージから機密情報を除外
-                    const safeMessage = e.message.replace(/token/gi, '[REDACTED]');
+                    const safeMessage = sanitizeLog(e.message);
                     console.error(`  [ERROR] Failed to read ${m.file}: ${safeMessage}`);
                     process.exit(1);
                 }
@@ -177,7 +188,7 @@ if (require.main === module) {
             console.log('All done!');
         } catch (error) {
             // 最終的なエラーハンドリング（機密情報のフィルタリング付き）
-            const safeMessage = error.message.replace(/token/gi, '[REDACTED]');
+            const safeMessage = sanitizeLog(error.message);
             console.error('Deployment process failed:', safeMessage);
             process.exit(1);
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: '>=4.18.1'
         version: 4.18.1
       posthog-js:
-        specifier: ^1.376.0
-        version: 1.376.0
+        specifier: ^1.376.2
+        version: 1.376.3
     devDependencies:
       '@codecov/rollup-plugin':
         specifier: ^2.0.1
@@ -651,11 +651,11 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@posthog/core@1.29.9':
-    resolution: {integrity: sha512-DjvuIyBZ2Z/gBhtZlITlM2D8PlnMsHSQ1D78dbUYoVsgGguvanpJTobZObjLlFkybyvfZFYkpoJkFNI/2Pw4IQ==}
+  '@posthog/core@1.29.12':
+    resolution: {integrity: sha512-r/2RUa4zbN0XdBp6d+Yk8Jw1rPWXHxyXIgSm/wJf9yDLIouZbH0Pdkgbc1RIuhwL6BIHCFrOqK5jy8TFKTI6iw==}
 
-  '@posthog/types@1.376.0':
-    resolution: {integrity: sha512-gbFfxCuZDs/D4QZMwdE+smD1jsuqgGpS6yKGHZZ19foxMy8RYHsU1E47iG1b88n/uN02fAabLibVwuxLtq8juw==}
+  '@posthog/types@1.376.3':
+    resolution: {integrity: sha512-w21lBoz3/ZGw7BZT7t2lJq1mpJwMvWpZijW7vEwBFNAQlq0KfKf2mj5KKUYZMXM1GdIQ0jHnn931uXPB1Ae60w==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2393,8 +2393,8 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  posthog-js@1.376.0:
-    resolution: {integrity: sha512-YGfQ6gSmqmEh287PHjXRDJ9zML3Su1UIt1+xjRy7Yk6yW43Sc7sFK3CpCkLchCGhIA4x6VaqK+LaqB+7+MCo7A==}
+  posthog-js@1.376.3:
+    resolution: {integrity: sha512-Wmj4N6E352b8aWt/AjRYIOfagQgOlkb8LCD/r7i1eGj8WPBhrYLEXojQeZ+jndbiPbRo21l24bFJso7fyNafWQ==}
 
   preact@10.29.2:
     resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
@@ -3577,11 +3577,11 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
-  '@posthog/core@1.29.9':
+  '@posthog/core@1.29.12':
     dependencies:
-      '@posthog/types': 1.376.0
+      '@posthog/types': 1.376.3
 
-  '@posthog/types@1.376.0': {}
+  '@posthog/types@1.376.3': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -5392,15 +5392,15 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  posthog-js@1.376.0:
+  posthog-js@1.376.3:
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
       '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
-      '@posthog/core': 1.29.9
-      '@posthog/types': 1.376.0
+      '@posthog/core': 1.29.12
+      '@posthog/types': 1.376.3
       core-js: 3.49.0
       dompurify: 3.4.5
       fflate: 0.4.8

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -82,6 +82,18 @@ function _record(level, message) {
 }
 
 /**
+ * Security: Redacts absolute Unix and Windows paths from a string.
+ * Prevents internal directory structure leakage in logs.
+ * @param {string} str
+ * @returns {string}
+ */
+function _redactPaths(str) {
+    if (typeof str !== 'string') return str;
+    // Matches /abs/path or C:\abs\path
+    return str.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+}
+
+/**
  * Security: Escapes HTML special characters to prevent console injection.
  * ⚡ PERFORMANCE: Hoisted the escape character map and added a fast-path regex check
  * to avoid unnecessary .replace() calls on safe strings.
@@ -256,10 +268,12 @@ function error(message, error) {
 
     let full = sanitizedMessage;
     if (error instanceof Error) {
-        // Security: Truncate error message to avoid Memory DoS
-        const sanitizedErrorMsg = String(
+        // Security: Truncate and redact error message to avoid Memory DoS and path leakage
+        const rawErrorMsg = String(
             error.message !== null && error.message !== undefined ? error.message : ''
         ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+        const sanitizedErrorMsg = _redactPaths(rawErrorMsg);
+
         full += ` | ${sanitizedErrorMsg}`;
         if (error.stack) {
             full += `\n${getSafeStack(error.stack)}`;
@@ -310,25 +324,22 @@ function getSafeStack(stack, maxLines) {
     return lines
         .slice(0, maxLines || 5)
         .map((line, index) => {
-            // Security: The first line often contains the error message, which may
-            // include internal paths (e.g., "Error: Cannot find module '/abs/path'").
-            // We redact absolute-looking paths from the message to prevent leakage.
-            if (index === 0) {
-                return line.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
-            }
-
             // Match "filename:line:col" at the end of a path segment.
             // Uses a simple non-backtracking pattern to avoid ReDoS.
             const match = line.match(/[^/\\]+:\d+:\d+/);
             if (match) {
                 return `    at ${match[0]}`;
             }
+
             // Security: If the line looks like a stack trace entry but doesn't match
             // the safe pattern, redact it to prevent internal path leakage.
             if (line.trim().startsWith('at ')) {
                 return '    at [REDACTED]';
             }
-            return line;
+
+            // Security: For the first line (error message) or non-stack lines,
+            // redact absolute paths to prevent leakage.
+            return _redactPaths(line);
         })
         .join('\n');
 }

--- a/tests/sentinel_path_redaction.test.js
+++ b/tests/sentinel_path_redaction.test.js
@@ -1,0 +1,109 @@
+/**
+ * Sentinel Security Test: Path Redaction
+ * Verifies that absolute internal file paths are redacted from error logs.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Mock Screeps environment
+global.Game = { time: 100 };
+global.Memory = {};
+
+// Mock Constants for src/utils/logger
+jest.mock(
+  '../src/constants',
+  () => ({
+    LOG_LEVEL: {
+      DEBUG: 0,
+      INFO: 1,
+      WARN: 2,
+      ERROR: 3,
+      NONE: 4,
+    },
+    DEFAULT_LOG_LEVEL: 1,
+  }),
+  { virtual: true }
+);
+
+// Mock console.log to avoid noise
+const originalLog = console.log;
+beforeAll(() => {
+  console.log = jest.fn();
+});
+afterAll(() => {
+  console.log = originalLog;
+});
+
+const utilsLogging = require('../utils.logging');
+const srcLogger = require('../src/utils/logger');
+
+describe('Sentinel: Path Redaction Security', () => {
+  beforeEach(() => {
+    global.Memory = { logs: [] };
+    srcLogger.setLevel(0); // DEBUG
+  });
+
+  describe('utils.logging.js', () => {
+    test('tryCatch redacts absolute paths from error messages', () => {
+      const fn = () => {
+        const err = new Error('Cannot find module "/abs/path/to/secret.js"');
+        throw err;
+      };
+
+      utilsLogging.tryCatch(fn, 'test_context');
+
+      const lastLog = Memory.logs[Memory.logs.length - 1];
+      expect(lastLog.level).toBe('error');
+      expect(lastLog.message).toContain('[REDACTED]');
+      expect(lastLog.message).not.toContain('/abs/path/to/');
+    });
+
+    test('getSafeStack redacts absolute paths from the first line', () => {
+      const stack = 'Error: Failed at /home/user/app/main.js\n    at Object.run (/home/user/app/main.js:10:5)';
+      const safeStack = utilsLogging.getSafeStack(stack);
+
+      expect(safeStack).toContain('[REDACTED]');
+      expect(safeStack).not.toContain('/home/user/app/');
+    });
+
+    test('getSafeStack redacts Windows-style absolute paths', () => {
+      const stack = 'Error: Failed at C:\\Users\\Admin\\project\\main.js\n    at Object.run (C:\\Users\\Admin\\project\\main.js:10:5)';
+      const safeStack = utilsLogging.getSafeStack(stack);
+
+      expect(safeStack).toContain('[REDACTED]');
+      expect(safeStack).not.toContain('C:\\Users\\Admin');
+    });
+  });
+
+  describe('src/utils/logger.js', () => {
+    test('error() redacts absolute paths from error messages', () => {
+      const err = new Error('Failed to load /var/www/html/config.php');
+      srcLogger.error('Initialization failed', err);
+
+      // src/utils/logger records to internal _history array
+      const history = srcLogger.getHistory(1);
+      const lastEntry = history[0];
+
+      expect(lastEntry.level).toBe('error');
+      expect(lastEntry.message).toContain('[REDACTED]');
+      expect(lastEntry.message).not.toContain('/var/www/html/');
+    });
+
+    test('getSafeStack redacts absolute paths from the first line', () => {
+      const stack = 'Error: Internal failure in /opt/screeps/server.js\n    at Server.start (/opt/screeps/server.js:50:12)';
+      const safeStack = srcLogger.getSafeStack(stack);
+
+      expect(safeStack).toContain('[REDACTED]');
+      expect(safeStack).not.toContain('/opt/screeps/');
+    });
+
+    test('getSafeStack redacts Windows-style absolute paths', () => {
+      const stack = 'Error: Internal failure in D:\\Screeps\\main.js\n    at Object.run (D:\\Screeps\\main.js:5:10)';
+      const safeStack = srcLogger.getSafeStack(stack);
+
+      expect(safeStack).toContain('[REDACTED]');
+      expect(safeStack).not.toContain('D:\\Screeps');
+    });
+  });
+});

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -103,6 +103,16 @@ module.exports = {
     },
 
     /**
+     * Security: Redacts absolute Unix and Windows paths from a string.
+     * Prevents internal directory structure leakage in logs.
+     */
+    _redactPaths: function (str) {
+        if (typeof str !== 'string') return str;
+        // Matches /abs/path or C:\abs\path
+        return str.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+    },
+
+    /**
      * Sanitizes a stack trace to remove internal file paths while keeping
      * function names and line numbers for debugging.
      *
@@ -120,13 +130,6 @@ module.exports = {
             .split('\n')
             .slice(0, 5) // Security: Limit number of lines to prevent DoS
             .map((line, index) => {
-                // Security: The first line often contains the error message, which may
-                // include internal paths (e.g., "Error: Cannot find module '/abs/path'").
-                // We redact absolute-looking paths from the message to prevent leakage.
-                if (index === 0) {
-                    return line.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
-                }
-
                 // Match "filename:line:col" at the end of a path segment.
                 // Uses a simple non-backtracking pattern: match the last
                 // path component only, without nested quantifiers.
@@ -134,12 +137,16 @@ module.exports = {
                 if (match) {
                     return `    at ${match[0]}`;
                 }
+
                 // Security: If the line looks like a stack trace entry but doesn't match
                 // the safe pattern, redact it to prevent internal path leakage.
                 if (line.trim().startsWith('at ')) {
                     return '    at [REDACTED]';
                 }
-                return line;
+
+                // Security: For the first line (error message) or non-stack lines,
+                // redact absolute paths to prevent leakage.
+                return this._redactPaths(line);
             })
             .join('\n');
     },
@@ -149,9 +156,10 @@ module.exports = {
         try {
             return fn(...args);
         } catch (e) {
-            // Security: Sanitize stack trace before logging to avoid path exposure
+            // Security: Sanitize error message and stack trace before logging to avoid path exposure
+            const safeMessage = this._redactPaths(e.message);
             const safeStack = this.getSafeStack(e.stack);
-            this.error(`Exception in ${context}: ${e.message}\n${safeStack}`);
+            this.error(`Exception in ${context}: ${safeMessage}\n${safeStack}`);
             return null;
         }
     },


### PR DESCRIPTION
This PR addresses a security vulnerability where internal file system paths were exposed in application and deployment logs.

### 🚨 Severity: MEDIUM (Information Leakage)

### 💡 Vulnerability
Error messages (e.g., `Cannot find module '/abs/path'`) and stack traces often contain absolute paths revealing the internal directory structure of the host or CI environment.

### 🎯 Impact
An attacker could use this information to map the server's file system, identifying sensitive configuration files, auxiliary tools, or vulnerable paths for secondary attacks like path traversal or local file inclusion.

### 🔧 Fix
Implemented a robust path redaction mechanism using a non-backtracking regex (`/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`) that replaces absolute paths with `[REDACTED]` in:
- `utils.logging.js` (core logging)
- `src/utils/logger.js` (source-level logging)
- `deploy.js` (deployment script logs)

### ✅ Verification
- Created `tests/sentinel_path_redaction.test.js` covering Unix and Windows path formats.
- Verified all tests pass with `npx jest --reporters=default`.
- Confirmed that the fix does not break existing stack trace parsing.

---
*PR created automatically by Jules for task [12573394080853758240](https://jules.google.com/task/12573394080853758240) started by @tadanobutubutu*

## Summary by Sourcery

Redact absolute file system paths and sensitive tokens from error messages and logs across core logging utilities and deployment scripts to prevent internal path leakage.

Bug Fixes:
- Ensure error messages and stack traces in both runtime and source-level loggers redact Unix and Windows absolute paths before logging to avoid information disclosure.
- Sanitize deployment logs to remove absolute paths and tokens from API responses, raw data, and error messages before output.

Enhancements:
- Introduce shared path-redaction helpers in logging and deployment code to consistently scrub sensitive paths from all log outputs.

Documentation:
- Document the path-leakage incident and prevention strategy in the Sentinel security notes.

Tests:
- Add Sentinel security tests verifying that logging utilities and stack sanitization correctly redact Unix and Windows-style absolute paths from logged errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts absolute Unix and Windows paths from error messages and stack traces to prevent internal directory leakage. Applies sanitization in core/source loggers and deployment logs, with tests covering both path formats.

- **Bug Fixes**
  - Add shared path redaction in `utils.logging.js`, `src/utils/logger.js`, and `deploy.js`.
  - Sanitize messages and stacks while preserving filename:line:col; uses `/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`.
  - Add `tests/sentinel_path_redaction.test.js` to verify redaction on Unix and Windows paths.

- **Dependencies**
  - Bump `posthog-js` to `1.376.3` (with `@posthog/core` `1.29.12` and `@posthog/types` `1.376.3`).

<sup>Written for commit ffee60776b908da773d0fc8c474237f8ecb4e880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/641?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

