### PR TITLE
Add comprehensive test suite for harvester role

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -61,6 +61,7 @@ module.exports = [
                 ERR_NO_PATH: 'readonly',
                 ERR_NAME_EXISTS: 'readonly',
                 ERR_BUSY: 'readonly',
+        ERR_FULL: 'readonly',
                 ERR_NOT_FOUND: 'readonly',
                 ERR_NOT_ENOUGH_ENERGY: 'readonly',
                 ERR_NOT_ENOUGH_RESOURCES: 'readonly',

--- a/src/roles/harvester.js
+++ b/src/roles/harvester.js
@@ -295,4 +295,4 @@ function getBody(energy) {
     return [WORK, CARRY, MOVE];
 }
 
-module.exports = { run, getBody, TASK, _findDroppedEnergy, _findAvailableContainer };
+module.exports = { run, getBody, TASK, _findDroppedEnergy, _findAvailableContainer, _updateWorkingState, _harvest, _deliver, _findEnergyTarget, _upgradeAsBackup };

--- a/tests/src.roles.harvester.test.js
+++ b/tests/src.roles.harvester.test.js
@@ -5,6 +5,7 @@
 global.Game = { creeps: {} };
 global.Memory = {};
 global.RESOURCE_ENERGY = 'energy';
+global.OK = 0;
 global.WORK = 'work';
 global.CARRY = 'carry';
 global.MOVE = 'move';
@@ -51,6 +52,7 @@ jest.mock(
     { virtual: true }
 );
 
+const { MEMORY_KEYS } = require('../src/constants');
 const pathfinder = require('../src/utils/pathfinder');
 const harvester = require('../src/roles/harvester');
 
@@ -278,5 +280,408 @@ describe('_findAvailableContainer', () => {
             validContainer2,
         ]);
         expect(result).toBe(validContainer2);
+    });
+});
+
+describe('_updateWorkingState', () => {
+    test('working状態のとき、エネルギーが0なら採掘モード(working=false)に遷移する', () => {
+        const creep = {
+            memory: { [MEMORY_KEYS.WORKING]: true, [MEMORY_KEYS.SOURCE_ID]: 'source1' },
+            store: { [global.RESOURCE_ENERGY]: 0, getCapacity: jest.fn().mockReturnValue(100) },
+            say: jest.fn(),
+        };
+
+        harvester._updateWorkingState(creep);
+
+        expect(creep.memory[MEMORY_KEYS.WORKING]).toBe(false);
+        expect(creep.say).toHaveBeenCalledWith('🔄 採掘');
+        expect(creep.memory[MEMORY_KEYS.SOURCE_ID]).toBeUndefined();
+    });
+
+    test('working状態ではないとき、エネルギーが満杯なら納品モード(working=true)に遷移する', () => {
+        const creep = {
+            memory: { [MEMORY_KEYS.WORKING]: false },
+            store: { [global.RESOURCE_ENERGY]: 100, getCapacity: jest.fn().mockReturnValue(100) },
+            say: jest.fn(),
+        };
+
+        harvester._updateWorkingState(creep);
+
+        expect(creep.memory[MEMORY_KEYS.WORKING]).toBe(true);
+        expect(creep.say).toHaveBeenCalledWith('🚚 納品');
+    });
+
+    test('その他の状態では何もしない', () => {
+        const creep = {
+            memory: { [MEMORY_KEYS.WORKING]: true, [MEMORY_KEYS.SOURCE_ID]: 'source1' },
+            store: { [global.RESOURCE_ENERGY]: 50, getCapacity: jest.fn().mockReturnValue(100) },
+            say: jest.fn(),
+        };
+
+        harvester._updateWorkingState(creep);
+
+        expect(creep.memory[MEMORY_KEYS.WORKING]).toBe(true);
+        expect(creep.say).not.toHaveBeenCalled();
+        expect(creep.memory[MEMORY_KEYS.SOURCE_ID]).toBe('source1');
+    });
+});
+
+describe('_harvest', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('落下エネルギーがある場合、それを拾う', () => {
+        const dropped = { amount: 50, resourceType: global.RESOURCE_ENERGY };
+        mockCache.getDroppedResources.mockReturnValue([dropped]);
+        pathfinder.closest.mockReturnValue(dropped);
+
+        const creep = {
+            pos: {},
+            room: {},
+            pickup: jest.fn().mockReturnValue(global.OK),
+        };
+
+        harvester._harvest(creep);
+
+        expect(creep.pickup).toHaveBeenCalledWith(dropped);
+        expect(pathfinder.moveTo).not.toHaveBeenCalled();
+    });
+
+    test('落下エネルギーがある場合、距離が遠ければ移動する', () => {
+        const dropped = { amount: 50, resourceType: global.RESOURCE_ENERGY };
+        mockCache.getDroppedResources.mockReturnValue([dropped]);
+        pathfinder.closest.mockReturnValue(dropped);
+
+        const creep = {
+            pos: {},
+            room: {},
+            pickup: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
+        };
+
+        harvester._harvest(creep);
+
+        expect(creep.pickup).toHaveBeenCalledWith(dropped);
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, dropped, { range: 1 });
+    });
+
+    test('コンテナにエネルギーがある場合、引き出す', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        const container = { store: { [global.RESOURCE_ENERGY]: 200 } };
+        mockCache.getContainers.mockReturnValue([container]);
+        pathfinder.closest.mockReturnValue(container);
+
+        const creep = {
+            pos: {},
+            room: {},
+            withdraw: jest.fn().mockReturnValue(global.OK),
+        };
+
+        harvester._harvest(creep);
+
+        expect(creep.withdraw).toHaveBeenCalledWith(container, global.RESOURCE_ENERGY);
+        expect(pathfinder.moveTo).not.toHaveBeenCalled();
+    });
+
+    test('コンテナにエネルギーがある場合、距離が遠ければ移動する', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        const container = { store: { [global.RESOURCE_ENERGY]: 200 } };
+        mockCache.getContainers.mockReturnValue([container]);
+        pathfinder.closest.mockReturnValue(container);
+
+        const creep = {
+            pos: {},
+            room: {},
+            withdraw: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
+        };
+
+        harvester._harvest(creep);
+
+        expect(creep.withdraw).toHaveBeenCalledWith(container, global.RESOURCE_ENERGY);
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, container, { range: 1 });
+    });
+
+    test('ソースから採掘する', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        const source = { id: 'source1' };
+        mockCache.assignSource.mockReturnValue(source);
+
+        const creep = {
+            pos: {},
+            room: {},
+            harvest: jest.fn().mockReturnValue(global.OK),
+            name: 'creep1'
+        };
+
+        harvester._harvest(creep);
+
+        expect(mockCache.assignSource).toHaveBeenCalledWith(creep, creep.room);
+        expect(creep.harvest).toHaveBeenCalledWith(source);
+    });
+
+    test('ソースから採掘し、ソースが空の場合メモリをクリアする', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        const source = { id: 'source1' };
+        mockCache.assignSource.mockReturnValue(source);
+
+        const creep = {
+            pos: {},
+            room: {},
+            harvest: jest.fn().mockReturnValue(global.ERR_NOT_ENOUGH_ENERGY),
+            memory: { [MEMORY_KEYS.SOURCE_ID]: 'source1' },
+            name: 'creep1'
+        };
+
+        harvester._harvest(creep);
+
+        expect(creep.harvest).toHaveBeenCalledWith(source);
+        expect(creep.memory[MEMORY_KEYS.SOURCE_ID]).toBeUndefined();
+    });
+
+    test('ソースが見つからない場合は警告を出す', () => {
+        mockCache.getDroppedResources.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        const logger = require('../src/utils/logger');
+        mockCache.assignSource.mockReturnValue(null);
+
+        const creep = {
+            pos: {},
+            room: {},
+            name: 'creep1'
+        };
+
+        harvester._harvest(creep);
+
+        expect(logger.warn).toHaveBeenCalledWith(`[creep1] ソースが見つかりません`);
+    });
+});
+
+describe('_deliver', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('キャッシュされたターゲットが存在し、容量がある場合はそれを使用する', () => {
+        const target = {
+            id: 'spawn1',
+            store: { getFreeCapacity: jest.fn().mockReturnValue(10) },
+            structureType: global.STRUCTURE_SPAWN,
+        };
+        global.Game.getObjectById = jest.fn().mockReturnValue(target);
+
+        const creep = {
+            memory: { targetId: 'spawn1' },
+            transfer: jest.fn().mockReturnValue(global.OK),
+            room: { name: 'W1N1' }
+        };
+
+        harvester._deliver(creep);
+
+        expect(global.Game.getObjectById).toHaveBeenCalledWith('spawn1');
+        expect(creep.transfer).toHaveBeenCalledWith(target, global.RESOURCE_ENERGY);
+        expect(creep.memory.targetId).toBeUndefined();
+    });
+
+    test('キャッシュされたターゲットが無効な場合（存在しない、容量0）、再検索する', () => {
+        const invalidTarget = {
+            id: 'spawn1',
+            store: { getFreeCapacity: jest.fn().mockReturnValue(0) },
+            structureType: global.STRUCTURE_SPAWN,
+        };
+        global.Game.getObjectById = jest.fn().mockReturnValue(invalidTarget);
+
+        const newTarget = {
+            id: 'ext1',
+            store: { getFreeCapacity: jest.fn().mockReturnValue(50) },
+            structureType: global.STRUCTURE_EXTENSION,
+        };
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([newTarget]);
+
+        const creep = {
+            memory: { targetId: 'spawn1' },
+            transfer: jest.fn().mockReturnValue(global.OK),
+            room: { name: 'W1N1' },
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) }
+        };
+
+        harvester._deliver(creep);
+
+        expect(creep.memory.targetId).toBeUndefined(); // Should be cleared, then might be reassigned to undefined or deleted at the end of successful transfer
+    });
+
+    test('ターゲットに納品して ERR_FULL になった場合、キャッシュを無効化する', () => {
+        const target = {
+            id: 'spawn1',
+            store: { getFreeCapacity: jest.fn().mockReturnValue(10) },
+            structureType: global.STRUCTURE_SPAWN,
+        };
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([target]);
+        global.Game.getObjectById = jest.fn().mockReturnValue(null);
+
+        const creep = {
+            memory: {},
+            transfer: jest.fn().mockReturnValue(global.ERR_FULL),
+            room: { name: 'W1N1' },
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) }
+        };
+
+        harvester._deliver(creep);
+
+        expect(creep.memory.targetId).toBeUndefined();
+        expect(mockCache.invalidate).toHaveBeenCalledWith(`need_energy_W1N1`);
+    });
+
+    test('納品先がない場合はアップグレードを補助する', () => {
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        mockCache.getStorage.mockReturnValue(null);
+        global.Game.getObjectById = jest.fn().mockReturnValue(null);
+
+        const controller = { id: 'controller' };
+        const creep = {
+            memory: {},
+            transfer: jest.fn(),
+            upgradeController: jest.fn().mockReturnValue(global.OK),
+            room: { name: 'W1N1', controller },
+            pos: {}
+        };
+
+        harvester._deliver(creep);
+
+        expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+    });
+});
+
+describe('_findEnergyTarget', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('スポーン・エクステンションが最も優先される', () => {
+        const creep = {
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {}
+        };
+        const spawn = { structureType: global.STRUCTURE_SPAWN };
+        const tower = { structureType: global.STRUCTURE_TOWER, store: { getFreeCapacity: jest.fn().mockReturnValue(300) } };
+
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([spawn, tower]);
+
+        const result = harvester._findEnergyTarget(creep);
+
+        expect(result).toBe(spawn);
+    });
+
+    test('スポーン・エクステンションがない場合、タワー（空き容量>200）が優先される', () => {
+        const creep = {
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {}
+        };
+        const tower = { structureType: global.STRUCTURE_TOWER, store: { getFreeCapacity: jest.fn().mockReturnValue(300) } };
+
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([tower]);
+
+        const result = harvester._findEnergyTarget(creep);
+
+        expect(result).toBe(tower);
+    });
+
+    test('上記のどれもない場合、コンテナ（空き容量>200）が優先される', () => {
+        const creep = {
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {}
+        };
+        const container = { store: { getFreeCapacity: jest.fn().mockReturnValue(300) } };
+
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([container]);
+
+        const result = harvester._findEnergyTarget(creep);
+
+        expect(result).toBe(container);
+    });
+
+    test('コンテナもない場合、ストレージ（空き容量>0）が選ばれる', () => {
+        const creep = {
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {}
+        };
+        const storage = { store: { getFreeCapacity: jest.fn().mockReturnValue(100) } };
+
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        mockCache.getStorage.mockReturnValue(storage);
+
+        const result = harvester._findEnergyTarget(creep);
+
+        expect(result).toBe(storage);
+    });
+
+    test('候補が何もない場合はnullを返す', () => {
+        const creep = {
+            pos: { getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {}
+        };
+
+        mockCache.getStructuresNeedingEnergy.mockReturnValue([]);
+        mockCache.getContainers.mockReturnValue([]);
+        mockCache.getStorage.mockReturnValue(null);
+
+        const result = harvester._findEnergyTarget(creep);
+
+        expect(result).toBeNull();
+    });
+});
+
+describe('_upgradeAsBackup', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('コントローラーがない場合は何もしない', () => {
+        const creep = {
+            room: {}
+        };
+
+        harvester._upgradeAsBackup(creep);
+
+        // 呼び出しによるエラーが起きないことを確認
+    });
+
+    test('コントローラーが範囲外の場合は移動する', () => {
+        const controller = { id: 'controller' };
+        const creep = {
+            upgradeController: jest.fn().mockReturnValue(global.ERR_NOT_IN_RANGE),
+            room: { controller }
+        };
+
+        harvester._upgradeAsBackup(creep);
+
+        expect(creep.upgradeController).toHaveBeenCalledWith(controller);
+        expect(pathfinder.moveTo).toHaveBeenCalledWith(creep, controller, { range: 3 });
+    });
+});
+
+describe('getBody', () => {
+    test('energy >= 750', () => {
+        expect(harvester.getBody(750)).toEqual([WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE]);
+        expect(harvester.getBody(800)).toEqual([WORK, WORK, WORK, CARRY, CARRY, MOVE, MOVE, MOVE]);
+    });
+
+    test('energy >= 500', () => {
+        expect(harvester.getBody(500)).toEqual([WORK, WORK, CARRY, CARRY, MOVE, MOVE]);
+        expect(harvester.getBody(749)).toEqual([WORK, WORK, CARRY, CARRY, MOVE, MOVE]);
+    });
+
+    test('energy >= 300', () => {
+        expect(harvester.getBody(300)).toEqual([WORK, WORK, CARRY, MOVE]);
+        expect(harvester.getBody(499)).toEqual([WORK, WORK, CARRY, MOVE]);
+    });
+
+    test('energy < 300', () => {
+        expect(harvester.getBody(299)).toEqual([WORK, CARRY, MOVE]);
+        expect(harvester.getBody(0)).toEqual([WORK, CARRY, MOVE]);
     });
 });


### PR DESCRIPTION
This PR adds extensive test coverage for the harvester role module, including tests for internal helper functions that were previously untested.

**Key Changes:**

- **Exported internal functions** from `harvester.js` to enable testing: `_updateWorkingState`, `_harvest`, `_deliver`, `_findEnergyTarget`, and `_upgradeAsBackup`
- **Added 406 lines of test cases** covering:
  - `_updateWorkingState`: State transitions between harvesting and delivery modes based on energy levels
  - `_harvest`: Energy collection from dropped resources, containers, and sources with proper error handling
  - `_deliver`: Energy delivery to spawns, extensions, towers, containers, and storage with priority logic
  - `_findEnergyTarget`: Target prioritization for energy delivery
  - `_upgradeAsBackup`: Controller upgrade as fallback behavior
  - `getBody`: Body composition based on available energy
- **Updated ESLint config** to recognize the `ERR_FULL` global constant
- **Added test setup** for required constants and mocks

The test suite validates the harvester's core logic including state management, resource prioritization, and error handling across various game scenarios.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added unit tests for `src/roles/harvester.js`, exporting internal helpers to verify harvesting/delivery logic and edge cases. Coverage for the module now hits 100% for statements and functions.

- **Tests**
  - Covered state transitions, pickup/withdraw/harvest flows, delivery priority, cache invalidation, and upgrade fallback.
  - Verified edge cases like missing targets, empty sources, and invalid cached targets.

- **Refactors**
  - Exported `_updateWorkingState`, `_harvest`, `_deliver`, `_findEnergyTarget`, and `_upgradeAsBackup` for testing.
  - Added `ERR_FULL` to `eslint.config.js` globals to support test assertions.

<sup>Written for commit 1e4b07040fe20b95f2e8a3ad3253ac7af66d88af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

