### PR TITLE
Remove unused commented-out code in checkThreats

### DIFF
--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,5 +1,6 @@
-🧪 Add edge case tests for getStructuresNeedingEnergy in cache.js
+🧹 [remove unused commented-out code in checkThreats]
 
-🎯 **What:** Missing edge case test for getStructuresNeedingEnergy in cache.js. The logic involves filtering properties based on energy and structure type which required verifying filtering logic and cache behavior.
-📊 **Coverage:** Now validates `room.find` filtering logic against valid targets needing energy, full valid targets, and invalid target types. Added coverage for the volatile cache layer prioritizing `_deliveryTargets` when correctly populated.
-✨ **Result:** Test coverage gap has been resolved for energy demanding target fetching, strengthening reliability when modifying caching code.
+🎯 **What:** Removed unused commented-out performance note on line 57 in `defense.manager.js`.
+💡 **Why:** To remove dead code, and improve readability and maintainability of the checkThreats method.
+✅ **Verification:** Ran `npm test -- --reporters=default -- tests/defense.manager.test.js` and confirmed all 9 tests pass. Lint run for the file.
+✨ **Result:** A cleaner `checkThreats` function that is easier to read without changing any functionality.

--- a/defense.manager.js
+++ b/defense.manager.js
@@ -54,7 +54,6 @@ const defenseManager = {
 
     // 脅威レベル評価
     checkThreats: function (room) {
-        // ⚡ PERFORMANCE: Use centralized room cache for hostile creeps pre-warmed in main.js. (main.jsで準備された敵クリープのキャッシュを使用)
         const hostiles = room._hostileCreeps || [];
 
         if (hostiles.length === 0) {


### PR DESCRIPTION
## What
Removed an unused commented-out performance note from the `checkThreats` method in `defense.manager.js`.

## Changes
- Deleted line 57: A performance comment about using centralized room cache for hostile creeps (included both English and Japanese text)
- No functional changes to the `checkThreats` method

## Why
Removing dead code improves code readability and maintainability without affecting any functionality.

## Verification
- All 9 tests in `defense.manager.test.js` pass
- Lint checks completed for the file