### PR TITLE
Optimize defender target selection with single-pass loop and score caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -28,3 +28,8 @@
 ## 2025-05-14 - Single-pass loop for multi-criteria target selection
 **Learning:** Chaining `.filter().sort()` or `.filter().closest()` in high-frequency roles (like Repairers or Upgraders) leads to (N \log N)$ complexity and multiple array allocations per tick.
 **Action:** Replace functional chains with a single `for` loop that tracks multiple minima (priority, hit ratio, distance) to achieve (N)$ complexity and zero intermediate array allocations.
+
+## 2024-06-05 - Caching Scores in Target Selection Loops
+
+**Learning:** Using `enemies.reduce` for target selection in Screeps roles (like Defenders) often leads to recalculating the score of the current "best" candidate in every iteration. In the worst case, this results in N$ calls to the scoring function.
+**Action:** Refactor selection logic to use a single-pass `for` loop and local variable to cache the `bestScore`. This ensures exactly $ scoring calls and avoids the minor overhead of the `reduce` callback.

--- a/src/roles/defender.js
+++ b/src/roles/defender.js
@@ -156,16 +156,21 @@ function _selectTarget(creep, enemies) {
         return null;
     }
 
-    return enemies.reduce((best, enemy) => {
-        if (!best) {
-            return enemy;
+    // ⚡ PERFORMANCE OPTIMIZATION: Use single-pass for loop and cache bestScore to reduce engine calls.
+    // Estimated impact: Reduces _calcThreatScore calls from 2N to N.
+    let best = null;
+    let bestScore = -Infinity;
+
+    for (let i = 0; i < enemies.length; i++) {
+        const enemy = enemies[i];
+        const score = _calcThreatScore(creep, enemy);
+        if (score > bestScore) {
+            bestScore = score;
+            best = enemy;
         }
+    }
 
-        const bestScore = _calcThreatScore(creep, best);
-        const enemyScore = _calcThreatScore(creep, enemy);
-
-        return enemyScore > bestScore ? enemy : best;
-    }, null);
+    return best;
 }
 
 /**


### PR DESCRIPTION
### Description

In this pull request, we are optimizing the target selection logic in the `Defender` role by reducing the number of calls to the scoring function. This optimization involves replacing the use of `enemies.reduce` with a single-pass `for` loop and caching the `bestScore` to improve performance.

Changes in this PR:
- Improved target selection performance in the `Defender` role by optimizing the loop and score caching.

Summary of changes:
- Replaced the `enemies.reduce` function with a single-pass `for` loop.
- Introduced `bestScore` to cache the score of the best target.
- Updated the logic to compare scores and select the best target efficiently.

## Summary by Sourcery

Optimize defender target selection performance by reducing threat score calculations and documenting the pattern in Bolt notes.

Enhancements:
- Refactor defender target selection to use a single-pass loop with cached scores for improved performance.

Documentation:
- Add Bolt note describing caching of scores in target selection loops to minimize scoring function calls.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize Defender target selection to run in a single pass with a cached best score. This cuts `_calcThreatScore` calls from 2N to N and reduces CPU during combat ticks.

- **Refactors**
  - Rewrote `_selectTarget` to use a single-pass `for` loop with a `bestScore` cache.
  - Added a performance note in `.jules/bolt.md` on caching scores for selection loops.

<sup>Written for commit 7c4d624c4e8e7a9e9e4eead69300e9033814c65f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

