### PR TITLE
feat(ci): remove expired BLUECAVE_TOKEN and use standard GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-merge-pr.yml
+++ b/.github/workflows/auto-merge-pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.BLUECAVE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Set up Python
@@ -32,8 +32,8 @@ jobs:
 
       - name: High-Speed Penetration Merge
         env:
-          GH_TOKEN: ${{ secrets.BLUECAVE_TOKEN || secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.BLUECAVE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OPENROUTER_TOKEN: ${{ secrets.OPENROUTER_TOKEN }}
         run: |
           # Get list of all open PRs


### PR DESCRIPTION
This PR fixes the Git authentication/checkout error by replacing the invalid BLUECAVE_TOKEN with the standard GITHUB_TOKEN.

## Summary by Sourcery

CI:
- Update the auto-merge GitHub Actions workflow to use only GITHUB_TOKEN for checkout and merge operations instead of BLUECAVE_TOKEN.