### PR TITLE
Harden log redaction with sensitive keyword filtering

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -46,3 +46,8 @@
 **Vulnerability:** Information Leakage via `JSON.stringify`.
 **Learning:** Even if `message` and `stack` are sanitized, absolute paths can still leak if they are contained within data objects passed to logging functions. Many logging utilities stringify these objects separately, bypassing the redaction applied to the main message.
 **Prevention:** Ensure the object serialization helper (e.g., `_safeStringify`) applies path redaction to the resulting string before it is output or stored. Use comprehensive redaction regex at the lowest level of the logging pipeline.
+
+## 2026-06-01 - [Log Secret Redaction Hardening]
+**Vulnerability:** Accidental logging of credentials (tokens, passwords, API keys) within strings or stringified objects.
+**Learning:** Heuristic-based redaction using regex can effectively catch common credential patterns in logs. A robust regex must account for various separators ( `:`, `=`, spaces) and common prefixes like `Bearer` to avoid partial leaks while ensuring the sensitive value itself is replaced. Applying this redaction within a `_safeStringify` helper ensures that even structured data logged as objects is sanitized before output.
+**Prevention:** Always use centralized logging utilities for any output. Implement multi-layered redaction that covers both system paths and common sensitive keywords.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,11 +43,13 @@
 **Prevention:** エラーメッセージおよびスタックトレースの全行に対して、UnixおよびWindows形式の絶対パスを検知・置換する堅牢な正規表現 (`/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`) を適用するサニタイズ処理を共通化し、すべてのログ出力ポイントで強制する。
 
 ## 2026-06-05 - Object Serialization Path Leakage
+
 **Vulnerability:** Information Leakage via `JSON.stringify`.
 **Learning:** Even if `message` and `stack` are sanitized, absolute paths can still leak if they are contained within data objects passed to logging functions. Many logging utilities stringify these objects separately, bypassing the redaction applied to the main message.
 **Prevention:** Ensure the object serialization helper (e.g., `_safeStringify`) applies path redaction to the resulting string before it is output or stored. Use comprehensive redaction regex at the lowest level of the logging pipeline.
 
 ## 2026-06-01 - [Log Secret Redaction Hardening]
+
 **Vulnerability:** Accidental logging of credentials (tokens, passwords, API keys) within strings or stringified objects.
 **Learning:** Heuristic-based redaction using regex can effectively catch common credential patterns in logs. A robust regex must account for various separators ( `:`, `=`, spaces) and common prefixes like `Bearer` to avoid partial leaks while ensuring the sensitive value itself is replaced. Applying this redaction within a `_safeStringify` helper ensures that even structured data logged as objects is sanitized before output.
 **Prevention:** Always use centralized logging utilities for any output. Implement multi-layered redaction that covers both system paths and common sensitive keywords.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -43,13 +43,11 @@
 **Prevention:** エラーメッセージおよびスタックトレースの全行に対して、UnixおよびWindows形式の絶対パスを検知・置換する堅牢な正規表現 (`/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g`) を適用するサニタイズ処理を共通化し、すべてのログ出力ポイントで強制する。
 
 ## 2026-06-05 - Object Serialization Path Leakage
-
 **Vulnerability:** Information Leakage via `JSON.stringify`.
 **Learning:** Even if `message` and `stack` are sanitized, absolute paths can still leak if they are contained within data objects passed to logging functions. Many logging utilities stringify these objects separately, bypassing the redaction applied to the main message.
 **Prevention:** Ensure the object serialization helper (e.g., `_safeStringify`) applies path redaction to the resulting string before it is output or stored. Use comprehensive redaction regex at the lowest level of the logging pipeline.
 
 ## 2026-06-01 - [Log Secret Redaction Hardening]
-
 **Vulnerability:** Accidental logging of credentials (tokens, passwords, API keys) within strings or stringified objects.
 **Learning:** Heuristic-based redaction using regex can effectively catch common credential patterns in logs. A robust regex must account for various separators ( `:`, `=`, spaces) and common prefixes like `Bearer` to avoid partial leaks while ensuring the sensitive value itself is replaced. Applying this redaction within a `_safeStringify` helper ensures that even structured data logged as objects is sanitized before output.
 **Prevention:** Always use centralized logging utilities for any output. Implement multi-layered redaction that covers both system paths and common sensitive keywords.

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -89,8 +89,14 @@ function _record(level, message) {
  */
 function _redactPaths(str) {
     if (typeof str !== 'string') return str;
-    // Matches /abs/path or C:\abs\path
-    return str.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+    // Security: Redact absolute paths and sensitive keywords (tokens, passwords, etc.)
+    // セキュリティ：絶対パスおよび機密キーワード（トークン、パスワードなど）をサニタイズします
+    return str
+        .replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]')
+        .replace(
+            /(token|password|secret|apiKey|auth|credentials|bearer|session)([^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10})(Bearer\s+)?([^ \n\t"']+)/gi,
+            '$1$2$3[REDACTED]'
+        );
 }
 
 /**

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -94,8 +94,12 @@ function _redactPaths(str) {
     return str
         .replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]')
         .replace(
-            /(token|password|secret|apiKey|auth|credentials|bearer|session)([^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10})(Bearer\s+)?([^ \n\t"']+)/gi,
-            '$1$2$3[REDACTED]'
+            /(token|password|secret|apiKey|auth|credentials|bearer|session|apiToken)[^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10}(Bearer\s+)?([^ \n\t"']+)/gi,
+            (match, g1, g2, g3) => {
+                // Keep the keyword, separator, and optional 'Bearer ' prefix, but redact the value
+                const prefix = match.substring(0, match.lastIndexOf(g3));
+                return prefix + '[REDACTED]';
+            }
         );
 }
 
@@ -213,10 +217,9 @@ function debug(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -237,10 +240,9 @@ function info(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -261,10 +263,9 @@ function warn(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -285,10 +286,9 @@ function error(message, error) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     let full = sanitizedMessage;
@@ -321,10 +321,9 @@ function success(message) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     _record('info', sanitizedMessage);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -213,9 +213,10 @@ function debug(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(
-        message !== null && message !== undefined ? message : ''
-    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
+        0,
+        MAX_LOG_MESSAGE_LENGTH
+    );
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -236,9 +237,10 @@ function info(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(
-        message !== null && message !== undefined ? message : ''
-    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
+        0,
+        MAX_LOG_MESSAGE_LENGTH
+    );
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -259,9 +261,10 @@ function warn(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(
-        message !== null && message !== undefined ? message : ''
-    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
+        0,
+        MAX_LOG_MESSAGE_LENGTH
+    );
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -282,9 +285,10 @@ function error(message, error) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(
-        message !== null && message !== undefined ? message : ''
-    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
+        0,
+        MAX_LOG_MESSAGE_LENGTH
+    );
     const sanitizedMessage = _redactPaths(rawMessage);
 
     let full = sanitizedMessage;
@@ -317,9 +321,10 @@ function success(message) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(
-        message !== null && message !== undefined ? message : ''
-    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
+    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
+        0,
+        MAX_LOG_MESSAGE_LENGTH
+    );
     const sanitizedMessage = _redactPaths(rawMessage);
 
     _record('info', sanitizedMessage);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -213,10 +213,9 @@ function debug(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -237,10 +236,9 @@ function info(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -261,10 +259,9 @@ function warn(message, data) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     const full =
@@ -285,10 +282,9 @@ function error(message, error) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     let full = sanitizedMessage;
@@ -321,10 +317,9 @@ function success(message) {
 
     // Security: Truncate and redact message to avoid Memory DoS and path leakage
     // セキュリティ：メモリDoSとパス漏洩を避けるためにメッセージを切り詰め、サニタイズする
-    const rawMessage = String(message !== null && message !== undefined ? message : '').substring(
-        0,
-        MAX_LOG_MESSAGE_LENGTH
-    );
+    const rawMessage = String(
+        message !== null && message !== undefined ? message : ''
+    ).substring(0, MAX_LOG_MESSAGE_LENGTH);
     const sanitizedMessage = _redactPaths(rawMessage);
 
     _record('info', sanitizedMessage);

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -110,8 +110,14 @@ module.exports = {
      */
     _redactPaths: function (str) {
         if (typeof str !== 'string') return str;
-        // Matches /abs/path or C:\abs\path
-        return str.replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]');
+        // Security: Redact absolute paths and sensitive keywords (tokens, passwords, etc.)
+        // セキュリティ：絶対パスおよび機密キーワード（トークン、パスワードなど）をサニタイズします
+        return str
+            .replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]')
+            .replace(
+                /(token|password|secret|apiKey|auth|credentials|bearer|session)([^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10})(Bearer\s+)?([^ \n\t"']+)/gi,
+                '$1$2$3[REDACTED]'
+            );
     },
 
     /**

--- a/utils.logging.js
+++ b/utils.logging.js
@@ -115,8 +115,11 @@ module.exports = {
         return str
             .replace(/(\/|[a-zA-Z]:\\)[^ \n\t"']*/g, '[REDACTED]')
             .replace(
-                /(token|password|secret|apiKey|auth|credentials|bearer|session)([^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10})(Bearer\s+)?([^ \n\t"']+)/gi,
-                '$1$2$3[REDACTED]'
+                /(token|password|secret|apiKey|auth|credentials|bearer|session|apiToken)[^a-zA-Z0-9]{0,10}[:= ]+[^a-zA-Z0-9]{0,10}(Bearer\s+)?([^ \n\t"']+)/gi,
+                (match, g1, g2, g3) => {
+                    const prefix = match.substring(0, match.lastIndexOf(g3));
+                    return prefix + '[REDACTED]';
+                }
             );
     },
 


### PR DESCRIPTION
### Description

In this pull request, changes have been made to enhance the security of logging by improving the redaction process for sensitive information such as credentials (tokens, passwords, API keys) present in logs.

Below are the key changes in the code diffs provided:
- Added a new section in the logging utility regarding the log secret redaction hardening.
- Updated the `_redactPaths` function in both `utils.logging.js` and `src/utils/logger.js` to include regex patterns that redact sensitive keywords like tokens, passwords, and specific separators to prevent accidental logging of credentials.
- Additional regex pattern has been introduced to handle common sensitive keywords in logs to ensure they are redacted effectively.

These changes aim to strengthen the security measures taken to prevent the inadvertent exposure of sensitive information in log files and outputs.

## Summary by Sourcery

Harden log redaction by expanding centralized path-sanitization helpers to also scrub credential-like values from log strings.

Bug Fixes:
- Prevent accidental logging of credentials by redacting values associated with common sensitive keywords in log messages and stringified objects.

Enhancements:
- Extend logging redaction helpers to cover both absolute file paths and heuristic detection of tokens, passwords, API keys, and related secrets across codepaths using the shared utility.

Documentation:
- Document the new log secret redaction hardening scenario and recommended prevention measures in the security sentinel notes.