### PR TITLE
Harden reward parameter validation in mission creation

### DIFF
--- a/tests/utils.missions.test.js
+++ b/tests/utils.missions.test.js
@@ -146,4 +146,38 @@ describe('utils.missions', () => {
         expect(mission1.id).not.toBe(mission2.id);
         mockMath.mockRestore();
     });
+
+    describe('reward validation defense-in-depth', () => {
+        test('should default to 0 for non-numeric, negative, infinite or NaN reward values', () => {
+            MissionSystem.initMemory();
+
+            // Negative numbers
+            const negMission = MissionSystem.createMission('scout', 'W0N0', -150);
+            expect(negMission.reward).toBe(0);
+
+            // NaN values
+            const nanMission = MissionSystem.createMission('scout', 'W0N0', NaN);
+            expect(nanMission.reward).toBe(0);
+
+            // Infinite values
+            const infMission = MissionSystem.createMission('scout', 'W0N0', Infinity);
+            expect(infMission.reward).toBe(0);
+
+            // String types
+            const strMission = MissionSystem.createMission('scout', 'W0N0', '100');
+            expect(strMission.reward).toBe(0);
+
+            // Object types
+            const objMission = MissionSystem.createMission('scout', 'W0N0', { amount: 500 });
+            expect(objMission.reward).toBe(0);
+
+            // Array types
+            const arrMission = MissionSystem.createMission('scout', 'W0N0', [250]);
+            expect(arrMission.reward).toBe(0);
+
+            // Valid positive reward
+            const validMission = MissionSystem.createMission('scout', 'W0N0', 500);
+            expect(validMission.reward).toBe(500);
+        });
+    });
 });

--- a/utils.missions.js
+++ b/utils.missions.js
@@ -85,11 +85,17 @@ const MissionSystem = {
             Memory.missions.active.splice(evictIndex, 1);
         }
 
+        // Security: Harden reward parameter to prevent injection of negative numbers, NaN, Infinity, or non-number types.
+        let safeReward = 0;
+        if (typeof reward === 'number' && Number.isFinite(reward) && !isNaN(reward)) {
+            safeReward = Math.max(0, reward);
+        }
+
         const mission = {
             id: generateMissionId(),
             type: sanitizedType,
             target: sanitizedTarget,
-            reward: reward || 0,
+            reward: safeReward,
             createdAt: Game.time,
             status: 'active',
         };


### PR DESCRIPTION
🎯 What: Hardened the `reward` parameter validation in `utils.missions.js` to ensure only valid, finite, non-negative numbers are saved.
⚠️ Risk: Unvalidated numeric inputs or type coercion bypasses could allow negative, infinite, NaN, or non-numeric types into mission records in Memory, causing logic errors, data corruption, or Memory exhaustion.
🛡️🛡️ Solution: Implemented robust checks verifying parameter type, finiteness, non-NaN, and non-negativity constraint. Added comprehensive unit tests in `tests/utils.missions.test.js`.

---
*PR created automatically by Jules for task [10160679024777955286](https://jules.google.com/task/10160679024777955286) started by @tadanobutubutu*

## Summary by Sourcery

Harden reward handling in mission creation to ensure only valid non-negative numeric rewards are stored and covered by tests.

Bug Fixes:
- Prevent invalid, negative, NaN, infinite, or non-numeric reward values from being persisted on missions by normalizing them to zero.

Tests:
- Add defense-in-depth tests verifying mission rewards default to zero for invalid inputs and correctly store valid positive rewards.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened mission `reward` validation to block non-numeric, NaN, Infinity, and negative values. Invalid rewards now default to 0 to prevent corrupted mission records and potential Memory issues.

- **Bug Fixes**
  - Sanitize `reward` in `utils.missions.js`: accept only finite numbers ≥ 0; otherwise set to 0.
  - Add tests in `tests/utils.missions.test.js` covering negative, NaN, Infinity, strings/objects/arrays, and valid positive rewards.

<sup>Written for commit 9c1264d8e9227fd868762675700a640d33d78967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

