### PR TITLE
Enhance getStats test coverage with explicit assertions

### DIFF
--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -30,6 +30,7 @@ describe('logger', () => {
         global.Game.time = 100;
         console.log = jest.fn();
         logger.setLevel(0);
+        logger.resetStats();
     });
 
     describe('debug', () => {
@@ -77,6 +78,11 @@ describe('logger', () => {
 
             expect(stats).toBeDefined();
             expect(typeof stats).toBe('object');
+            expect(stats.info).toBe(1);
+            expect(stats.warn).toBe(1);
+            expect(stats.error).toBe(1);
+            expect(stats.debug).toBe(0);
+            expect(stats.total).toBe(3);
         });
     });
 


### PR DESCRIPTION
This PR improves the test coverage for the `getStats` function in the logger module by adding explicit assertions for all stat counters.

**Changes:**
- Added `logger.resetStats()` call in the `beforeEach` hook to prevent test state leaks between test cases
- Enhanced the `getStats` test with explicit assertions for individual log level counts (`debug`, `info`, `warn`, `error`) and the total count
- Validates that the stats aggregation correctly tracks all logging calls

**Why:** These improvements ensure the logger's statistics tracking works as expected and provides confidence when modifying logging logic in the future.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve `logger.getStats` test coverage by resetting stats in `beforeEach` and asserting counts for info, warn, error, debug, and total. Prevents state leaks between tests and verifies accurate aggregation.

<sup>Written for commit 11665ffaa0619c6c1628aa11c9c6c3b830ff7401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

