### PR TITLE
Add manual refresh button and retry logic to dashboard

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -5,23 +5,30 @@ export default function Dashboard() {
     const [stats, setStats] = useState<any>(null),
         [error, setError] = useState<string | null>(null),
         [loading, setLoading] = useState(true),
+        [refreshing, setRefreshing] = useState(false),
         [copied, setCopied] = useState(false),
-        [focused, setFocused] = useState(false);
+        [focused, setFocused] = useState(false),
+        [refreshFocused, setRefreshFocused] = useState(false);
+
+    const fetchData = async (isRefresh = false) => {
+        if (isRefresh) setRefreshing(true);
+        else setLoading(true);
+        setError(null);
+        try {
+            const r = await fetch('/api/screeps?endpoint=overview');
+            const d = await r.json();
+            if (!r.ok || d.error) throw new Error(d.error || `エラー: ${r.status}`);
+            setStats(d);
+        } catch (e: any) {
+            setError(e.message || String(e));
+        } finally {
+            setLoading(false);
+            setRefreshing(false);
+        }
+    };
+
     useEffect(() => {
-        fetch('/api/screeps?endpoint=overview')
-            .then(async (r) => {
-                const d = await r.json();
-                if (!r.ok || d.error) throw new Error(d.error || `エラー: ${r.status}`);
-                return d;
-            })
-            .then((d) => {
-                setStats(d);
-                setLoading(false);
-            })
-            .catch((e) => {
-                setError(e.message || String(e));
-                setLoading(false);
-            });
+        fetchData();
     }, []);
     const copyErr = () =>
         error &&
@@ -39,7 +46,48 @@ export default function Dashboard() {
     if (error)
         return (
             <main style={{ padding: '2rem', fontFamily: 'monospace' }}>
-                <h1 style={{ color: '#b71c1c' }}>⚠️ エラー</h1>
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '1rem',
+                        marginBottom: '1rem',
+                    }}
+                >
+                    <h1 style={{ color: '#b71c1c', margin: 0 }}>⚠️ エラー</h1>
+                    <button
+                        onClick={() => fetchData(true)}
+                        onFocus={() => setRefreshFocused(true)}
+                        onBlur={() => setRefreshFocused(false)}
+                        disabled={refreshing}
+                        title={refreshing ? '更新中...' : '再試行'}
+                        aria-label={refreshing ? '更新中...' : '再試行'}
+                        style={{
+                            backgroundColor: 'transparent',
+                            border: '1px solid #b71c1c',
+                            color: '#b71c1c',
+                            borderRadius: '4px',
+                            padding: '0.4rem',
+                            cursor: refreshing ? 'not-allowed' : 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            outline: 'none',
+                            boxShadow: refreshFocused ? '0 0 0 3px rgba(183, 28, 28, 0.4)' : 'none',
+                            transition: 'all 0.2s ease',
+                        }}
+                    >
+                        <span
+                            style={{
+                                display: 'inline-block',
+                                animation: refreshing ? 'spin 1s linear infinite' : 'none',
+                                fontSize: '1.2rem',
+                            }}
+                        >
+                            🔄
+                        </span>
+                    </button>
+                </div>
                 <pre
                     style={{
                         color: '#c53030',
@@ -73,7 +121,48 @@ export default function Dashboard() {
         );
     return (
         <main style={{ padding: '2rem', fontFamily: 'monospace' }}>
-            <h1 style={{ color: '#004b73' }}>🐛 Screeps ダッシュボード</h1>
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '1rem',
+                    marginBottom: '1rem',
+                }}
+            >
+                <h1 style={{ color: '#004b73', margin: 0 }}>🐛 Screeps ダッシュボード</h1>
+                <button
+                    onClick={() => fetchData(true)}
+                    onFocus={() => setRefreshFocused(true)}
+                    onBlur={() => setRefreshFocused(false)}
+                    disabled={refreshing}
+                    title={refreshing ? '更新中...' : 'データを更新'}
+                    aria-label={refreshing ? '更新中...' : 'データを更新'}
+                    style={{
+                        backgroundColor: 'transparent',
+                        border: '1px solid #004b73',
+                        color: '#004b73',
+                        borderRadius: '4px',
+                        padding: '0.4rem',
+                        cursor: refreshing ? 'not-allowed' : 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        outline: 'none',
+                        boxShadow: refreshFocused ? '0 0 0 3px rgba(0, 75, 115, 0.4)' : 'none',
+                        transition: 'all 0.2s ease',
+                    }}
+                >
+                    <span
+                        style={{
+                            display: 'inline-block',
+                            animation: refreshing ? 'spin 1s linear infinite' : 'none',
+                            fontSize: '1.2rem',
+                        }}
+                    >
+                        🔄
+                    </span>
+                </button>
+            </div>
             <div
                 style={{
                     marginBottom: '1rem',

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
### Description

In this pull request, the following changes are made:

- Added a state variable `refreshing` and an updater function `setRefreshing` to manage the refreshing state of the data.
- Added a state variable `refreshFocused` and updater functions `setRefreshFocused` to manage focus state during data refresh.
- Updated the `fetchData` function to handle refreshing state and updated the fetch logic for data.
- Added a refresh button to trigger data refresh, along with styles and disabled state management.
- Updated the UI to include the refresh button for data updating.
- Refactored the code to use the `fetchData` function instead of separate `fetch` blocks inside `useEffect`.
- Updated the import path in `next-env.d.ts` file.

These changes enhance the functionality of the Dashboard component to allow users to manually trigger a data refresh, resulting in a more interactive and responsive user experience.