### PR TITLE
Add test coverage for getMyCreeps cache utility

### DIFF
--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -231,6 +231,34 @@ describe('cache', () => {
         });
     });
 
+    describe('getMyCreeps', () => {
+        test('自分のクリープを取得する', () => {
+            const mockRoom = {
+                name: 'W1N1',
+                find: jest.fn().mockReturnValue([{ name: 'creep1' }]),
+            };
+
+            const creeps = cache.getMyCreeps(mockRoom);
+
+            expect(creeps.length).toBeGreaterThan(0);
+            expect(mockRoom.find).toHaveBeenCalledWith(global.FIND_MY_CREEPS);
+        });
+
+        test('キャッシュから取得される場合はフィルタリングが実行されない', () => {
+            const mockCreeps = [{ name: 'creep2' }];
+            const mockRoom = {
+                name: 'W1N1',
+                _myCreeps: mockCreeps,
+                _myCreepsTick: global.Game.time,
+                find: jest.fn(),
+            };
+
+            const creeps = cache.getMyCreeps(mockRoom);
+            expect(creeps).toBe(mockCreeps);
+            expect(mockRoom.find).not.toHaveBeenCalled();
+        });
+    });
+
     describe('getConstructionSites', () => {
         test('建設サイトを取得する', () => {
             const mockRoom = {


### PR DESCRIPTION
This PR adds comprehensive unit tests for the `getMyCreeps` function in the cache utilities module.

**Changes:**
- Added test suite for `getMyCreeps` with two test cases:
  - Verifies that the function correctly retrieves creeps from a room using `FIND_MY_CREEPS`
  - Validates that cached creeps are returned without re-querying when available in the current tick
- Tests confirm proper caching behavior and that the `find` method is only called when necessary

**Test Coverage:**
The new tests ensure the caching mechanism works as intended, preventing unnecessary room queries when creep data is already cached for the current game tick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `getMyCreeps` in utils/cache to validate room retrieval via `FIND_MY_CREEPS` and per-tick caching. Confirms cached creeps are returned and `room.find` is not called when the cache is warm.

<sup>Written for commit d3a9b403d4ca37f7daaa8c3f99a7e7911418de2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

