### PR TITLE
Fix accessible interactive nesting in dashboard summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -46,3 +46,8 @@
 
 **Learning:** Providing non-disruptive, transient visual feedback for manually triggered background actions (such as dashboard refresh buttons or keyboard shortcuts like Alt + R) makes interactions feel responsive and highly rewarding. Pairing this banner with an `aria-live="polite"` attribute ensures keyboard and screen reader users are immediately updated on task completion without shifting focus.
 **Action:** Always include transient visual badges accompanied by `aria-live="polite"` attributes when actions complete in the background to keep all users seamlessly informed.
+
+## 2026-07-28 - [Accessible Interactive Nesting inside Summary]
+
+**Learning:** Nesting interactive elements like `<button>` inside a `<summary>` element violates HTML specifications and breaks accessibility. Screen readers and keyboard navigation users lose focus control or fail to activate either the details disclosure or the nested button correctly.
+**Action:** Keep `<summary>` elements clean of nested focusable controls; instead, place interactive buttons or tooltips inside the body of the `<details>` container, formatted with appropriate visual groupings.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -405,55 +405,57 @@ export default function Dashboard() {
                     title="生データを JSON 形式で表示/非表示にします"
                     style={{
                         color: '#4a5568',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.5rem',
+                        padding: '0.2rem 0',
                     }}
                 >
                     <span>生データを確認</span>
-                    <button
-                        onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            copyRawData();
-                        }}
-                        onMouseEnter={() => setJsonHover(true)}
-                        onMouseLeave={() => setJsonHover(false)}
-                        onFocus={() => setJsonHover(true)}
-                        onBlur={() => setJsonHover(false)}
-                        aria-label={copiedJson ? 'コピー済み' : '生データをJSONとしてコピー'}
-                        title={copiedJson ? 'コピー済み' : 'JSONをコピー'}
+                </summary>
+                <div style={{ marginTop: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+                    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+                        <button
+                            onClick={(e) => {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                copyRawData();
+                            }}
+                            onMouseEnter={() => setJsonHover(true)}
+                            onMouseLeave={() => setJsonHover(false)}
+                            onFocus={() => setJsonHover(true)}
+                            onBlur={() => setJsonHover(false)}
+                            aria-label={copiedJson ? 'コピー済み' : '生データをJSONとしてコピー'}
+                            title={copiedJson ? 'コピー済み' : 'JSONをコピー'}
+                            style={{
+                                fontSize: '0.75rem',
+                                padding: '0.3rem 0.6rem',
+                                backgroundColor: copiedJson
+                                    ? '#155d27'
+                                    : jsonHover
+                                      ? '#e2e8f0'
+                                      : '#edf2f7',
+                                border: '1px solid #cbd5e0',
+                                borderRadius: '4px',
+                                color: copiedJson ? 'white' : '#4a5568',
+                                cursor: 'pointer',
+                                transition: 'all 0.2s ease-in-out',
+                                transform: jsonHover ? 'scale(1.05)' : 'scale(1)',
+                                boxShadow: jsonHover ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
+                            }}
+                        >
+                            {copiedJson ? '✅ コピー済み' : '📋 JSONをコピー'}
+                        </button>
+                    </div>
+                    <pre
                         style={{
-                            fontSize: '0.7rem',
-                            padding: '0.1rem 0.4rem',
-                            backgroundColor: copiedJson
-                                ? '#155d27'
-                                : jsonHover
-                                  ? '#e2e8f0'
-                                  : '#f7fafc',
-                            border: '1px solid #cbd5e0',
+                            backgroundColor: '#f7fafc',
+                            padding: '1rem',
                             borderRadius: '4px',
-                            color: copiedJson ? 'white' : '#4a5568',
-                            cursor: 'pointer',
-                            transition: 'all 0.2s ease-in-out',
-                            transform: jsonHover ? 'scale(1.05)' : 'scale(1)',
-                            boxShadow: jsonHover ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
+                            margin: 0,
+                            overflow: 'auto',
                         }}
                     >
-                        {copiedJson ? '✅ コピー済み' : '📋 JSONをコピー'}
-                    </button>
-                </summary>
-                <pre
-                    style={{
-                        backgroundColor: '#f7fafc',
-                        padding: '1rem',
-                        borderRadius: '4px',
-                        marginTop: '0.5rem',
-                        overflow: 'auto',
-                    }}
-                >
-                    {JSON.stringify(stats, null, 2)}
-                </pre>
+                        {JSON.stringify(stats, null, 2)}
+                    </pre>
+                </div>
             </details>
         </main>
     );


### PR DESCRIPTION
This PR resolves HTML specification violations and accessibility issues in the dashboard's raw data disclosure component.

**Changes:**
- Moved the "JSONをコピー" (Copy JSON) button out of the `<summary>` element into the expanded body of the `<details>` container
- Restructured the layout to use a flex column wrapper for better visual organization of the button and JSON preview
- Updated button styling for improved visibility and interaction feedback within the new context
- Documented the accessibility learning in `.jules/palette.md` for future reference

**Why:**
Nesting interactive elements like `<button>` inside `<summary>` violates HTML specifications and breaks keyboard navigation and screen reader functionality. Users lose proper focus control and may fail to activate either the disclosure or the button. This fix ensures all users—including those using assistive technologies—can properly interact with both the disclosure toggle and the copy button.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an HTML spec and accessibility issue by moving the "JSONをコピー" button out of the `<summary>` and into the body of the `<details>`, so keyboard and screen reader users can use both controls correctly. Also updates the flex layout and button styles, and adds an accessibility note to `.jules/palette.md`.

<sup>Written for commit 2016f4de52ade7c5dcb17a2e6dac7c7754e06a9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

