### PR TITLE
refactor(roles): 🧹 [code health] Extract _getEnergy logic in repairer into modular sub-functions

### DIFF
--- a/src/roles/repairer.js
+++ b/src/roles/repairer.js
@@ -277,7 +277,19 @@ function _getEnergy(creep) {
     // ⚡ PERFORMANCE OPTIMIZATION: Use single-pass for loops to avoid filter array allocations and find the closest target directly.
     // Estimated impact: Reduces CPU cycles and memory churn in energy acquisition path.
 
-    // 1. 落下リソースを優先回収
+    if (_getEnergyFromDropped(creep, room)) return;
+    if (_getEnergyFromContainer(creep, room)) return;
+    if (_getEnergyFromStorage(creep, room)) return;
+    _getEnergyFromSource(creep, room);
+}
+
+/**
+ * 落下リソースを優先回収
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromDropped(creep, room) {
     const dropped = cache.getDroppedResources(room);
     let bestDrop = null;
     let minDropDist = Infinity;
@@ -297,10 +309,18 @@ function _getEnergy(creep) {
         if (creep.pickup(bestDrop) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, bestDrop, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // 2. コンテナから取得
+/**
+ * コンテナから取得
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromContainer(creep, room) {
     const containers = cache.getContainers(room);
     let bestContainer = null;
     let minContainerDist = Infinity;
@@ -320,25 +340,43 @@ function _getEnergy(creep) {
         if (creep.withdraw(bestContainer, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, bestContainer, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // 3. ストレージから取得
+/**
+ * ストレージから取得
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromStorage(creep, room) {
     const storage = cache.getStorage(room);
     if (storage && storage.store[RESOURCE_ENERGY] >= 200) {
         if (creep.withdraw(storage, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, storage, { range: 1 });
         }
-        return;
+        return true;
     }
+    return false;
+}
 
-    // 4. ソースから直接採掘
+/**
+ * ソースから直接採掘
+ * @param {Creep} creep
+ * @param {Room} room
+ * @returns {boolean}
+ */
+function _getEnergyFromSource(creep, room) {
     const source = cache.assignSource(creep, room);
     if (source) {
         if (creep.harvest(source) === ERR_NOT_IN_RANGE) {
             pathfinder.moveTo(creep, source, { range: 1 });
         }
+        return true;
     }
+    return false;
 }
 
 // ============================================================


### PR DESCRIPTION
🎯 **What:** Extracted the monolithic `_getEnergy` function in `src/roles/repairer.js` into four distinct helper functions (`_getEnergyFromDropped`, `_getEnergyFromContainer`, `_getEnergyFromStorage`, and `_getEnergyFromSource`).

💡 **Why:** To improve code readability and maintainability. The main `_getEnergy` function now acts as a clean orchestrator, evaluating sources sequentially and exiting early, which matches the established pattern used in `src/roles/upgrader.js`.

✅ **Verification:** Validated syntax with `node -c src/roles/repairer.js` and ran the test suite using `npm test -- --reporters=default --passWithNoTests src/roles/repairer.js` and `npm test` to ensure no new regressions were introduced (out-of-scope pre-existing errors in `utils.logging.js` etc. were ignored).

✨ **Result:** A cleaner, more modular repairer energy logic that preserves the original behavior while drastically reducing the length of the original `_getEnergy` function.

---
*PR created automatically by Jules for task [12687679472597556723](https://jules.google.com/task/12687679472597556723) started by @tadanobutubutu*