### PR TITLE
feat(ci): add google gemini api key support as primary for issue solver

### DIFF
--- a/.github/workflows/auto-pr-from-issues.yml
+++ b/.github/workflows/auto-pr-from-issues.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_TOKEN: ${{ secrets.OPENROUTER_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
           python3 scripts/ai_issue_solver.py

--- a/scripts/ai_issue_solver.py
+++ b/scripts/ai_issue_solver.py
@@ -1,39 +1,39 @@
 import os, sys, json, subprocess, urllib.request, re
 
-def main():
-    issue_no = os.environ.get("ISSUE_NUMBER")
-    openrouter_token = os.environ.get("OPENROUTER_TOKEN")
-    if not issue_no or not openrouter_token:
-        print("Missing ISSUE_NUMBER or OPENROUTER_TOKEN")
-        return
-    
-    # 1. Fetch Issue Details
+def call_gemini_api(prompt, key):
     try:
-        res = subprocess.run(["gh", "issue", "view", str(issue_no), "--json", "title,body"], capture_output=True, text=True)
-        ctx = json.loads(res.stdout)
+        print("Trying direct Google Gemini API (gemini-1.5-flash)...")
+        url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent?key={key}"
+        payload = {
+            "contents": [{"parts": [{"text": prompt}]}]
+        }
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode('utf-8'),
+            headers={"Content-Type": "application/json"}
+        )
+        with urllib.request.urlopen(req, timeout=60) as f:
+            res = json.loads(f.read().decode('utf-8'))
+            return res['candidates'][0]['content']['parts'][0]['text']
     except Exception as e:
-        print(f"Failed to fetch issue details: {e}")
-        return
-    
-    # 2. Call OpenRouter with free models list
+        print(f"Direct Gemini API failed: {e}")
+        return None
+
+def call_openrouter(prompt, token):
     models = [
         "google/gemini-2.5-flash:free",
         "google/gemini-2.0-flash-exp:free",
         "meta-llama/llama-3-8b-instruct:free",
     ]
-    
-    prompt = f"Fix this JS code error for the file main.js.\nIssue Title: {ctx['title']}\nIssue Body: {ctx['body']}\nProvide ONLY the complete updated file content of main.js inside a javascript code block."
-    
-    result = None
     for model in models:
         try:
-            print(f"Trying model {model}...")
+            print(f"Trying OpenRouter model {model}...")
             payload = {
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}]
             }
             headers = {
-                "Authorization": f"Bearer {openrouter_token}",
+                "Authorization": f"Bearer {token}",
                 "Content-Type": "application/json",
                 "X-Title": "screeps-issue-solver",
                 "HTTP-Referer": "https://github.com/tadanobutubutu/screeps"
@@ -45,13 +45,36 @@ def main():
             )
             with urllib.request.urlopen(req, timeout=60) as f:
                 res = json.loads(f.read().decode('utf-8'))
-                result = res['choices'][0]['message']['content']
-                if result:
-                    print(f"Successfully obtained response using {model}")
-                    break
+                return res['choices'][0]['message']['content']
         except Exception as e:
-            print(f"Error calling model {model}: {e}")
-            
+            print(f"OpenRouter model {model} failed: {e}")
+    return None
+
+def main():
+    issue_no = os.environ.get("ISSUE_NUMBER")
+    openrouter_token = os.environ.get("OPENROUTER_TOKEN")
+    gemini_api_key = os.environ.get("GEMINI_API_KEY")
+    
+    if not issue_no:
+        print("Missing ISSUE_NUMBER")
+        return
+    
+    # 1. Fetch Issue Details
+    try:
+        res = subprocess.run(["gh", "issue", "view", str(issue_no), "--json", "title,body"], capture_output=True, text=True)
+        ctx = json.loads(res.stdout)
+    except Exception as e:
+        print(f"Failed to fetch issue details: {e}")
+        return
+    
+    prompt = f"Fix this JS code error for the file main.js.\nIssue Title: {ctx['title']}\nIssue Body: {ctx['body']}\nProvide ONLY the complete updated file content of main.js inside a javascript code block."
+    
+    result = None
+    if gemini_api_key:
+        result = call_gemini_api(prompt, gemini_api_key)
+    if not result and openrouter_token:
+        result = call_openrouter(prompt, openrouter_token)
+        
     if not result:
         result = "// Fix pending due to API errors"
     


### PR DESCRIPTION
This PR adds direct Google Gemini API key support to the issue solver to resolve OpenRouter 404 errors.

## Summary by Sourcery

Add primary support for Google Gemini API in the automated issue solver, with OpenRouter as a fallback.

New Features:
- Introduce a direct Google Gemini API integration for generating fixes in the issue solver script.

Enhancements:
- Refactor the issue solver script to separate Gemini and OpenRouter API calls and support fallback behavior when one provider fails.

CI:
- Update the auto-pr-from-issues GitHub workflow to pass a Gemini API key secret to the issue solver script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Gemini as the primary provider for the issue solver, with OpenRouter as a fallback. This reduces OpenRouter 404s and makes CI-generated fixes more reliable.

- **New Features**
  - Direct Gemini call (`gemini-1.5-flash`) via Google Generative Language API.
  - Separate provider functions with fallback: try Gemini first, then OpenRouter.
  - Better error handling with a safe placeholder if both providers fail.

- **Migration**
  - Add `GEMINI_API_KEY` to repo secrets; the workflow now passes it to the solver.

<sup>Written for commit 16da7eda2fb6c736ff0e81e00b43838a1a456d06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

