### PR TITLE
Add accessible toast notifications and keyboard shortcut hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ junit.xml
 .cache/
 coverage/
 docs/plato-report/
+*.tsbuildinfo
 
 # AI solver artifacts
 scripts/__pycache__/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -51,3 +51,8 @@
 
 **Learning:** Nesting interactive elements like `<button>` inside a `<summary>` element violates HTML specifications and breaks accessibility. Screen readers and keyboard navigation users lose focus control or fail to activate either the details disclosure or the nested button correctly.
 **Action:** Keep `<summary>` elements clean of nested focusable controls; instead, place interactive buttons or tooltips inside the body of the `<details>` container, formatted with appropriate visual groupings.
+
+## 2026-07-29 - [Overlay Portal Placement for Toast Notifications]
+
+**Learning:** When implementing a floating Toast notification system, rendering the Toast component nested deep inside layout wrappers (like collapsible `<details>` or scrollable boxes) can cause the Toast to become completely hidden or cut off by container styles (`display: none` or `overflow: hidden`). Placing the Toast at the root level of the component's main layout prevents layout inheritance issues and ensures visual consistency.
+**Action:** Always position floating status/feedback notifications at the absolute root or outermost level of your React component hierarchy rather than nested inside conditional blocks.

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 
 export default function Dashboard() {
     const [stats, setStats] = useState<any>(null),
@@ -15,6 +15,29 @@ export default function Dashboard() {
     const [hoveredRoom, setHoveredRoom] = useState<string | null>(null);
     const [jsonHover, setJsonHover] = useState(false);
     const [refreshSuccess, setRefreshSuccess] = useState(false);
+    const [toastMsg, setToastMsg] = useState<string | null>(null);
+
+    const toastTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+    const showToast = (msg: string) => {
+        if (toastTimeoutRef.current) {
+            clearTimeout(toastTimeoutRef.current);
+        }
+        setToastMsg(msg);
+        toastTimeoutRef.current = setTimeout(() => {
+            setToastMsg(null);
+            toastTimeoutRef.current = null;
+        }, 2500);
+    };
+
+    // Clean up timeout on unmount
+    useEffect(() => {
+        return () => {
+            if (toastTimeoutRef.current) {
+                clearTimeout(toastTimeoutRef.current);
+            }
+        };
+    }, []);
 
     const formatNumber = (num: number) => {
         if (num >= 1000000000) return (num / 1000000000).toFixed(1) + 'B';
@@ -35,9 +58,11 @@ export default function Dashboard() {
             if (isManual) {
                 setRefreshSuccess(true);
                 setTimeout(() => setRefreshSuccess(false), 2000);
+                showToast('データを最新の状態に更新しました');
             }
         } catch (e: any) {
             setError(e.message || String(e));
+            showToast('データの更新に失敗しました');
         } finally {
             setLoading(false);
             setRefreshing(false);
@@ -75,12 +100,14 @@ export default function Dashboard() {
         navigator.clipboard.writeText(error).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
+            showToast('エラーメッセージをクリップボードにコピーしました');
         });
 
     const copyRoom = (room: string) => {
         navigator.clipboard.writeText(room).then(() => {
             setCopiedRoom(room);
             setTimeout(() => setCopiedRoom(null), 2000);
+            showToast(`部屋名 ${room} をクリップボードにコピーしました`);
         });
     };
 
@@ -88,6 +115,7 @@ export default function Dashboard() {
         navigator.clipboard.writeText(JSON.stringify(stats, null, 2)).then(() => {
             setCopiedJson(true);
             setTimeout(() => setCopiedJson(false), 2000);
+            showToast('生データをクリップボードにコピーしました');
         });
     };
 
@@ -200,6 +228,7 @@ export default function Dashboard() {
                         <kbd
                             className="interactive-hint"
                             tabIndex={0}
+                            aria-label="キーボードショートカット Alt + R キーでダッシュボードの更新ができます"
                             title="Alt + R キーで更新できます"
                             style={{
                                 backgroundColor: '#f7fafc',
@@ -457,6 +486,31 @@ export default function Dashboard() {
                     </pre>
                 </div>
             </details>
+            {toastMsg && (
+                <div
+                    aria-live="polite"
+                    style={{
+                        position: 'fixed',
+                        bottom: '2rem',
+                        right: '2rem',
+                        backgroundColor: '#004b73',
+                        color: 'white',
+                        padding: '0.75rem 1.5rem',
+                        borderRadius: '8px',
+                        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+                        fontSize: '0.9rem',
+                        fontWeight: 'bold',
+                        zIndex: 1000,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.5rem',
+                        animation: 'bounce 0.5s ease-in-out',
+                    }}
+                >
+                    <span>✨</span>
+                    <span>{toastMsg}</span>
+                </div>
+            )}
         </main>
     );
 }


### PR DESCRIPTION
This PR enhances the Dashboard component with improved user feedback and accessibility features.

**Key Changes:**

- **Toast Notification System**: Implemented a floating toast notification component that displays at the root level of the layout to ensure visibility and prevent layout inheritance issues. Toasts automatically dismiss after 2.5 seconds with proper cleanup on component unmount.

- **User Feedback Integration**: Added toast messages for key user actions:
  - Data refresh success/failure notifications (in Japanese)
  - Clipboard copy confirmations for error messages, room names, and raw data

- **Accessibility Improvements**: 
  - Added `aria-live="polite"` to toast notifications for screen reader announcements
  - Added `aria-label` to keyboard shortcut hint for better context to assistive technology users

- **Documentation**: Updated the Jules Palette with a new learning entry about proper overlay portal placement for floating notifications to prevent layout-related visibility issues.

- **Build Configuration**: Added `*.tsbuildinfo` to `.gitignore` to exclude TypeScript build cache files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds accessible, floating toast notifications to the Dashboard and integrates them with refresh and copy actions. Also improves the Alt+R shortcut hint, ignores TypeScript build cache, and documents toast portal placement.

- New Features
  - Floating toast at layout root; auto-dismiss after 2.5s with cleanup; screen reader-friendly via aria-live="polite".
  - Toasts for refresh success/failure (Japanese) and clipboard copy confirmations (error text, room names, raw data).
  - Added aria-label to the Alt+R shortcut hint for clearer assistive tech context.
  - Ignore `*.tsbuildinfo` in `.gitignore` and added a learning note in `/.jules/palette.md` on correct toast portal placement.

<sup>Written for commit db60b0cac8961bb4ca1a99c41772818017c7a4a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

