### PR TITLE
Harden logging against console injection and credential leakage

### DIFF
--- a/utils.logging.js
+++ b/utils.logging.js
@@ -74,6 +74,9 @@ function _redactPaths(str) {
         [97, 112, 105, 75, 101, 121], // apiKey
         [97, 117, 116, 104], // auth
         [99, 114, 101, 100, 101, 110, 116, 105, 97, 108], // credential
+        [99, 114, 101, 100, 101, 110, 116, 105, 97, 108, 115], // credentials
+        [98, 101, 97, 114, 101, 114], // bearer
+        [115, 101, 115, 115, 105, 111, 110], // session
         [100, 115, 110], // dsn
     ]
         .map((codes) => codes.map((c) => String.fromCharCode(c)).join(''))
@@ -138,14 +141,17 @@ function getSafeStack(stack, maxLines) {
     return lines
         .slice(0, maxLines || 5)
         .map((line) => {
+            let processed;
             const match = line.match(/[^/\\]+:\d+:\d+/);
             if (match) {
-                return `    at ${match[0]}`;
+                processed = `    at ${match[0]}`;
+            } else if (line.trim().startsWith('at ')) {
+                processed = '    at [REDACTED]';
+            } else {
+                processed = _redactPaths(line);
             }
-            if (line.trim().startsWith('at ')) {
-                return '    at [REDACTED]';
-            }
-            return _redactPaths(line);
+            // Security: Escape each line to prevent HTML injection in console
+            return _escapeHTML(processed);
         })
         .join('\n');
 }
@@ -171,7 +177,10 @@ const format = (label, msg, meta) => {
         ? LOG_EMOJIS[label]
         : DEFAULT_EMOJI;
 
-    return `${emoji} [${label}] ${escapedMsg}${metaPart}`;
+    // Security: Escape the label to prevent console injection
+    const escapedLabel = _escapeHTML(label);
+
+    return `${emoji} [${escapedLabel}] ${escapedMsg}${metaPart}`;
 };
 
 /**


### PR DESCRIPTION
### Description

The changes in this pull request include updates to the logging utility file to improve security and add support for new credentials. Here is a summary of the changes:

- Added support for redacting the "credentials" and "session" fields in the log redaction process.
- Updated the redacted stack trace processing to handle different cases correctly, ensuring sensitive information is properly masked.
- Added an escape function to prevent HTML injection in log messages and labels for improved security.

These changes enhance security in the logging functionality and ensure sensitive information is appropriately handled and protected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened logging to prevent console/HTML injection and reduce sensitive data leakage. Escapes stack lines and labels, and expands redaction coverage.

- Bug Fixes
  - Escape stack trace lines and labels to block injection.
  - Redact “credentials”, “session”, and “bearer” fields.
  - Improve stack handling: keep only file:line:col, redact unknown frames, and sanitize paths.

<sup>Written for commit 7fd44968041b3da6eef0a57328dbed16d9240a40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

