### PR TITLE
🧹 Code health: Refactor _planExtensions into smaller helper functions in roomManager.js

### DIFF
--- a/src/managers/roomManager.js
+++ b/src/managers/roomManager.js
@@ -153,15 +153,16 @@ function _planRoads(room) {
 }
 
 /**
- * スポーン周囲にエクステンションを配置する計画を立てる
+ * 必要なエクステンションの数を計算する
  * @param {Room} room
+ * @returns {number}
  */
-function _planExtensions(room) {
+function _getNeededExtensionCount(room) {
     const rcl = room.controller.level;
     const maxExtensions = CONTROLLER_STRUCTURES[STRUCTURE_EXTENSION][rcl] || 0;
 
     if (maxExtensions === 0) {
-        return;
+        return 0;
     }
 
     const existing = cache.getMyStructures(room, STRUCTURE_EXTENSION);
@@ -171,18 +172,19 @@ function _planExtensions(room) {
 
     const currentCount = existing.length + sites.length;
     if (currentCount >= maxExtensions) {
-        return;
+        return 0;
     }
 
-    const spawns = cache.getSpawns(room);
-    if (spawns.length === 0) {
-        return;
-    }
+    return Math.min(5, maxExtensions - currentCount);
+}
 
-    const spawn = spawns[0];
-    const needed = Math.min(5, maxExtensions - currentCount);
-    let placed = 0;
-
+/**
+ * スポーン周辺の障害物マップを作成する
+ * @param {Room} room
+ * @param {StructureSpawn} spawn
+ * @returns {Set<string>}
+ */
+function _getBlockedMap(room, spawn) {
     const top = Math.max(2, spawn.pos.y - 6);
     const left = Math.max(2, spawn.pos.x - 6);
     const bottom = Math.min(47, spawn.pos.y + 6);
@@ -196,6 +198,19 @@ function _planExtensions(room) {
             blockedMap.add(`${item.x},${item.y}`);
         }
     }
+    return blockedMap;
+}
+
+/**
+ * スパイラルパターンでエクステンションを配置する
+ * @param {Room} room
+ * @param {StructureSpawn} spawn
+ * @param {number} needed
+ * @param {Set<string>} blockedMap
+ * @returns {number} 配置された数
+ */
+function _placeExtensions(room, spawn, needed, blockedMap) {
+    let placed = 0;
 
     // スポーン周囲のスパイラルパターンでエクステンションを配置
     for (let radius = 2; radius <= 6 && placed < needed; radius++) {
@@ -228,6 +243,27 @@ function _planExtensions(room) {
             }
         }
     }
+    return placed;
+}
+
+/**
+ * スポーン周囲にエクステンションを配置する計画を立てる
+ * @param {Room} room
+ */
+function _planExtensions(room) {
+    const needed = _getNeededExtensionCount(room);
+    if (needed === 0) {
+        return;
+    }
+
+    const spawns = cache.getSpawns(room);
+    if (spawns.length === 0) {
+        return;
+    }
+
+    const spawn = spawns[0];
+    const blockedMap = _getBlockedMap(room, spawn);
+    const placed = _placeExtensions(room, spawn, needed, blockedMap);
 
     if (placed > 0) {
         logger.info(`[RoomManager] エクステンション ${placed} か所を計画`);


### PR DESCRIPTION
🎯 **What:** The `_planExtensions` function in `src/managers/roomManager.js` was too long and violated the Single Responsibility Principle by combining structure count verification, obstacle mapping, and placement logic.
💡 **Why:** Splitting this function up into `_getNeededExtensionCount`, `_getBlockedMap`, and `_placeExtensions` makes the code significantly easier to read, maintain, and test individually while adhering to SRP.
✅ **Verification:** Ran code formatting/linting and ran the full `jest` test suite locally to verify the behavior and ensure all unit tests continue to pass.
✨ **Result:** Improved modularity and code health in the room infrastructure planning logic without changing existing behavior.

---
*PR created automatically by Jules for task [14927169945251133118](https://jules.google.com/task/14927169945251133118) started by @tadanobutubutu*