### PR TITLE
Expand test coverage for defender role

### DIFF
--- a/tests/src.roles.defender.test.js
+++ b/tests/src.roles.defender.test.js
@@ -209,4 +209,236 @@ describe('src/roles/defender', () => {
             global.MOVE,
         ]);
     });
+
+    test('run() catches and logs errors', () => {
+        const creep = {
+            name: 'error_creep',
+            room: roomMock,
+            getActiveBodyparts: jest.fn().mockImplementation(() => {
+                throw new Error('Test Error');
+            }),
+        };
+        const logger = require('../src/utils/logger');
+
+        defender.run(creep);
+        expect(logger.error).toHaveBeenCalled();
+    });
+
+    test('_attack returns early if no target is selected', () => {
+        const enemyWithNoScore = {
+            id: 'enemy_zero',
+            hits: 100,
+            hitsMax: 100,
+            pos: new RoomPosition(10, 10, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(0),
+            room: roomMock,
+        };
+        // Mock _calcThreatScore indirectly or pass empty enemies
+        cache.getEnemies.mockReturnValue([]);
+        const creep = {
+            name: 'def_notarget',
+            memory: {},
+            room: roomMock,
+            pos: new RoomPosition(11, 11, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(1),
+            rangedAttack: jest.fn(),
+            attack: jest.fn(),
+        };
+
+        defender.run(creep);
+        expect(creep.attack).not.toHaveBeenCalled();
+        expect(creep.rangedAttack).not.toHaveBeenCalled();
+    });
+
+    test('_executeMeleeCombat branches appropriately', () => {
+        const target = {
+            id: 'enemy2',
+            hits: 50,
+            hitsMax: 100,
+            pos: new RoomPosition(15, 15, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(1),
+            room: roomMock,
+        };
+        cache.getEnemies.mockReturnValue([target]);
+
+        const creep = {
+            name: 'def_melee',
+            hits: 100,
+            hitsMax: 100,
+            memory: {},
+            room: roomMock,
+            pos: new RoomPosition(11, 11, 'W0N0'),
+            getActiveBodyparts: jest.fn((part) => part === global.ATTACK ? 1 : 0),
+            attack: jest.fn(),
+        };
+
+        // Dist > 1 (e.g. pos 11,11 to 15,15 dist is 4)
+        defender.run(creep);
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, target, { range: 1 });
+        expect(creep.attack).not.toHaveBeenCalled();
+
+        // Dist <= 1
+        creep.pos = new RoomPosition(14, 15, 'W0N0');
+        pathfinder.moveTo.mockClear();
+        defender.run(creep);
+        expect(creep.attack).toHaveBeenCalledWith(target);
+        expect(pathfinder.moveTo).not.toHaveBeenCalled();
+    });
+
+    test('_executeRangedCombat branches when dist > RANGED_RANGE', () => {
+        const target = {
+            id: 'enemy_ranged',
+            hits: 50,
+            hitsMax: 100,
+            pos: new RoomPosition(20, 20, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(1),
+            room: roomMock,
+        };
+        cache.getEnemies.mockReturnValue([target]);
+
+        const creep = {
+            name: 'def_ranged',
+            hits: 100,
+            hitsMax: 100,
+            memory: {},
+            room: roomMock,
+            pos: new RoomPosition(10, 10, 'W0N0'), // dist 10
+            getActiveBodyparts: jest.fn((part) => part === global.RANGED_ATTACK ? 1 : 0),
+            rangedAttack: jest.fn(),
+        };
+
+        defender.run(creep);
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, target, { range: 3 });
+        expect(creep.rangedAttack).not.toHaveBeenCalled();
+    });
+
+    test('_patrol generates fallback patrol points if no ramparts', () => {
+        cache.getEnemies.mockReturnValue([]);
+        cache.getMyStructures.mockReturnValue([]); // No ramparts
+
+        const creep = {
+            name: 'def_patrol_fallback',
+            memory: { patrolIndex: 0 },
+            room: roomMock,
+            pos: new RoomPosition(25, 25, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(0),
+        };
+
+        defender.run(creep);
+        // The mock room doesn't move but we can verify pathfinder was called with one of the fallback points (e.g. 5, 5 or 25, 25).
+        // For patrolIndex 0, it should target the first fallback point {x: 5, y: 5}.
+        expect(pathfinder.moveTo).toHaveBeenCalled();
+        const callArgs = pathfinder.moveTo.mock.calls[0];
+        expect(callArgs[1].x).toBe(5);
+        expect(callArgs[1].y).toBe(5);
+    });
+
+    test('_patrol handles moving to next point', () => {
+        cache.getEnemies.mockReturnValue([]);
+        const rampart1 = { pos: new RoomPosition(5, 5, 'W0N0') };
+        const rampart2 = { pos: new RoomPosition(10, 10, 'W0N0') };
+        cache.getMyStructures.mockReturnValue([rampart1, rampart2]);
+
+        const posMock = {
+            x: 5,
+            y: 5,
+            roomName: 'W0N0',
+            getRangeTo: jest.fn().mockReturnValue(1) // Force distance <= 2
+        };
+
+        const creep = {
+            name: 'def_patrol_next',
+            memory: { patrolIndex: 0 },
+            room: roomMock,
+            pos: posMock,
+            getActiveBodyparts: jest.fn().mockReturnValue(0),
+        };
+
+        defender.run(creep);
+        expect(creep.memory.patrolIndex).toBe(1); // Should advance index
+    });
+
+    test('getBody handles various energy levels', () => {
+        // Ranged
+        expect(defender.getBody(450, true)).toEqual([global.TOUGH, global.RANGED_ATTACK, global.RANGED_ATTACK, global.MOVE, global.MOVE, global.MOVE]);
+        expect(defender.getBody(300, true)).toEqual([global.RANGED_ATTACK, global.MOVE]);
+
+        // Melee
+        expect(defender.getBody(800, false)).toEqual([global.TOUGH, global.TOUGH, global.TOUGH, global.ATTACK, global.ATTACK, global.ATTACK, global.MOVE, global.MOVE, global.MOVE, global.MOVE]);
+        expect(defender.getBody(400, false)).toEqual([global.TOUGH, global.TOUGH, global.ATTACK, global.ATTACK, global.MOVE, global.MOVE, global.MOVE]);
+        expect(defender.getBody(100, false)).toEqual([global.ATTACK, global.MOVE]);
+    });
+
+    test('shouldActivateSafeMode early returns false conditions', () => {
+        // No controller
+        let room = { controller: null };
+        expect(defender.shouldActivateSafeMode(room)).toBe(false);
+
+        // Controller not mine
+        room = { controller: { my: false } };
+        expect(defender.shouldActivateSafeMode(room)).toBe(false);
+
+        // Safe mode already active
+        room = { controller: { my: true, safeMode: 1000, safeModeAvailable: 1 } };
+        expect(defender.shouldActivateSafeMode(room)).toBe(false);
+
+        // No safe mode available
+        room = { controller: { my: true, safeMode: null, safeModeAvailable: 0 } };
+        expect(defender.shouldActivateSafeMode(room)).toBe(false);
+
+        // No invasion
+        room = { controller: { my: true, safeMode: null, safeModeAvailable: 1 } };
+        cache.getEnemies.mockReturnValue([]);
+        expect(defender.shouldActivateSafeMode(room)).toBe(false);
+    });
+
+    test('shouldActivateSafeMode correctly factors in defenderCount', () => {
+        const hostile = { getActiveBodyparts: jest.fn().mockReturnValue(1), hitsMax: 100 };
+        cache.getEnemies.mockReturnValue([hostile, hostile, hostile]); // 3 enemies
+
+        // 3 defenders => false
+        cache.getMyCreeps.mockReturnValue([
+            { memory: { role: 'defender' }, getActiveBodyparts: jest.fn().mockReturnValue(1) },
+            { memory: { role: 'defender' }, getActiveBodyparts: jest.fn().mockReturnValue(1) },
+            { memory: { role: 'defender' }, getActiveBodyparts: jest.fn().mockReturnValue(1) },
+        ]);
+        expect(defender.shouldActivateSafeMode(roomMock)).toBe(false);
+
+        // 2 defenders => true
+        cache.getMyCreeps.mockReturnValue([
+            { memory: { role: 'defender' }, getActiveBodyparts: jest.fn().mockReturnValue(1) },
+            { memory: { role: 'defender' }, getActiveBodyparts: jest.fn().mockReturnValue(1) },
+        ]);
+        expect(defender.shouldActivateSafeMode(roomMock)).toBe(true);
+    });
+
+    test('_executeRangedCombat kiting when dist <= 1 and hasMelee=false', () => {
+        const target = {
+            id: 'enemy_kite',
+            hits: 50,
+            hitsMax: 100,
+            pos: new RoomPosition(10, 10, 'W0N0'),
+            getActiveBodyparts: jest.fn().mockReturnValue(1),
+            room: roomMock,
+        };
+        cache.getEnemies.mockReturnValue([target]);
+
+        const creep = {
+            name: 'def_kite',
+            hits: 100,
+            hitsMax: 100,
+            memory: {},
+            room: roomMock,
+            pos: new RoomPosition(10, 11, 'W0N0'), // dist 1
+            getActiveBodyparts: jest.fn((part) => part === global.RANGED_ATTACK ? 1 : 0),
+            rangedAttack: jest.fn(),
+            attack: jest.fn(),
+        };
+
+        defender.run(creep);
+        expect(creep.rangedAttack).toHaveBeenCalledWith(target);
+        expect(pathfinder.moveTo).toHaveBeenCalled(); // _fleeFrom uses moveTo with range: 0
+    });
+
+
 });


### PR DESCRIPTION
This PR significantly improves test coverage for the defender role module by adding 11 new test cases covering critical functionality and edge cases.

**Key additions:**

- **Error handling**: Test that `run()` properly catches and logs errors
- **Attack logic**: Tests for early returns when no target is selected, melee combat branching (distance-based movement vs. attack), and ranged combat behavior
- **Patrol mechanics**: Tests for fallback patrol point generation when no ramparts exist and patrol index advancement
- **Body composition**: Tests for `getBody()` across various energy levels for both ranged and melee variants
- **Safe mode activation**: Comprehensive tests for `shouldActivateSafeMode()` including controller validation, safe mode availability checks, and defender count calculations
- **Kiting behavior**: Test for ranged-only creeps executing proper kiting (ranged attack + retreat) when enemies are adjacent

These tests ensure the defender role handles combat scenarios, patrol routes, and defensive decisions correctly across different configurations and edge cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added 11 unit tests for the defender role covering error handling, combat branches, patrol logic, body selection, safe mode decisions, and kiting. This increases coverage and reduces regressions in core defense behavior.

- **Testing**
  - run() catches and logs errors.
  - Early return when no target; melee moves vs. attacks by distance; ranged moves when out of range.
  - Ranged kiting when adjacent and no melee parts.
  - Patrol: fallback points without ramparts; patrol index advances at waypoints.
  - getBody validates ranged and melee builds across energy tiers.
  - shouldActivateSafeMode checks controller state, availability, invasions, and defender count.

<sup>Written for commit 87d1e17bf7856a561788c8d43880c3f607bcd441. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

