### PR TITLE
Add tests for showDashboard logger method

### DIFF
--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -111,6 +111,41 @@ describe('logger', () => {
         });
     });
 
+
+    describe('showDashboard', () => {
+        test('ダッシュボード情報を正しく出力する', () => {
+            // ダッシュボードに表示するログを追加
+            logger.setLevel(0); // 全てのログを出力するようにする
+            logger.info('Test info dashboard');
+            logger.warn('Test warn dashboard');
+
+            logger.showDashboard();
+
+            // ヘッダーやレベルの表示など、複数回 console.log が呼ばれることを確認
+            expect(console.log).toHaveBeenCalled();
+
+            // 出力内容のチェック
+            const calls = console.log.mock.calls.map(call => call[0]);
+
+            // 各行の出力が含まれているか確認
+            const hasHeader = calls.some(msg => msg.includes('=== Logger Dashboard ==='));
+            const hasLevel = calls.some(msg => msg.includes('Level: 0 (0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NONE)'));
+            const hasStats = calls.some(msg => msg.includes('Stats: DEBUG=0 INFO=1 WARN=1 ERROR=0'));
+            const hasRecentLogsHeader = calls.some(msg => msg.includes('Recent logs:'));
+
+            // エスケープ処理されたログメッセージが出力されているか確認
+            const hasInfoLog = calls.some(msg => msg.includes('Test info dashboard'));
+            const hasWarnLog = calls.some(msg => msg.includes('Test warn dashboard'));
+
+            expect(hasHeader).toBe(true);
+            expect(hasLevel).toBe(true);
+            expect(hasStats).toBe(true);
+            expect(hasRecentLogsHeader).toBe(true);
+            expect(hasInfoLog).toBe(true);
+            expect(hasWarnLog).toBe(true);
+        });
+    });
+
     describe('_redactPaths', () => {
         test('文字列以外の入力はそのまま返す', () => {
             expect(logger._redactPaths(null)).toBeNull();


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `showDashboard` method in the logger module.

**Changes:**
- Added a new test suite for `showDashboard` that verifies the dashboard output displays correctly
- Tests validate that the dashboard includes all expected components:
  - Dashboard header ("=== Logger Dashboard ===")
  - Current log level with description
  - Log statistics (counts by level: DEBUG, INFO, WARN, ERROR)
  - Recent logs section with logged messages
- Test sets up logger state with sample info and warn level logs to ensure output accuracy

**Implementation Details:**
- Test verifies `console.log` is called and inspects all output calls to confirm expected content
- Validates that both the dashboard structure and actual log messages are properly displayed
- Uses Japanese comments indicating this is part of a Japanese-language codebase

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `showDashboard` in the logger to verify the dashboard shows the header, current level, stats, and recent logs. Tests seed info and warn logs, call `showDashboard`, and assert `console.log` includes the expected lines and messages.

<sup>Written for commit 85975d62898a72dc6f2f063eebf5344049918772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

