### PR TITLE
feat(ci): キー不要AIフォールバック層の共通化・拡張

### DIFF
--- a/scripts/ai_issue_solver.py
+++ b/scripts/ai_issue_solver.py
@@ -1,158 +1,105 @@
-import os, sys, json, subprocess, urllib.request, re
+import json
+import os
+import re
+import subprocess
+import sys
 
-def call_gemini_api(prompt, key):
-    try:
-        print("Trying direct Google Gemini API (gemini-1.5-flash-latest)...")
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key={key}"
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}]
-        }
-        req = urllib.request.Request(
-            url,
-            data=json.dumps(payload).encode('utf-8'),
-            headers={"Content-Type": "application/json"}
-        )
-        with urllib.request.urlopen(req, timeout=60) as f:
-            res = json.loads(f.read().decode('utf-8'))
-            return res['candidates'][0]['content']['parts'][0]['text']
-    except Exception as e:
-        print(f"Direct Gemini API failed: {e}")
-        return None
+from ai_providers import extract_code_block, generate_with_fallback, is_valid_response, normalize_token
 
-def call_openrouter(prompt, token):
-    models = [
-        "openrouter/free",
-        "google/gemini-2.5-flash:free",
-        "google/gemini-2.0-flash-exp:free",
-    ]
-    for model in models:
-        try:
-            print(f"Trying OpenRouter model {model}...")
-            payload = {
-                "model": model,
-                "messages": [{"role": "user", "content": prompt}]
-            }
-            headers = {
-                "Authorization": f"Bearer {token}",
-                "Content-Type": "application/json",
-                "X-Title": "screeps-issue-solver",
-                "HTTP-Referer": "https://github.com/tadanobutubutu/screeps"
-            }
-            req = urllib.request.Request(
-                "https://openrouter.ai/api/v1/chat/completions",
-                data=json.dumps(payload).encode('utf-8'),
-                headers=headers
-            )
-            with urllib.request.urlopen(req, timeout=60) as f:
-                res = json.loads(f.read().decode('utf-8'))
-                if 'choices' in res and len(res['choices']) > 0:
-                    return res['choices'][0]['message']['content']
-        except Exception as e:
-            print(f"OpenRouter model {model} failed: {e}")
-    return None
 
-def call_pollinations_ai(prompt):
-    try:
-        print("Trying Pollinations AI (openai-fast)...")
-        payload = {
-            "messages": [{"role": "user", "content": prompt}],
-            "model": "openai"
-        }
-        req = urllib.request.Request(
-            "https://text.pollinations.ai/",
-            data=json.dumps(payload).encode('utf-8'),
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": "Mozilla/5.0"
-            }
-        )
-        with urllib.request.urlopen(req, timeout=60) as f:
-            return f.read().decode('utf-8')
-    except Exception as e:
-        print(f"Pollinations AI failed: {e}")
-    return None
+def comment_on_issue(issue_no, body):
+    subprocess.run(
+        ["gh", "issue", "comment", str(issue_no), "--body", body],
+        check=False,
+    )
 
-def call_huggingface_anonymous(prompt):
-    try:
-        print("Trying Hugging Face Serverless Anonymous (Qwen2.5-Coder)...")
-        url = "https://api-inference.huggingface.co/models/Qwen/Qwen2.5-Coder-7B-Instruct"
-        payload = {
-            "inputs": prompt,
-            "parameters": {"max_new_tokens": 1000}
-        }
-        req = urllib.request.Request(
-            url,
-            data=json.dumps(payload).encode('utf-8'),
-            headers={
-                "Content-Type": "application/json",
-                "User-Agent": "Mozilla/5.0"
-            }
-        )
-        with urllib.request.urlopen(req, timeout=60) as f:
-            res = json.loads(f.read().decode('utf-8'))
-            if isinstance(res, list) and len(res) > 0 and 'generated_text' in res[0]:
-                return res[0]['generated_text']
-            elif isinstance(res, dict) and 'generated_text' in res:
-                return res['generated_text']
-    except Exception as e:
-        print(f"Hugging Face anonymous failed: {e}")
-    return None
 
 def main():
     issue_no = os.environ.get("ISSUE_NUMBER")
-    openrouter_token = os.environ.get("OPENROUTER_TOKEN")
-    gemini_api_key = os.environ.get("GEMINI_API_KEY")
-    
+    openrouter_token = normalize_token(os.environ.get("OPENROUTER_TOKEN"))
+    gemini_api_key = normalize_token(os.environ.get("GEMINI_API_KEY"))
+
     if not issue_no:
         print("Missing ISSUE_NUMBER")
-        return
-    
-    # 1. Fetch Issue Details
+        sys.exit(1)
+
     try:
-        res = subprocess.run(["gh", "issue", "view", str(issue_no), "--json", "title,body"], capture_output=True, text=True)
+        res = subprocess.run(
+            ["gh", "issue", "view", str(issue_no), "--json", "title,body"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
         ctx = json.loads(res.stdout)
-    except Exception as e:
-        print(f"Failed to fetch issue details: {e}")
-        return
-    
-    prompt = f"Fix this JS code error for the file main.js.\nIssue Title: {ctx['title']}\nIssue Body: {ctx['body']}\nProvide ONLY the complete updated file content of main.js inside a javascript code block."
-    
-    result = None
-    # Cascading Fallback Layers:
-    # 1. Direct Gemini API Key (Stable Free Tier)
-    if gemini_api_key:
-        result = call_gemini_api(prompt, gemini_api_key)
-    # 2. OpenRouter Token (Free Router Slug)
-    if not result and openrouter_token:
-        result = call_openrouter(prompt, openrouter_token)
-    # 3. Pollinations AI (Anonymous, Keyless, 100% Free)
-    if not result:
-        result = call_pollinations_ai(prompt)
-    # 4. Hugging Face Serverless Anonymous (Keyless Coder LLM)
-    if not result:
-        result = call_huggingface_anonymous(prompt)
-        
-    if not result:
-        result = "// Fix pending due to API errors"
-    
-    # 3. Apply the fix
-    code_match = re.search(r"```(?:javascript|js)?\s*(.*?)\s*```", result, re.DOTALL)
-    code = code_match.group(1) if code_match else result
-    
-    # Configure Git identity for the runner
+    except Exception as exc:
+        print(f"Failed to fetch issue details: {exc}")
+        sys.exit(1)
+
+    prompt = (
+        f"Fix this JS code error for the file main.js.\n"
+        f"Issue Title: {ctx['title']}\n"
+        f"Issue Body: {ctx['body']}\n"
+        "Provide ONLY the complete updated file content of main.js inside a javascript code block."
+    )
+
+    result, provider = generate_with_fallback(
+        prompt,
+        gemini_key=gemini_api_key,
+        openrouter_token=openrouter_token,
+        min_length=100,
+    )
+
+    if not result or not is_valid_response(result, min_length=100):
+        msg = (
+            "🤖 AI Issue Solver: 全プロバイダーが失敗したため PR を作成しませんでした。\n\n"
+            "試行順: Pollinations(GET/POST) → Kilo Gateway → OVH → Gemini → OpenRouter\n"
+            "手動で Issue を確認してください。"
+        )
+        print(msg)
+        comment_on_issue(issue_no, msg)
+        sys.exit(1)
+
+    code = extract_code_block(result)
+    if not code or len(code.strip()) < 100:
+        msg = (
+            f"🤖 AI Issue Solver: プロバイダー `{provider}` の応答が不正なため中止しました。"
+        )
+        print(msg)
+        comment_on_issue(issue_no, msg)
+        sys.exit(1)
+
     subprocess.run(["git", "config", "--global", "user.name", "AI Issue Solver"])
     subprocess.run(["git", "config", "--global", "user.email", "ai-issue-solver@screeps.local"])
-    
+
     branch = f"fix/ai-{issue_no}"
-    subprocess.run(["git", "checkout", "-b", branch])
-    with open("main.js", "w") as f:
-        f.write(code)
-    
-    subprocess.run(["git", "add", "."])
-    subprocess.run(["git", "commit", "--no-verify", "-m", f"fix: resolve issue #{issue_no}"])
-    subprocess.run(["git", "push", "origin", branch])
-    subprocess.run(["gh", "pr", "create", "--title", f"Fix #{issue_no}", "--body", f"Closes #{issue_no}", "--head", branch, "--base", "main"])
-    subprocess.run(["gh", "issue", "close", str(issue_no)])
+    subprocess.run(["git", "checkout", "-b", branch], check=True)
+    with open("main.js", "w", encoding="utf-8") as handle:
+        handle.write(code)
+
+    subprocess.run(["git", "add", "main.js"], check=True)
+    subprocess.run(
+        ["git", "commit", "--no-verify", "-m", f"fix: resolve issue #{issue_no} via {provider}"],
+        check=True,
+    )
+    subprocess.run(["git", "push", "origin", branch], check=True)
+    subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--title",
+            f"Fix #{issue_no}",
+            "--body",
+            f"Closes #{issue_no}\n\nAI provider: `{provider}`",
+            "--head",
+            branch,
+            "--base",
+            "main",
+        ],
+        check=True,
+    )
+    subprocess.run(["gh", "issue", "close", str(issue_no)], check=False)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/ai_providers.py
+++ b/scripts/ai_providers.py
@@ -1,0 +1,237 @@
+"""共有AIプロバイダー・フォールバック層（キー不要優先）。"""
+import json
+import re
+import urllib.parse
+import urllib.request
+
+POLLINATIONS_GET_MODELS = ["openai-fast", "openai"]
+POLLINATIONS_POST_MODELS = ["openai", "openai-fast"]
+
+OVH_BASE = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/chat/completions"
+OVH_MODELS = [
+    "Mistral-7B-Instruct-v0.3",
+    "Llama-3.1-8B-Instruct",
+    "Meta-Llama-3_3-70B-Instruct",
+    "Qwen3-Coder-30B-A3B-Instruct",
+    "gpt-oss-20b",
+]
+
+KILO_BASE = "https://api.kilo.ai/api/gateway/chat/completions"
+KILO_MODELS = [
+    "openrouter/free",
+    "minimax/minimax-m2.5:free",
+    "x-ai/grok-code-fast-1:free",
+]
+
+OPENROUTER_MODELS = [
+    "openrouter/free",
+    "qwen/qwen3-coder:free",
+    "nvidia/nemotron-3-super-120b-a12b:free",
+    "openai/gpt-oss-120b:free",
+    "meta-llama/llama-3.3-70b-instruct:free",
+    "poolside/laguna-m.1:free",
+]
+
+INVALID_RESPONSE_MARKERS = (
+    "fix pending due to api errors",
+    "model not found",
+    "api rate limit exceeded",
+    "missing api key",
+)
+
+
+def normalize_token(value):
+    if not value:
+        return None
+    token = value.strip().strip('"').strip("'")
+    return token or None
+
+
+def _openai_chat(url, model, prompt, headers=None, timeout=90):
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    req_headers = {"Content-Type": "application/json"}
+    if headers:
+        req_headers.update(headers)
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=req_headers,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        data = json.loads(response.read().decode("utf-8"))
+        if "choices" in data and data["choices"]:
+            content = data["choices"][0]["message"]["content"]
+            if content and content.strip():
+                return content.strip()
+    return None
+
+
+def is_valid_response(text, min_length=50):
+    if not text or not text.strip():
+        return False
+    normalized = text.strip().lower()
+    if len(normalized) < min_length:
+        return False
+    if any(marker in normalized for marker in INVALID_RESPONSE_MARKERS):
+        return False
+    return True
+
+
+def call_pollinations_get(prompt, model="openai-fast"):
+    try:
+        print(f"Trying Pollinations GET ({model})...")
+        encoded = urllib.parse.quote(prompt[:3000])
+        url = f"https://text.pollinations.ai/{encoded}?model={model}"
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req, timeout=90) as response:
+            text = response.read().decode("utf-8").strip()
+            if text and not text.startswith("{"):
+                return text
+    except Exception as exc:
+        print(f"Pollinations GET ({model}) failed: {exc}")
+    return None
+
+
+def call_pollinations_post(prompt, model="openai"):
+    try:
+        print(f"Trying Pollinations POST ({model})...")
+        payload = {
+            "messages": [{"role": "user", "content": prompt}],
+            "model": model,
+        }
+        req = urllib.request.Request(
+            "https://text.pollinations.ai/",
+            data=json.dumps(payload).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "Mozilla/5.0",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=90) as response:
+            text = response.read().decode("utf-8").strip()
+            if text and not text.startswith("{"):
+                return text
+    except Exception as exc:
+        print(f"Pollinations POST ({model}) failed: {exc}")
+    return None
+
+
+def call_kilo_gateway(prompt):
+    for model in KILO_MODELS:
+        try:
+            print(f"Trying Kilo Gateway ({model})...")
+            result = _openai_chat(KILO_BASE, model, prompt, timeout=90)
+            if result:
+                return result
+        except Exception as exc:
+            print(f"Kilo Gateway ({model}) failed: {exc}")
+    return None
+
+
+def call_ovh_anonymous(prompt):
+    for model in OVH_MODELS:
+        try:
+            print(f"Trying OVH AI Endpoints ({model})...")
+            result = _openai_chat(OVH_BASE, model, prompt, timeout=90)
+            if result:
+                return result
+        except Exception as exc:
+            print(f"OVH ({model}) failed: {exc}")
+    return None
+
+
+def call_openrouter(prompt, token):
+    token = normalize_token(token)
+    if not token:
+        return None
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Title": "screeps-ai-fallback",
+        "HTTP-Referer": "https://github.com/tadanobutubutu/screeps",
+    }
+    for model in OPENROUTER_MODELS:
+        try:
+            print(f"Trying OpenRouter ({model})...")
+            result = _openai_chat(
+                "https://openrouter.ai/api/v1/chat/completions",
+                model,
+                prompt,
+                headers=headers,
+                timeout=90,
+            )
+            if result:
+                return result
+        except Exception as exc:
+            print(f"OpenRouter ({model}) failed: {exc}")
+    return None
+
+
+def call_gemini(prompt, key):
+    key = normalize_token(key)
+    if not key:
+        return None
+    try:
+        print("Trying Google Gemini API (gemini-1.5-flash-latest)...")
+        url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            f"gemini-1.5-flash-latest:generateContent?key={key}"
+        )
+        payload = {"contents": [{"parts": [{"text": prompt}]}]}
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=90) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return data["candidates"][0]["content"]["parts"][0]["text"]
+    except Exception as exc:
+        print(f"Gemini API failed: {exc}")
+    return None
+
+
+def generate_with_fallback(prompt, gemini_key=None, openrouter_token=None, min_length=50):
+    """キー不要プロバイダーを優先し、順次フォールバックする。"""
+    providers = []
+
+    for model in POLLINATIONS_GET_MODELS:
+        providers.append((f"pollinations-get:{model}", lambda m=model: call_pollinations_get(prompt, m)))
+    for model in POLLINATIONS_POST_MODELS:
+        providers.append((f"pollinations-post:{model}", lambda m=model: call_pollinations_post(prompt, m)))
+    providers.append(("kilo-gateway", lambda: call_kilo_gateway(prompt)))
+    providers.append(("ovh-anonymous", lambda: call_ovh_anonymous(prompt)))
+
+    if gemini_key:
+        providers.append(("gemini", lambda: call_gemini(prompt, gemini_key)))
+    if openrouter_token:
+        providers.append(("openrouter", lambda: call_openrouter(prompt, openrouter_token)))
+
+    for name, caller in providers:
+        result = caller()
+        if is_valid_response(result, min_length=min_length):
+            print(f"✅ Success via {name}")
+            return result, name
+        if result:
+            print(f"⚠️ Rejected short/invalid response from {name}")
+
+    return None, None
+
+
+def extract_code_block(text):
+    match = re.search(r"```(?:javascript|js)?\s*(.*?)\s*```", text, re.DOTALL)
+    return match.group(1) if match else text
+
+
+def clean_plain_response(content):
+    content = content.strip()
+    if content.startswith("```"):
+        lines = content.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip() == "```":
+            lines = lines[:-1]
+        content = "\n".join(lines).strip()
+    return content

--- a/scripts/resolve_conflicts.py
+++ b/scripts/resolve_conflicts.py
@@ -2,8 +2,8 @@ import json
 import os
 import subprocess
 import sys
-import urllib.request
-import re
+
+from ai_providers import clean_plain_response, generate_with_fallback, normalize_token
 
 def run_cmd(args, check=True):
     print(f"Executing: {' '.join(args)}")
@@ -17,29 +17,10 @@ def run_cmd(args, check=True):
         )
     return res
 
-def call_gemini_api(prompt, key):
-    try:
-        print("Trying direct Google Gemini API (gemini-1.5-flash-latest)...")
-        url = f"https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key={key}"
-        payload = {
-            "contents": [{"parts": [{"text": prompt}]}]
-        }
-        req = urllib.request.Request(
-            url,
-            data=json.dumps(payload).encode('utf-8'),
-            headers={"Content-Type": "application/json"}
-        )
-        with urllib.request.urlopen(req, timeout=60) as f:
-            res = json.loads(f.read().decode('utf-8'))
-            return res['candidates'][0]['content']['parts'][0]['text']
-    except Exception as e:
-        print(f"Direct Gemini API failed: {e}")
-        return None
+def call_conflict_resolver_ai(file_content, filename):
+    token = normalize_token(os.environ.get("OPENROUTER_TOKEN"))
+    gemini_key = normalize_token(os.environ.get("GEMINI_API_KEY"))
 
-def call_openrouter_ai(file_content, filename):
-    token = os.environ.get("OPENROUTER_TOKEN")
-    gemini_key = os.environ.get("GEMINI_API_KEY")
-    
     prompt = f"""You are a Senior JavaScript/Node.js Developer resolving a Git merge conflict in a Screeps bot repository.
 Below is the content of the file '{filename}' with Git conflict markers.
 Please resolve the conflict in a meaningful, logical manner. Make sure to keep and integrate both changes if they both add features, or choose the correct logic that compiles and satisfies both needs. Do not discard functionality unless they are clearly redundant.
@@ -53,56 +34,16 @@ Here is the conflicting file:
 =========================================
 """
 
-    # 1. Try Direct Google Gemini API first
-    if gemini_key:
-        res = call_gemini_api(prompt, gemini_key)
-        if res:
-            return clean_response(res)
-            
-    # 2. Try OpenRouter free models
-    if token:
-        models = [
-            "openrouter/free",
-            "google/gemini-2.5-flash:free",
-            "google/gemini-2.0-flash-exp:free",
-        ]
-        for model in models:
-            try:
-                print(f"Trying OpenRouter model {model}...")
-                payload = {
-                    "model": model,
-                    "messages": [{"role": "user", "content": prompt}],
-                }
-                req = urllib.request.Request(
-                    "https://openrouter.ai/api/v1/chat/completions",
-                    data=json.dumps(payload).encode("utf-8"),
-                    headers={
-                        "Authorization": f"Bearer {token}",
-                        "Content-Type": "application/json",
-                        "X-Title": "screeps-conflict-resolver",
-                        "HTTP-Referer": "https://github.com/tadanobutubutu/screeps"
-                    },
-                )
-                with urllib.request.urlopen(req, timeout=90) as response:
-                    res_data = json.loads(response.read().decode("utf-8"))
-                    if 'choices' in res_data and len(res_data['choices']) > 0:
-                        content = res_data['choices'][0]['message']['content'].strip()
-                        if content:
-                            return clean_response(content)
-            except Exception as e:
-                print(f"OpenRouter model {model} failed: {e}")
-                
+    result, provider = generate_with_fallback(
+        prompt,
+        gemini_key=gemini_key,
+        openrouter_token=token,
+        min_length=50,
+    )
+    if result:
+        print(f"Conflict resolution succeeded via {provider}")
+        return clean_plain_response(result)
     return None
-
-def clean_response(content):
-    if content.startswith("```"):
-        lines = content.splitlines()
-        if lines[0].startswith("```"):
-            lines = lines[1:]
-        if lines and lines[-1].strip() == "```":
-            lines = lines[:-1]
-        content = "\n".join(lines).strip()
-    return content
 
 def main():
     if len(sys.argv) < 2:
@@ -175,7 +116,7 @@ def main():
         with open(filename, "r", encoding="utf-8", errors="ignore") as f:
             content = f.read()
 
-        resolved_content = call_openrouter_ai(content, filename)
+        resolved_content = call_conflict_resolver_ai(content, filename)
         if resolved_content:
             with open(filename, "w", encoding="utf-8") as f:
                 f.write(resolved_content)


### PR DESCRIPTION
## 概要
全員調査の結果を反映し、CI用AIスクリプトのフォールバック層を共通化・拡張しました。

## 調査で確認したキー不要/低制限プロバイダー

| プロバイダー | キー | 制限 | エンドポイント | 動作確認 |
|---|---|---|---|---|
| **Pollinations (GET)** | 不要 | 不明 | `GET https://text.pollinations.ai/{prompt}?model=openai-fast` | ✅ |
| **Pollinations (POST)** | 不要 | 不明 | `POST https://text.pollinations.ai/` | ✅ |
| **Kilo Gateway** | 不要 | ~200 req/hr | `POST https://api.kilo.ai/api/gateway/chat/completions` | ✅ |
| **OVH AI Endpoints** | 不要 | 2 RPM/IP/モデル | `POST https://oai.endpoints.kepler.ai.cloud.ovh.net/v1/chat/completions` | ✅ (レート制限あり) |
| OpenRouter `:free` | 要 | 20 RPM, 200 RPD | 旧モデル名は404 → 現行IDに更新 | キーあり時 |
| LLM7.io | 要（匿名は拒否） | 30 RPM | `https://api.llm7.io/v1` | ❌ キー必須化 |
| HuggingFace router | 要 | クレジット制 | `https://router.huggingface.co/v1` | ❌ |

## 変更内容

- 新規 `scripts/ai_providers.py` — 共有フォールバック層
- `ai_issue_solver.py` — キー不要プロバイダー優先、全失敗時は **PR作成せず exit 1**（main.js破損防止）
- `resolve_conflicts.py` — 同一フォールバック層を利用

## フォールバック順序

1. Pollinations GET (`openai-fast`, `openai`)
2. Pollinations POST
3. Kilo Gateway (`openrouter/free` 等)
4. OVH 匿名 (Mistral-7B, Llama-3.1-8B 等)
5. Gemini API（キーあり時）
6. OpenRouter 無料モデル（キーあり時、現行ID）

## 参考
- [awesome-free-llm-apis](https://github.com/mnfst/awesome-free-llm-apis)
- [freellmpool](https://github.com/0xzr/freellmpool) — 19プロバイダープール（将来の統合候補）

## Summary by Sourcery

Introduce a shared AI provider fallback layer for CI scripts, prioritizing keyless providers and tightening failure handling.

New Features:
- Add a reusable ai_providers module that centralizes AI provider configuration and fallback logic for CI automation.
- Report provider usage and failure outcomes back to GitHub issues when AI-based issue resolution cannot proceed.

Enhancements:
- Update ai_issue_solver to use the shared fallback layer, prefer keyless providers, validate AI responses, and avoid creating PRs when generation fails.
- Refactor resolve_conflicts to rely on the common AI provider module and improve conflict resolution robustness and logging.

CI:
- Standardize AI provider usage across CI-related scripts to use a unified, extensible fallback sequence with keyless providers first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies and expands the CI AI fallback layer with keyless providers first, and stops PR creation when all providers fail to avoid corrupting `main.js`. Both the issue solver and conflict resolver now use a shared provider module.

- **New Features**
  - Added `scripts/ai_providers.py` with a reusable fallback layer and response validation.
  - Fallback order: Pollinations (GET/POST) → Kilo Gateway → OVH anonymous → Gemini (key) → OpenRouter free (key).
  - Updated OpenRouter free model IDs to current ones.
  - When all providers fail, the workflow comments on the issue and exits without creating a PR.

- **Refactors**
  - `scripts/ai_issue_solver.py`: uses the shared fallback, extracts code blocks safely, commits with provider name, and writes only `main.js`.
  - `scripts/resolve_conflicts.py`: switches to the shared fallback and removes duplicated HTTP logic.

<sup>Written for commit aa64811471fd19e92f79c8945d620e8233855867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

