### PR TITLE
Add error path test for format_everything

### DIFF
--- a/tests/format_everything.test.js
+++ b/tests/format_everything.test.js
@@ -1,0 +1,50 @@
+jest.mock('child_process', () => ({
+    execSync: jest.fn()
+}));
+
+describe('format_everything.js', () => {
+    beforeEach(() => {
+        jest.resetModules();
+        jest.clearAllMocks();
+    });
+
+    it('executes prettier and eslint successfully', () => {
+        const child_process = require('child_process');
+        child_process.execSync = jest.fn();
+
+        jest.doMock('child_process', () => child_process);
+
+        require('../format_everything.js');
+
+        expect(child_process.execSync).toHaveBeenCalledWith(
+            expect.stringContaining('prettier --write'),
+            expect.any(Object)
+        );
+        expect(child_process.execSync).toHaveBeenCalledWith(
+            expect.stringContaining('eslint'),
+            expect.any(Object)
+        );
+    });
+
+    it('catches and ignores errors from execSync', () => {
+        const child_process = require('child_process');
+        child_process.execSync = jest.fn().mockImplementation(() => {
+            throw new Error('Mock error');
+        });
+
+        jest.doMock('child_process', () => child_process);
+
+        expect(() => {
+            require('../format_everything.js');
+        }).not.toThrow();
+
+        expect(child_process.execSync).toHaveBeenCalledWith(
+            expect.stringContaining('prettier --write'),
+            expect.any(Object)
+        );
+        expect(child_process.execSync).toHaveBeenCalledWith(
+            expect.stringContaining('eslint'),
+            expect.any(Object)
+        );
+    });
+});


### PR DESCRIPTION
This PR adds comprehensive test coverage for the `format_everything.js` module, specifically focusing on error handling scenarios.

**Changes:**
- Created new test file `tests/format_everything.test.js` with full test suite
- Added test for successful execution of prettier and eslint commands
- Added test for error handling to verify that execution errors are properly caught and ignored
- Mocked `child_process.execSync` to isolate the module under test

**Key Details:**
- Tests verify that both prettier and eslint are invoked with correct command patterns
- Error path test ensures the module gracefully handles exceptions without propagating them
- Uses Jest mocking to control `child_process` behavior and validate command execution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Jest tests for `format_everything.js` that cover success and error paths, verifying `prettier` and `eslint` are invoked with the expected commands. Mocks `child_process.execSync` and confirms errors are caught and ignored so the script doesn’t throw.

<sup>Written for commit db6f158a0c0fa9af85d8d9c3294ba2c7ab36c1f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

