### PR TITLE
Enhance GCL progress display and accessibility with number formatting

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -31,3 +31,8 @@
 **Learning:** When adding `title` attributes (tooltips) to non-interactive elements like `<p>` tags for UX hints, it is crucial to include `tabIndex={0}`. This ensures the hint is discoverable and readable by keyboard and screen reader users who would otherwise skip over the element.
 
 **Action:** Always pair `title` or UX hints on static elements with `tabIndex={0}` and appropriate semantic classes (e.g., `.interactive-hint`) to maintain accessibility standards.
+
+## 2026-07-16 - [Enhanced Progress Clarity & Accessibility]
+
+**Learning:** Combining number formatting (K, M, B suffixes) with `aria-valuetext` on progress bars provides a high-fidelity experience for both visual and screen-reader users. Showing the raw values (e.g., "1.2M / 2.0M") alongside the percentage reduces cognitive load and provides more tangible progress context.
+**Action:** Always provide both relative (percentage) and absolute (formatted count) values for progress metrics, and mirror this in `aria-valuetext` for accessibility.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -11,6 +11,13 @@ export default function Dashboard() {
         [copiedRoom, setCopiedRoom] = useState<string | null>(null),
         [copiedJson, setCopiedJson] = useState(false);
 
+    const formatNumber = (num: number) => {
+        if (num >= 1000000000) return (num / 1000000000).toFixed(1) + 'B';
+        if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M';
+        if (num >= 1000) return (num / 1000).toFixed(1) + 'K';
+        return num.toString();
+    };
+
     const fetchStats = useCallback(async (isManual = false) => {
         if (isManual) setRefreshing(true);
         try {
@@ -121,8 +128,8 @@ export default function Dashboard() {
                 <button
                     onClick={() => fetchStats(true)}
                     disabled={refreshing}
-                    aria-label="データを再読み込み"
-                    title="データを再読み込み"
+                    aria-label={refreshing ? '読み込み中...' : 'データを再読み込み'}
+                    title={refreshing ? '読み込み中...' : 'データを再読み込み'}
                     style={{
                         marginLeft: '1rem',
                         padding: '0.5rem 1rem',
@@ -162,6 +169,8 @@ export default function Dashboard() {
                     )}
                     <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
                         <kbd
+                            className="interactive-hint"
+                            tabIndex={0}
                             title="Alt + R キーで更新できます"
                             style={{
                                 backgroundColor: '#f7fafc',
@@ -179,8 +188,8 @@ export default function Dashboard() {
                         <button
                             onClick={() => fetchStats(true)}
                             disabled={refreshing}
-                            aria-label="更新 (Alt + R)"
-                            title="データを更新 (Alt + R)"
+                            aria-label={refreshing ? '更新中...' : '更新 (Alt + R)'}
+                            title={refreshing ? '更新中...' : 'データを更新 (Alt + R)'}
                             style={{
                                 padding: '0.5rem',
                                 borderRadius: '50%',
@@ -214,7 +223,12 @@ export default function Dashboard() {
                     borderRadius: '8px',
                 }}
             >
-                <div style={{ marginBottom: '1rem' }}>
+                <div
+                    style={{ marginBottom: '1rem' }}
+                    className="interactive-hint"
+                    tabIndex={0}
+                    title={`GCL ${stats?.gcl?.level || 0} 進捗: ${stats?.gcl?.progress || 0} / ${stats?.gcl?.progressTotal || 0}`}
+                >
                     <div
                         style={{
                             display: 'flex',
@@ -223,11 +237,14 @@ export default function Dashboard() {
                         }}
                     >
                         <span>🌐 GCL: {stats?.gcl?.level}</span>
-                        <span>
+                        <span style={{ fontSize: '0.85rem' }}>
+                            {stats?.gcl?.progress && stats?.gcl?.progressTotal ? (
+                                `${formatNumber(stats.gcl.progress)} / ${formatNumber(stats.gcl.progressTotal)} (`
+                            ) : ''}
                             {stats?.gcl?.progressTotal
                                 ? ((stats.gcl.progress / stats.gcl.progressTotal) * 100).toFixed(2)
                                 : '0.00'}
-                            %
+                            %{stats?.gcl?.progress && stats?.gcl?.progressTotal ? ')' : ''}
                         </span>
                     </div>
                     <div
@@ -236,6 +253,11 @@ export default function Dashboard() {
                         aria-valuenow={stats?.gcl?.progress || 0}
                         aria-valuemin={0}
                         aria-valuemax={stats?.gcl?.progressTotal || 100}
+                        aria-valuetext={`${stats?.gcl?.progress || 0} / ${stats?.gcl?.progressTotal || 0} (${
+                            stats?.gcl?.progressTotal
+                                ? ((stats.gcl.progress / stats.gcl.progressTotal) * 100).toFixed(2)
+                                : '0.00'
+                        }%)`}
                         style={{
                             height: '0.5rem',
                             backgroundColor: '#edf2f7',
@@ -257,13 +279,26 @@ export default function Dashboard() {
                         />
                     </div>
                 </div>
-                <p
-                    className="interactive-hint"
-                    title="現在のサーバー時間における AI の CPU 使用量です"
-                    tabIndex={0}
-                >
-                    📊 CPU 使用率: {stats?.cpuUsed?.toFixed(2)}
-                </p>
+                <div style={{ display: 'flex', gap: '2rem', marginBottom: '1rem' }}>
+                    <p
+                        className="interactive-hint"
+                        title="現在のサーバー時間における AI の CPU 使用量です"
+                        tabIndex={0}
+                        style={{ margin: 0 }}
+                    >
+                        📊 CPU 使用率: {stats?.cpuUsed?.toFixed(2)}
+                    </p>
+                    {stats?.power !== undefined && (
+                        <p
+                            className="interactive-hint"
+                            title="グローバルパワーレベル (GPL) です"
+                            tabIndex={0}
+                            style={{ margin: 0 }}
+                        >
+                            💪 GPL: {stats.power}
+                        </p>
+                    )}
+                </div>
                 <div
                     style={{
                         display: 'flex',
@@ -318,7 +353,7 @@ export default function Dashboard() {
                             e.stopPropagation();
                             copyRawData();
                         }}
-                        aria-label="生データをJSONとしてコピー"
+                        aria-label={copiedJson ? 'コピー済み' : '生データをJSONとしてコピー'}
                         title="JSONをコピー"
                         style={{
                             fontSize: '0.7rem',

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Implemented several micro-UX and accessibility improvements to the Screeps Dashboard. These include formatting large GCL numbers for better scanability, adding the missing Global Power Level (GPL) display, and significantly improving keyboard and screen-reader accessibility through proper ARIA attributes and focus management. The changes maintain linguistic consistency with the existing Japanese UI.

---
*PR created automatically by Jules for task [17984846698358570543](https://jules.google.com/task/17984846698358570543) started by @tadanobutubutu*

## Summary by Sourcery

Improve dashboard GCL progress display and overall accessibility for keyboard and screen-reader users.

New Features:
- Add Global Power Level (GPL) metric display alongside CPU usage on the dashboard.

Enhancements:
- Format large GCL progress values with K/M/B suffixes and show both absolute and percentage progress for better readability.
- Enhance accessibility hints by making key informational elements focusable and marking them with an interactive-hint class.
- Update refresh and copy buttons to reflect live status in their aria-labels and titles for clearer assistive feedback.
- Adjust Next.js TypeScript route type reference to use the dev routes types path.

Documentation:
- Add a palette note documenting best practices for combining formatted progress values with aria-valuetext for accessibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the dashboard to make GCL progress easier to read and more accessible, and added GPL next to CPU usage. Large numbers now use K/M/B formatting and controls work better with keyboard and screen readers.

- **New Features**
  - GCL progress shows "formatted current / formatted total (x%)" and exposes full context via `aria-valuetext`.
  - Added `formatNumber()` for K/M/B suffixes and a GPL stat alongside CPU usage.
  - Tooltip elements are focusable (`tabIndex={0}`) and buttons update `aria-label`/`title` based on state; Japanese labels are consistent.

<sup>Written for commit bcb66e40c758d1dcb38dec5b0555edabbf2beeff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GCL progress displays with readable K/M/B number formatting and percentage values.
  * Added clearer accessibility descriptions combining percentages with absolute progress counts.
  * Enhanced refresh, keyboard shortcut, and copy-status labels to reflect current states.
  * Added contextual GCL level and progress information, plus GPL details when available.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->