### PR TITLE
🛡️ Sentinel: [security improvement] Hardened log redaction for absolute paths

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -41,3 +41,8 @@
 **Vulnerability:** エラーメッセージを通じた内部ファイルシステムのパス漏洩。
 **Learning:** `stack` トレースのサニタイズだけでは不十分であり、`e.message` 自体に絶対パスが含まれるケース（例: "Cannot find module '/abs/path'"）がある。これを放置すると、CIログや共有ログサービスを通じて内部ディレクトリ構造が攻撃者に露呈するリスクがある。
 **Prevention:** エラーメッセージおよびスタックトレースの全行に対して、UnixおよびWindows形式の絶対パスを検知・置換する堅牢な正規表現 (`/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`) を適用するサニタイズ処理を共通化し、すべてのログ出力ポイントで強制する。
+
+## 2026-06-05 - Object Serialization Path Leakage
+**Vulnerability:** Information Leakage via `JSON.stringify`.
+**Learning:** Even if `message` and `stack` are sanitized, absolute paths can still leak if they are contained within data objects passed to logging functions. Many logging utilities stringify these objects separately, bypassing the redaction applied to the main message.
+**Prevention:** Ensure the object serialization helper (e.g., `_safeStringify`) applies path redaction to the resulting string before it is output or stored. Use comprehensive redaction regex at the lowest level of the logging pipeline.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -131,8 +131,15 @@ function _createCircularReplacer() {
 }
 
 /**
+/**
  * Security: Safely stringifies an object, handling circular references and limiting length.
  * Prevents Denial of Service (DoS) mid-tick from JSON.stringify failures.
+ * Also redacts absolute paths to prevent information leakage in logged objects.
+ *
+ * セキュリティ：循環参照を処理し、長さを制限してオブジェクトを安全に文字列化します。
+ * JSON.stringify の失敗によるティック途中での DoS を防ぎます。
+ * また、ログ出力されたオブジェクトからの情報漏洩を防ぐため、絶対パスをサニタイズします。
+ *
  * @param {*} obj
  * @param {number} [maxLength=500]
  * @returns {string}
@@ -147,7 +154,11 @@ function _safeStringify(obj, maxLength = 500) {
         if (str === undefined) {
             return 'undefined';
         }
-        return str.substring(0, maxLength);
+
+        // Security: Redact paths in stringified data to prevent information leakage
+        // セキュリティ：情報漏洩を防ぐため、文字列化されたデータ内のパスをサニタイズする
+        const redacted = _redactPaths(str);
+        return redacted.substring(0, maxLength);
     } catch (e) {
         return '[Unstringifiable Object]';
     }
@@ -194,11 +205,12 @@ function debug(message, data) {
     if (_level > LOG_LEVEL.DEBUG) return;
     _stats.debug++;
 
-    // Security: Truncate message to avoid Memory DoS
-    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
-    const sanitizedMessage = String(
+    // Security: Truncate and redact message to avoid Memory DoS and path leakage
+    // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
+    const rawMessage = String(
         message !== null && message !== undefined ? message : ''
     ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
         data !== undefined ? `${sanitizedMessage} ${_safeStringify(data)}` : sanitizedMessage;
@@ -216,11 +228,12 @@ function info(message, data) {
     if (_level > LOG_LEVEL.INFO) return;
     _stats.info++;
 
-    // Security: Truncate message to avoid Memory DoS
-    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
-    const sanitizedMessage = String(
+    // Security: Truncate and redact message to avoid Memory DoS and path leakage
+    // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
+    const rawMessage = String(
         message !== null && message !== undefined ? message : ''
     ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
         data !== undefined ? `${sanitizedMessage} ${_safeStringify(data)}` : sanitizedMessage;
@@ -238,11 +251,12 @@ function warn(message, data) {
     if (_level > LOG_LEVEL.WARN) return;
     _stats.warn++;
 
-    // Security: Truncate message to avoid Memory DoS
-    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
-    const sanitizedMessage = String(
+    // Security: Truncate and redact message to avoid Memory DoS and path leakage
+    // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
+    const rawMessage = String(
         message !== null && message !== undefined ? message : ''
     ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
         data !== undefined ? `${sanitizedMessage} ${_safeStringify(data)}` : sanitizedMessage;
@@ -260,11 +274,12 @@ function error(message, error) {
     if (_level > LOG_LEVEL.ERROR) return;
     _stats.error++;
 
-    // Security: Truncate message to avoid Memory DoS
-    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
-    const sanitizedMessage = String(
+    // Security: Truncate and redact message to avoid Memory DoS and path leakage
+    // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
+    const rawMessage = String(
         message !== null && message !== undefined ? message : ''
     ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const sanitizedMessage = _redactPaths(rawMessage);
 
     let full = sanitizedMessage;
     if (error instanceof Error) {
@@ -294,11 +309,12 @@ function success(message) {
     if (_level > LOG_LEVEL.INFO) return;
     _stats.info++;
 
-    // Security: Truncate message to avoid Memory DoS
-    // セキュリティ：メモリDoSを避けるためにメッセージを切り詰める
-    const sanitizedMessage = String(
+    // Security: Truncate and redact message to avoid Memory DoS and path leakage
+    // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
+    const rawMessage = String(
         message !== null && message !== undefined ? message : ''
     ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const sanitizedMessage = _redactPaths(rawMessage);
 
     _record('info', sanitizedMessage);
     // Security: Escape message to prevent console injection

--- a/tests/sentinel_logger_redaction_hardening.test.js
+++ b/tests/sentinel_logger_redaction_hardening.test.js
@@ -1,0 +1,106 @@
+/**
+ * Sentinel Security Hardening Test: Log Redaction
+ * Verifies that all log levels in both logging utilities redact absolute paths.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Mock Screeps environment
+global.Game = { time: 100 };
+global.Memory = {};
+
+// Mock Constants for src/utils/logger
+jest.mock(
+    '../src/constants',
+    () => ({
+        LOG_LEVEL: {
+            DEBUG: 0,
+            INFO: 1,
+            WARN: 2,
+            ERROR: 3,
+            NONE: 4,
+        },
+        DEFAULT_LOG_LEVEL: 0, // DEBUG
+    }),
+    { virtual: true }
+);
+
+// Mock console.log to avoid noise and capture output
+const originalLog = console.log;
+beforeAll(() => {
+    console.log = jest.fn();
+});
+afterAll(() => {
+    console.log = originalLog;
+});
+
+const utilsLogging = require('../utils.logging');
+const srcLogger = require('../src/utils/logger');
+
+describe('Sentinel: Comprehensive Log Redaction Hardening', () => {
+    beforeEach(() => {
+        global.Memory = { logs: [] };
+        srcLogger.setLevel(0); // DEBUG
+        console.log.mockClear();
+    });
+
+    const unixPath = '/var/lib/secret/data.json';
+    const winPath = 'D:\\Secrets\\config.yaml';
+
+    describe('src/utils/logger.js hardening', () => {
+        test('debug() should redact absolute paths', () => {
+            srcLogger.debug(`Loading from ${unixPath}`);
+            const history = srcLogger.getHistory(1);
+            expect(history[0].message).not.toContain(unixPath);
+            expect(history[0].message).toContain('[REDACTED]');
+        });
+
+        test('info() should redact absolute paths', () => {
+            srcLogger.info(`Connected to ${winPath}`);
+            const history = srcLogger.getHistory(1);
+            expect(history[0].message).not.toContain(winPath);
+            expect(history[0].message).toContain('[REDACTED]');
+        });
+
+        test('warn() should redact absolute paths', () => {
+            srcLogger.warn(`File ${unixPath} is missing`);
+            const history = srcLogger.getHistory(1);
+            expect(history[0].message).not.toContain(unixPath);
+            expect(history[0].message).toContain('[REDACTED]');
+        });
+
+        test('success() should redact absolute paths', () => {
+            srcLogger.success(`Saved to ${winPath}`);
+            const history = srcLogger.getHistory(1);
+            expect(history[0].message).not.toContain(winPath);
+            expect(history[0].message).toContain('[REDACTED]');
+        });
+
+        test('log methods should redact absolute paths in data objects', () => {
+            srcLogger.info('Data leak test', { path: unixPath });
+            const history = srcLogger.getHistory(1);
+            expect(history[0].message).not.toContain(unixPath);
+            expect(history[0].message).toContain('[REDACTED]');
+        });
+    });
+
+    describe('utils.logging.js hardening', () => {
+        test('log() should redact absolute paths for all levels', () => {
+            const levels = ['debug', 'info', 'warn', 'error'];
+            levels.forEach(level => {
+                utilsLogging.log(level, `Path: ${unixPath}`);
+                const lastLog = Memory.logs[Memory.logs.length - 1];
+                expect(lastLog.message).not.toContain(unixPath);
+                expect(lastLog.message).toContain('[REDACTED]');
+            });
+        });
+
+        test('convenience methods should redact absolute paths', () => {
+            utilsLogging.error(`Critical error at ${winPath}`);
+            const lastLog = Memory.logs[Memory.logs.length - 1];
+            expect(lastLog.message).not.toContain(winPath);
+            expect(lastLog.message).toContain('[REDACTED]');
+        });
+    });
+});

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -57,9 +57,11 @@ module.exports = {
             Memory.logs = [];
         }
 
-        // Security: Truncate level and message to avoid Memory DoS (2MB limit)
+        // Security: Truncate and redact level/message to avoid Memory DoS and path leakage
+        // セキュリティ：メモリDoSとパス漏洩を避けるためにレベルとメッセージを切り詰め、サニタイズする
         const sanitizedLevel = String(level).substring(0, 20);
-        const sanitizedMessage = String(message).substring(0, 500);
+        const rawMessage = String(message).substring(0, 500);
+        const sanitizedMessage = this._redactPaths(rawMessage);
 
         Memory.logs.push({
             time: Game.time,


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Information Leakage via absolute paths in logs and stringified objects.
🎯 **Impact:** Internal directory structures (Unix/Windows) could be exposed in CI logs or the Screeps console, providing attackers with filesystem layout information.
🔧 **Fix:** Applied \`_redactPaths\` to all log levels (debug, info, warn, error, success) and within the \`_safeStringify\` helper in \`src/utils/logger.js\` and the central \`log\` function in \`utils.logging.js\`.
✅ **Verification:** Created \`tests/sentinel_logger_redaction_hardening.test.js\` covering all log levels and data object serialization. All tests passed using \`npx jest --reporters=default\`.

---
*PR created automatically by Jules for task [14011455257675981581](https://jules.google.com/task/14011455257675981581) started by @tadanobutubutu*

## Summary by Sourcery

Harden logging to redact absolute filesystem paths across all logging utilities and serialization helpers to prevent information leakage.

Enhancements:
- Apply centralized path redaction to all log levels in src/utils/logger.js and utils.logging.js, including convenience methods.
- Extend the safe object serialization helper to redact absolute paths in stringified data before truncation.
- Document the new JSON.stringify-based path leakage scenario and required mitigations in the Sentinel security notes.

Tests:
- Add Jest tests ensuring all log levels and object serialization paths are redacted in both logger implementations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden log redaction to stop absolute filesystem paths from appearing in messages and serialized data. Applies redaction across all logger entry points to prevent information leakage in CI and the Screeps console.

- **Bug Fixes**
  - Apply `_redactPaths` to all levels (`debug`, `info`, `warn`, `error`, `success`) in `src/utils/logger.js`, and to `log()` and convenience methods in `utils.logging.js`.
  - Redact inside `_safeStringify` while truncating to limit size and remove paths in serialized objects.
  - Add Jest coverage in `tests/sentinel_logger_redaction_hardening.test.js` for Unix/Windows paths across both utilities; update `.jules/sentinel.md` with the serialization leakage note.

<sup>Written for commit 66b93ba2c6fb39fe87408155dcb3b45c22bdb816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

