### PR TITLE
Refactor `_getEnergy` into modular helper functions

### DIFF
--- a/src/roles/upgrader.js
+++ b/src/roles/upgrader.js
@@ -70,22 +70,43 @@ function _updateWorkingState(creep) {
 
 /**
  * 最適なエネルギー源からエネルギーを取得する
- * 優先順位: ストレージ → コンテナ → リンク → 落下リソース → ソース
+ * 優先順位: ストレージ → リンク → コンテナ → 落下リソース → ソース
  * @param {Creep} creep
  */
 function _getEnergy(creep) {
     const room = creep.room;
 
-    // ストレージから取得
+    if (_getEnergyFromStorage(creep, room)) return;
+    if (_getEnergyFromLink(creep, room)) return;
+    if (_getEnergyFromContainer(creep, room)) return;
+    if (_getEnergyFromDropped(creep, room)) return;
+    _getEnergyFromSource(creep, room);
+}
+
+/**
+ * ストレージから取得
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromStorage(creep, room) {
     const storage = cache.getStorage(room);
     if (storage && storage.store[RESOURCE_ENERGY] >= 1000) {
         if (creep.withdraw(storage, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, storage, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // リンクから取得
+/**
+ * リンクから取得
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromLink(creep, room) {
     const links = cache.getLinks(room);
     const readyLinks = links.filter((l) => l.store[RESOURCE_ENERGY] >= 200);
     if (readyLinks.length > 0) {
@@ -93,10 +114,18 @@ function _getEnergy(creep) {
         if (creep.withdraw(link, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, link, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // コントローラー付近のコンテナから取得
+/**
+ * コントローラー付近のコンテナから取得
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromContainer(creep, room) {
     const containers = cache.getContainers(room);
     const controller = room.controller;
     if (controller) {
@@ -108,11 +137,19 @@ function _getEnergy(creep) {
             if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
                 pathfinder.moveTo(creep, container, { range: 1 });
             }
-            return;
+            return true;
         }
     }
+    return false;
+}
 
-    // 落下リソースを回収
+/**
+ * 落下リソースを回収
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromDropped(creep, room) {
     const dropped = cache.getDroppedResources(room);
     const energyDrops = dropped.filter((r) => r.resourceType === RESOURCE_ENERGY && r.amount >= 50);
     if (energyDrops.length > 0) {
@@ -120,16 +157,26 @@ function _getEnergy(creep) {
         if (creep.pickup(res) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, res, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // 直接ソースから採掘
+/**
+ * 直接ソースから採掘
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromSource(creep, room) {
     const source = cache.assignSource(creep, room);
     if (source) {
         if (creep.harvest(source) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, source, { range: 1 });
         }
+        return true;
     }
+    return false;
 }
 
 // ============================================================


### PR DESCRIPTION
This PR refactors the `_getEnergy` function in `upgrader.js` by extracting energy retrieval logic into separate, focused helper functions.

**Key Changes:**
- Split monolithic `_getEnergy` function into five specialized functions: `_getEnergyFromStorage`, `_getEnergyFromLink`, `_getEnergyFromContainer`, `_getEnergyFromDropped`, and `_getEnergyFromSource`
- Each helper function now returns a boolean indicating success, enabling early exit pattern in the main function
- Updated energy source priority order: Storage → Link → Container → Dropped Resources → Source (Link moved up from Container)
- Added JSDoc comments to all new helper functions for improved code documentation

**Benefits:**
- Improved code readability and maintainability through single-responsibility principle
- Easier to test and debug individual energy sources
- Clearer priority logic with explicit early returns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `_getEnergy` in `src/roles/upgrader.js` into small helpers and made the energy source priority explicit: Storage → Link → Container → Dropped → Source. This simplifies the flow and makes the role easier to maintain and extend.

- **Refactors**
  - Extracted `_getEnergyFromStorage`, `_getEnergyFromLink`, `_getEnergyFromContainer`, `_getEnergyFromDropped`, `_getEnergyFromSource` (each returns a boolean).
  - `_getEnergy` now chains early returns in the priority order above.
  - Updated inline docs to match the code’s priority order.

<sup>Written for commit 95ec57828013da061721b247ece849f385eed140. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

