### PR TITLE
Remove unused commented-out code from attacker role

### DIFF
--- a/role.attacker.js
+++ b/role.attacker.js
@@ -11,7 +11,6 @@ const PATH_STYLE_STRUCTURE = { visualizePathStyle: { stroke: '#ff4400' }, reuseP
 const PATH_STYLE_PATROL = { visualizePathStyle: { stroke: '#ffaa00' } }
 const PATH_STYLE_PATROL_CONTROLLER = { visualizePathStyle: { stroke: '#ffaa00' }, range: 5 }
 
-// ⚡ PERFORMANCE: Hoisted filter function to reduce per-tick closure creation.
 const STRUCTURE_FILTER = (s) =>
   s.structureType === STRUCTURE_INVADER_CORE ||
     s.structureType === STRUCTURE_TOWER ||


### PR DESCRIPTION
This PR removes a commented-out performance note that is no longer needed in the codebase.

**Changes:**
- Removed obsolete comment about hoisted filter function optimization from `role.attacker.js`
- The `STRUCTURE_FILTER` function remains unchanged and continues to work as intended

**Rationale:**
Cleaning up stale comments improves code readability and reduces maintenance burden. The performance optimization referenced in the comment is already implemented in the code itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a stale commented-out performance note from role.attacker.js to improve readability. No behavior change; STRUCTURE_FILTER remains the same.

<sup>Written for commit 3f50cb4b10b0fa1dd740b8519d87880463919434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an outdated internal performance comment; gameplay behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->