### PR TITLE
Enhance getSources test coverage in cache.test.js

### DIFF
--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -202,6 +202,48 @@ describe('cache', () => {
             expect(sources.length).toBe(2);
             expect(mockRoom.find).toHaveBeenCalledWith(FIND_SOURCES);
         });
+
+        test('複数回呼び出してもキャッシュが利用され、findは1回だけ呼ばれる', () => {
+            const mockRoom = {
+                name: 'W1N2',
+                find: jest.fn().mockReturnValue([{ id: 'source1' }, { id: 'source2' }]),
+            };
+
+            const sources1 = cache.getSources(mockRoom);
+            const sources2 = cache.getSources(mockRoom);
+
+            expect(sources1).toBe(sources2);
+            expect(mockRoom.find).toHaveBeenCalledTimes(1);
+            expect(mockRoom.find).toHaveBeenCalledWith(FIND_SOURCES);
+        });
+
+        test('TTL経過後は再度findが呼ばれる', () => {
+            const mockRoom = {
+                name: 'W1N3',
+                find: jest.fn().mockReturnValue([{ id: 'source1' }]),
+            };
+
+            cache.getSources(mockRoom);
+            expect(mockRoom.find).toHaveBeenCalledTimes(1);
+
+            // TTLを進める
+            global.Game.time += 100; // CACHE_TTL.SOURCES
+
+            cache.getSources(mockRoom);
+            expect(mockRoom.find).toHaveBeenCalledTimes(2);
+        });
+
+        test('ソースが見つからない場合は空の配列を返す', () => {
+            const mockRoom = {
+                name: 'W1N4',
+                find: jest.fn().mockReturnValue([]),
+            };
+
+            const sources = cache.getSources(mockRoom);
+
+            expect(sources.length).toBe(0);
+            expect(mockRoom.find).toHaveBeenCalledWith(FIND_SOURCES);
+        });
     });
 
     describe('getStructures', () => {


### PR DESCRIPTION
This PR improves test coverage for the `getSources` method in the caching utilities by adding three new test cases that validate critical caching behavior.

**What's Added:**
- **Cache reuse test**: Verifies that multiple calls to `getSources` return the same cached instance and only invoke `room.find()` once
- **TTL expiration test**: Confirms that the cache properly invalidates after the TTL expires, triggering a fresh `room.find()` call
- **Empty response handling**: Ensures the method correctly returns an empty array when no sources are found

**Why This Matters:**
These tests provide confidence that the cache invalidation logic works as expected, making it safer to refactor the core caching utilities in the future. The tests cover the primary use cases and edge cases for source caching behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand test coverage for `getSources` in the caching utilities to guard against regressions. Adds three tests for cache reuse (multiple calls return the same cached instance and call `room.find` once), TTL expiration (after advancing `Game.time`, a fresh `room.find` occurs), and empty results (returns []).

<sup>Written for commit 3a08615e6d202065b4a1e9663acd26385b1f56c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

