### PR TITLE
Improve dashboard interactivity and accessibility

### DIFF
--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -41,7 +41,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               transition: none !important;
             }
           }
-          kbd:focus-visible {
+          button:focus-visible, kbd:focus-visible {
             outline: 2px solid #004b73;
             outline-offset: 2px;
           }

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -1,28 +1,35 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 
 export default function Dashboard() {
     const [stats, setStats] = useState<any>(null),
         [error, setError] = useState<string | null>(null),
         [loading, setLoading] = useState(true),
-        [copied, setCopied] = useState(false),
-        [focused, setFocused] = useState(false);
-    useEffect(() => {
-        fetch('/api/screeps?endpoint=overview')
-            .then(async (r) => {
-                const d = await r.json();
-                if (!r.ok || d.error) throw new Error(d.error || `エラー: ${r.status}`);
-                return d;
-            })
-            .then((d) => {
-                setStats(d);
-                setLoading(false);
-            })
-            .catch((e) => {
-                setError(e.message || String(e));
-                setLoading(false);
-            });
+        [refreshing, setRefreshing] = useState(false),
+        [lastUpdated, setLastUpdated] = useState<Date | null>(null),
+        [copied, setCopied] = useState(false);
+
+    const fetchStats = useCallback(async (isManual = false) => {
+        if (isManual) setRefreshing(true);
+        try {
+            const r = await fetch('/api/screeps?endpoint=overview');
+            const d = await r.json();
+            if (!r.ok || d.error) throw new Error(d.error || `エラー: ${r.status}`);
+            setStats(d);
+            setLastUpdated(new Date());
+            setError(null);
+        } catch (e: any) {
+            setError(e.message || String(e));
+        } finally {
+            setLoading(false);
+            setRefreshing(false);
+        }
     }, []);
+
+    useEffect(() => {
+        fetchStats();
+    }, [fetchStats]);
+
     const copyErr = () =>
         error &&
         navigator.clipboard.writeText(error).then(() => {
@@ -60,8 +67,6 @@ export default function Dashboard() {
                 </pre>
                 <button
                     onClick={copyErr}
-                    onFocus={() => setFocused(true)}
-                    onBlur={() => setFocused(false)}
                     aria-label={copied ? 'コピー済み' : 'エラーをコピー'}
                     style={{
                         backgroundColor: copied ? '#155d27' : '#004b73',
@@ -70,17 +75,80 @@ export default function Dashboard() {
                         border: 'none',
                         borderRadius: '4px',
                         cursor: 'pointer',
-                        outline: 'none',
-                        boxShadow: focused ? '0 0 0 3px rgba(0, 75, 115, 0.4)' : 'none',
+                        transition: 'background-color 0.2s',
                     }}
                 >
                     {copied ? '✅ コピー済み' : '📋 エラーをコピー'}
+                </button>
+                <button
+                    onClick={() => fetchStats(true)}
+                    disabled={refreshing}
+                    style={{
+                        marginLeft: '1rem',
+                        padding: '0.5rem 1rem',
+                        cursor: refreshing ? 'not-allowed' : 'pointer',
+                        backgroundColor: refreshing ? '#edf2f7' : '#f7fafc',
+                        color: refreshing ? '#a0aec0' : 'inherit',
+                        border: '1px solid #cbd5e0',
+                        borderRadius: '4px',
+                        transition: 'all 0.2s',
+                    }}
+                >
+                    {refreshing ? '読み込み中...' : '🔄 再試行'}
                 </button>
             </main>
         );
     return (
         <main style={{ padding: '2rem', fontFamily: 'monospace' }}>
-            <h1 style={{ color: '#004b73' }}>🐛 Screeps ダッシュボード</h1>
+            <div
+                style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    marginBottom: '1rem',
+                }}
+            >
+                <h1 style={{ color: '#004b73', margin: 0 }}>🐛 Screeps ダッシュボード</h1>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
+                    {lastUpdated && (
+                        <span
+                            className="interactive-hint"
+                            tabIndex={0}
+                            title="最後にデータが更新された時間です"
+                            style={{ fontSize: '0.8rem', color: '#718096' }}
+                        >
+                            🕒 {lastUpdated.toLocaleTimeString()}
+                        </span>
+                    )}
+                    <button
+                        onClick={() => fetchStats(true)}
+                        disabled={refreshing}
+                        aria-label="更新"
+                        title="データを更新"
+                        style={{
+                            padding: '0.5rem',
+                            borderRadius: '50%',
+                            border: 'none',
+                            backgroundColor: refreshing ? '#edf2f7' : '#004b73',
+                            color: refreshing ? '#a0aec0' : 'white',
+                            cursor: refreshing ? 'not-allowed' : 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            transition: 'all 0.2s',
+                        }}
+                    >
+                        <span
+                            style={{
+                                display: 'inline-block',
+                                animation: refreshing ? 'spin 1s linear infinite' : 'none',
+                            }}
+                        >
+                            🔄
+                        </span>
+                    </button>
+                </div>
+            </div>
             <div
                 style={{
                     marginBottom: '1rem',
@@ -139,9 +207,34 @@ export default function Dashboard() {
                 >
                     📊 CPU 使用率: {stats?.cpuUsed?.toFixed(2)}
                 </p>
-                <p>
-                    🏘️ {stats?.rooms?.length === 1 ? '部屋' : '部屋数'}: {stats?.rooms?.length || 0}
-                </p>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap' }}>
+                    <span
+                        className="interactive-hint"
+                        tabIndex={0}
+                        title="AI が現在活動している部屋のリストです"
+                    >
+                        🏘️ {stats?.rooms?.length === 1 ? '部屋' : '部屋数'}:
+                    </span>
+                    {stats?.rooms?.length > 0 ? (
+                        stats.rooms.map((room: string) => (
+                            <span
+                                key={room}
+                                style={{
+                                    fontSize: '0.75rem',
+                                    backgroundColor: '#edf2f7',
+                                    padding: '0.1rem 0.4rem',
+                                    borderRadius: '4px',
+                                    border: '1px solid #cbd5e0',
+                                    color: '#2d3748',
+                                }}
+                            >
+                                {room}
+                            </span>
+                        ))
+                    ) : (
+                        <span style={{ color: '#a0aec0', fontStyle: 'italic' }}>なし</span>
+                    )}
+                </div>
             </div>
             <details style={{ cursor: 'pointer' }}>
                 <summary


### PR DESCRIPTION
This PR enhances the Screeps Dashboard with several micro-UX improvements focused on interactivity and accessibility.

**Key Changes:**

- **Manual refresh functionality**: Added a circular refresh button with spinning animation and a "Retry" button in the error state for manual data updates
- **Last updated timestamp**: Displays when data was last fetched with an interactive hint tooltip for transparency
- **Enhanced room visualization**: Room names now render as accessible badges instead of plain text, improving visual hierarchy
- **Improved accessibility**: Extended focus-visible styles to buttons globally (previously only on `kbd` elements) for better keyboard navigation
- **Refactored fetch logic**: Converted dashboard data fetching to use `useCallback` for better React hook compliance and maintainability, with improved error handling and loading state management
- **Removed manual focus tracking**: Simplified button focus management by relying on CSS focus-visible styles instead of manual state

The changes maintain the existing Japanese UI while providing clearer feedback during data loading and error states.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual refresh, a "Last updated" timestamp, and accessible room badges to the dashboard. Improves keyboard focus, error handling, and fetch reliability.

- **New Features**
  - Manual refresh button with spinner; Retry button on errors.
  - "Last updated" time with tooltip.
  - Room names shown as badges for clarity.
  - Focus-visible styles applied to buttons for better keyboard navigation.

- **Refactors**
  - Moved fetching to a `useCallback` `fetchStats` with cleaner loading/error handling.
  - Removed manual focus tracking; rely on CSS focus-visible.

<sup>Written for commit 5288bb42ba03b65cdcae4088933ae6a51dadb320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

