### PR TITLE
Optimize repairer energy acquisition with single-pass loops

### DIFF
--- a/src/roles/repairer.js
+++ b/src/roles/repairer.js
@@ -274,29 +274,56 @@ function _buildAsBackup(creep) {
 function _getEnergy(creep) {
     const room = creep.room;
 
-    // 落下リソースを優先回収
+    // ⚡ PERFORMANCE OPTIMIZATION: Use single-pass for loops to avoid filter array allocations and find the closest target directly.
+    // Estimated impact: Reduces CPU cycles and memory churn in energy acquisition path.
+
+    // 1. 落下リソースを優先回収
     const dropped = cache.getDroppedResources(room);
-    const energyDrops = dropped.filter((r) => r.resourceType === RESOURCE_ENERGY && r.amount >= 30);
-    if (energyDrops.length > 0) {
-        const res = pathfinder.closest(creep.pos, energyDrops);
-        if (creep.pickup(res) === ERR_NOT_IN_RANGE) {
-            pathfinder.moveTo(creep, res, { range: 1 });
+    let bestDrop = null;
+    let minDropDist = Infinity;
+
+    for (let i = 0; i < dropped.length; i++) {
+        const r = dropped[i];
+        if (r.resourceType === RESOURCE_ENERGY && r.amount >= 30) {
+            const dist = creep.pos ? creep.pos.getRangeTo(r) : 0;
+            if (dist < minDropDist) {
+                minDropDist = dist;
+                bestDrop = r;
+            }
+        }
+    }
+
+    if (bestDrop) {
+        if (creep.pickup(bestDrop) === ERR_NOT_IN_RANGE) {
+            pathfinder.moveTo(creep, bestDrop, { range: 1 });
         }
         return;
     }
 
-    // コンテナから取得
+    // 2. コンテナから取得
     const containers = cache.getContainers(room);
-    const available = containers.filter((c) => c.store[RESOURCE_ENERGY] >= 100);
-    if (available.length > 0) {
-        const container = pathfinder.closest(creep.pos, available);
-        if (creep.withdraw(container, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-            pathfinder.moveTo(creep, container, { range: 1 });
+    let bestContainer = null;
+    let minContainerDist = Infinity;
+
+    for (let i = 0; i < containers.length; i++) {
+        const c = containers[i];
+        if (c.store[RESOURCE_ENERGY] >= 100) {
+            const dist = creep.pos ? creep.pos.getRangeTo(c) : 0;
+            if (dist < minContainerDist) {
+                minContainerDist = dist;
+                bestContainer = c;
+            }
+        }
+    }
+
+    if (bestContainer) {
+        if (creep.withdraw(bestContainer, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+            pathfinder.moveTo(creep, bestContainer, { range: 1 });
         }
         return;
     }
 
-    // ストレージから取得
+    // 3. ストレージから取得
     const storage = cache.getStorage(room);
     if (storage && storage.store[RESOURCE_ENERGY] >= 200) {
         if (creep.withdraw(storage, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
@@ -305,7 +332,7 @@ function _getEnergy(creep) {
         return;
     }
 
-    // ソースから直接採掘
+    // 4. ソースから直接採掘
     const source = cache.assignSource(creep, room);
     if (source) {
         if (creep.harvest(source) === ERR_NOT_IN_RANGE) {


### PR DESCRIPTION
### Description

In this pull request, we are optimizing the performance of the `_getEnergy` function in the `repairer.js` role. The aim is to optimize the energy acquisition process by using single-pass for loops to directly find and interact with the closest energy source, without the need for array filter operations. This optimization is expected to reduce CPU cycles and memory churn during the energy acquisition path, potentially leading to improved overall performance.

Below are the key changes made in the code:
- Replaced array filter operations with single-pass for loops to directly find and interact with the closest energy sources.
- Introduced variables to track the closest energy drops and containers, improving the efficiency of resource collection.
- Updated comments to reflect the optimized energy acquisition steps.

These code changes are focused on optimizing the energy acquisition process within the `repairer.js` role to enhance performance and reduce unnecessary array operations.

## Summary by Sourcery

Optimize the repairer role's energy acquisition routine for better performance.

Enhancements:
- Replace array-based filtering and closest-target selection with single-pass loops to directly find the nearest viable dropped energy and containers.
- Clarify and reorganize comments to document the prioritized, stepwise energy acquisition flow for repairers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimizes `_getEnergy` in `repairer.js` to find the nearest energy in one pass. Reduces CPU and memory use during the energy pickup path.

- **Refactors**
  - Replace array filters with single-pass loops for dropped energy and containers.
  - Select the nearest target via distance checks; movement and interactions unchanged.
  - Preserve acquisition order: dropped → containers → storage → source.

<sup>Written for commit 6a43ae26b562af34b97d8342f4ae53cce5fdcbb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

