### PR TITLE
Remove commented test explanation from log level bypass test

### DIFF
--- a/tests/sentinel_log_level_bypass.test.js
+++ b/tests/sentinel_log_level_bypass.test.js
@@ -37,10 +37,6 @@ describe('src/utils/logger security: log-level bypass', () => {
     });
 
     test('init() should default to INFO on invalid numeric Memory.logLevel', () => {
-        // Maliciously set Memory.logLevel to -1 to bypass gates
-        // If bug exists, _level is now -1.
-        // debug gate: if (_level > LOG_LEVEL.DEBUG) return;
-        // if (-1 > 0) return; -> false, so it logs!
         global.Memory.logLevel = -1; // Invalid negative value
 
         logger.init();


### PR DESCRIPTION
This PR removes outdated commented-out test logic that explained the security vulnerability being tested.

**Changes:**
- Removed 4 lines of explanatory comments from `sentinel_log_level_bypass.test.js` that documented the log-level bypass vulnerability scenario
- The test logic itself remains unchanged and continues to validate that invalid negative `Memory.logLevel` values default to INFO level

**Rationale:**
The comments were redundant documentation that cluttered the test code. The test case name and the actual test implementation are sufficiently clear without the additional explanation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed outdated commented-out logic from `tests/sentinel_log_level_bypass.test.js` to improve readability. Test behavior is unchanged and still verifies that invalid negative `Memory.logLevel` values default to INFO.

<sup>Written for commit 29886cc21b855160051edaf6cce89210e50a3a7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

