### PR TITLE
Add custom animated chevron and focus styles to details/summary

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -61,3 +61,7 @@
 
 **Learning:** Applying `cursor: pointer` to a parent `<details>` element causes the hand pointer cursor to be inherited by all of its nested children (including massive `<pre>` blocks). This misleadingly implies that the entire block is clickable and disrupts standard text-selection patterns. Setting `border: none` (or other structural styling) on the `<details>` container and applying `cursor: pointer` strictly to the `<summary>` element preserves expected interactive bounds.
 **Action:** Always scope `cursor: pointer` exclusively to the toggleable `<summary>` element rather than the parent `<details>` component.
+
+## 2026-07-25 - [Cross-Browser Disclosure Consistency & Keyboard Focus]
+**Learning:** Default `<details>` and `<summary>` list-style markers vary significantly across browser engines (Chrome, Firefox, Safari), resulting in visual inconsistency. Hiding the default markers using both `listStyle: 'none'` and `-webkit-details-marker` while explicitly tracking the element's expansion state via React's `onToggle` allows for a highly consistent and beautifully animated custom chevron indicator. Crucially, when overriding default summary styles, custom `:focus-visible` styles must be explicitly defined to maintain proper visual focus states for keyboard-only users.
+**Action:** Always hide default browser markers on summary tags globally, pair them with a state-driven rotating chevron element, and enforce an explicit `focus-visible` outline stylesheet rule.

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -67,6 +67,17 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             border-bottom: 1px solid #004b73;
             box-shadow: 0 0 0 2px rgba(0, 75, 115, 0.2);
           }
+          summary::-webkit-details-marker {
+            display: none;
+          }
+          summary {
+            list-style: none; /* for standard compliant browsers */
+            outline: none;
+          }
+          summary:focus-visible {
+            outline: 2px solid #004b73;
+            outline-offset: 2px;
+          }
         `}</style>
             </head>
             <body>{children}</body>

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -9,7 +9,8 @@ export default function Dashboard() {
         [lastUpdated, setLastUpdated] = useState<Date | null>(null),
         [copied, setCopied] = useState(false),
         [copiedRoom, setCopiedRoom] = useState<string | null>(null),
-        [copiedJson, setCopiedJson] = useState(false);
+        [copiedJson, setCopiedJson] = useState(false),
+        [detailsOpen, setDetailsOpen] = useState(false);
 
     const [refreshHover, setRefreshHover] = useState(false);
     const [hoveredRoom, setHoveredRoom] = useState<string | null>(null);
@@ -444,7 +445,10 @@ export default function Dashboard() {
                     )}
                 </div>
             </div>
-            <details style={{ border: 'none' }}>
+            <details
+                onToggle={(e) => setDetailsOpen((e.target as HTMLDetailsElement).open)}
+                style={{ border: 'none' }}
+            >
                 <summary
                     className="interactive-hint"
                     title="生データを JSON 形式で表示/非表示にします"
@@ -452,8 +456,21 @@ export default function Dashboard() {
                         color: '#4a5568',
                         padding: '0.2rem 0',
                         cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '0.4rem',
                     }}
                 >
+                    <span
+                        style={{
+                            display: 'inline-block',
+                            transition: 'transform 0.2s ease-in-out',
+                            transform: detailsOpen ? 'rotate(90deg)' : 'rotate(0deg)',
+                            fontSize: '0.75rem',
+                        }}
+                    >
+                        ▶
+                    </span>
                     <span>生データを確認</span>
                 </summary>
                 <div style={{ marginTop: '0.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>


### PR DESCRIPTION
### Description

In this pull request, the following changes have been made:

- In the `palette.md` file, a new section has been added regarding cross-browser disclosure consistency and keyboard focus.
- Modifications have been made in the `layout.tsx` file to hide default browser markers on summary tags globally, pair them with a state-driven rotating chevron element, and enforce an explicit `focus-visible` outline stylesheet rule.
- Changes to the `Dashboard.tsx` file include the addition of state management for the opening/closing of details, custom styling for the summary element, and the implementation of a rotating custom chevron indicator based on the state of the details open.

Summary of changes:
- Added new section in `palette.md` regarding cross-browser disclosure consistency and keyboard focus.
- Modified styles in `layout.tsx` to hide default browser markers, customize summary styling, and specify focus styles.
- Implemented state management for details opening/closing in `Dashboard.tsx`, added custom styling for summary, and added a rotating chevron indicator based on details state.

## Summary by Sourcery

Improve dashboard disclosure control with a custom chevron indicator and consistent focus styling.

New Features:
- Add a state-driven rotating chevron icon for the dashboard raw-data disclosure summary.

Enhancements:
- Standardize summary element styling and keyboard focus outlines globally for disclosure controls.

Documentation:
- Document cross-browser disclosure behavior and keyboard focus requirements in the palette guidelines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a custom animated chevron to dashboard disclosure toggles and standardizes cross-browser styles, improving clarity and keyboard accessibility. The chevron rotates on open/close with a smooth transition.

- **New Features**
  - Hides default `<details>/<summary>` markers across browsers and applies global styles in the dashboard layout for consistent UI.
  - Adds `detailsOpen` state driven by `onToggle` to rotate a chevron indicator with a 0.2s transition.
  - Adds explicit `:focus-visible` outline on `<summary>` to preserve keyboard focus visibility.

<sup>Written for commit 0a57013453548bba07d9311db67fe854a7e0694d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

