### PR TITLE
🔒 Sentinel: Replace execSync with spawnSync to prevent command injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The deployment script (`deploy.js`) was logging un-redacted token values in raw error responses. Its previous `sanitizeLog` function only redacted the word "token" but left the actual token value exposed if it followed the keyword (e.g., "token: value-here").
 **Learning:** Simple keyword-based redaction is insufficient when dealing with raw response payloads or complex strings. Redaction logic must account for the value following the keyword and use robust regex patterns that consider various delimiters (quotes, colons, equals).
 **Prevention:** Use a centralized redaction utility that handles multiple sensitive keywords and correctly identifies their associated values using non-backtracking regexes to avoid ReDoS. Always verify redaction logic with dedicated security tests.
+
+### Arbitrary Code Execution via execSync
+
+- **Vulnerability:** Using `execSync` with strings instead of argument arrays exposes applications to command injection if any part of the string contains untrusted input.
+- **Fix Pattern:** Always replace `execSync` with `spawnSync` utilizing its array form for arguments (`spawnSync('command', ['arg1', 'arg2'])`). This avoids spawning a shell, inherently neutralizing injection attempts via shell metacharacters.

--- a/format_everything.js
+++ b/format_everything.js
@@ -1,18 +1,20 @@
 const fs = require('fs');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 // Run standard prettier
 try {
-    execSync('npx prettier --write utils.defense.js tests/utils.defense.test.js', {
+    spawnSync('npx', ['prettier', '--write', 'utils.defense.js', 'tests/utils.defense.test.js'], {
         stdio: 'inherit',
     });
-} catch (e) {
-    }
+} catch (e) {}
 
 // Run standard eslint --fix
 try {
-    execSync('npx eslint@8.57.0 --fix utils.defense.js tests/utils.defense.test.js', {
-        stdio: 'inherit',
-    });
-} catch (e) {
-    }
+    spawnSync(
+        'npx',
+        ['eslint@8.57.0', '--fix', 'utils.defense.js', 'tests/utils.defense.test.js'],
+        {
+            stdio: 'inherit',
+        }
+    );
+} catch (e) {}


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in `format_everything.js` by replacing `execSync` with the array form of `spawnSync`.

⚠️ **Risk:** `execSync` executes commands inside a shell. If any part of the command string were to come from untrusted input (e.g., in the future), it could be manipulated with shell metacharacters to execute arbitrary system commands, leading to total compromise. Although the arguments are currently hardcoded, this represents a significant structural vulnerability and poor security hygiene.

🛡️ **Solution:** Swapped `execSync` for `spawnSync` from the `child_process` module. Crucially, I used the array format (e.g., `spawnSync('npx', ['prettier', ...])`). This approach does not spawn a shell by default, passing arguments directly to the executable and completely mitigating the risk of shell metacharacter injection.

Verified the file still performs formatting successfully. Documented the pattern in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13076887031225738001](https://jules.google.com/task/13076887031225738001) started by @tadanobutubutu*