### PR TITLE
Strengthen cache getStats tests with precise assertions

### DIFF
--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -174,8 +174,8 @@ describe('cache', () => {
             const stats = cache.getStats();
 
             expect(stats.total).toBe(2);
-            expect(stats.active).toBeGreaterThanOrEqual(0);
-            expect(stats.expired).toBeGreaterThanOrEqual(0);
+            expect(stats.active).toBe(2);
+            expect(stats.expired).toBe(0);
         });
 
         test('有効期限ジャストのキャッシュを期限切れとしてカウントする', () => {
@@ -187,6 +187,29 @@ describe('cache', () => {
             expect(stats.total).toBe(1);
             expect(stats.expired).toBe(1);
             expect(stats.active).toBe(0);
+        });
+
+        test('不正なexpiresプロパティを持つキャッシュは期限切れとしてカウントしない', () => {
+            cache.get('key1', () => 'data1', 10);
+            global.cache['key1'].expires = 'invalid';
+            global.Game.time += 10;
+
+            const stats = cache.getStats();
+
+            expect(stats.total).toBe(1);
+            expect(stats.expired).toBe(0);
+            expect(stats.active).toBe(1);
+        });
+
+        test('falsyなキャッシュエントリはエラーにならず無視される', () => {
+            cache.get('key1', () => 'data1', 10);
+            global.cache['key1'] = null; // inject falsy entry
+
+            const stats = cache.getStats();
+
+            expect(stats.total).toBe(1); // total counts the tracked cacheSize, which wasn't updated by our manual assignment
+            expect(stats.expired).toBe(0);
+            expect(stats.active).toBe(1);
         });
     });
 


### PR DESCRIPTION
This PR improves the test coverage for the cache utility's `getStats()` method by replacing loose assertions with precise expectations.

**Key Changes:**
- **Tightened existing assertions**: Changed `toBeGreaterThanOrEqual(0)` to exact value assertions (`toBe(2)` and `toBe(0)`) in the basic getStats test, ensuring deterministic test behavior
- **Added edge case tests**: Introduced two new test cases to verify robustness:
  - Invalid `expires` property handling: Ensures cache entries with malformed expiration values don't cause errors
  - Falsy cache entry handling: Verifies the stats calculation gracefully handles null/falsy entries without crashing

These improvements strengthen the test suite by validating both normal operation and error resilience of the cache statistics functionality.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strengthened `cache.getStats` tests to ensure accurate active/expired counts and safe handling of edge cases. Tightened expectations and added cases for invalid `expires` values and ignored falsy cache entries.

<sup>Written for commit 3a8292baf4679ccb43c9fe62257226e4b37a675f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved cache statistics coverage, including invalid expiration values and falsy entries.
  * Added exact assertions for active and expired cache counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->