### PR TITLE
refactor(repairer): 🧹 extract helpers in run method

### DIFF
--- a/role.repairer.js
+++ b/role.repairer.js
@@ -3,71 +3,83 @@ const PATH_STYLE_REPAIR = { visualizePathStyle: { stroke: '#ffff00' } };
 const PATH_STYLE_UPGRADE = { visualizePathStyle: { stroke: '#ffffff' } };
 const PATH_STYLE_HARVEST = { visualizePathStyle: { stroke: '#ffaa00' } };
 
-const roleRepairer = {
-    run: function (creep) {
-        if (creep.memory.repairing && creep.store[RESOURCE_ENERGY] === 0) {
-            creep.memory.repairing = false;
-            creep.say('⚡ harvest');
-        }
-        if (!creep.memory.repairing && creep.store.getFreeCapacity() === 0) {
-            creep.memory.repairing = true;
-            creep.say('🔧 repair');
-        }
+function _updateState(creep) {
+    if (creep.memory.repairing && creep.store[RESOURCE_ENERGY] === 0) {
+        creep.memory.repairing = false;
+        creep.say('⚡ harvest');
+    }
+    if (!creep.memory.repairing && creep.store.getFreeCapacity() === 0) {
+        creep.memory.repairing = true;
+        creep.say('🔧 repair');
+    }
+}
 
-        if (creep.memory.repairing) {
-            // ⚡ PERFORMANCE: Use pre-filtered room-level repair targets.
-            const targets = creep.room._repairTargets || [];
+function _performRepair(creep) {
+    // ⚡ PERFORMANCE: Use pre-filtered room-level repair targets.
+    const targets = creep.room._repairTargets || [];
 
-            if (targets && targets.length > 0) {
-                // ⚡ PERFORMANCE: Cache target ID to avoid redundant O(N) scans every tick
-                let target = Game.getObjectById(creep.memory.repairTargetId);
+    if (targets && targets.length > 0) {
+        // ⚡ PERFORMANCE: Cache target ID to avoid redundant O(N) scans every tick
+        let target = Game.getObjectById(creep.memory.repairTargetId);
 
-                // If target is invalid or fully repaired, find a new one
-                if (!target || target.hits === target.hitsMax) {
-                    // ⚡ PERFORMANCE: main.jsで計算済みの最優先修理ターゲットを使用 (O(1))
-                    target = creep.room._minHitsRepairTarget;
+        // If target is invalid or fully repaired, find a new one
+        if (!target || target.hits === target.hitsMax) {
+            // ⚡ PERFORMANCE: main.jsで計算済みの最優先修理ターゲットを使用 (O(1))
+            target = creep.room._minHitsRepairTarget;
 
-                    if (target) {
-                        creep.memory.repairTargetId = target.id;
-                    } else {
-                        delete creep.memory.repairTargetId;
-                    }
-                }
-
-                if (target && creep.repair(target) === ERR_NOT_IN_RANGE) {
-                    creep.moveTo(target, PATH_STYLE_REPAIR);
-                }
+            if (target) {
+                creep.memory.repairTargetId = target.id;
             } else {
                 delete creep.memory.repairTargetId;
-                // 修理対象がない場合はアップグレード
-                if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
-                    creep.moveTo(creep.room.controller, PATH_STYLE_UPGRADE);
-                }
             }
+        }
+
+        if (target && creep.repair(target) === ERR_NOT_IN_RANGE) {
+            creep.moveTo(target, PATH_STYLE_REPAIR);
+        }
+    } else {
+        delete creep.memory.repairTargetId;
+        // 修理対象がない場合はアップグレード
+        if (creep.upgradeController(creep.room.controller) === ERR_NOT_IN_RANGE) {
+            creep.moveTo(creep.room.controller, PATH_STYLE_UPGRADE);
+        }
+    }
+}
+
+function _performHarvest(creep) {
+    // エネルギーを採取
+    // ⚡ PERFORMANCE: Use pre-warmed room cache for active sources.
+    const sources = creep.room._activeSources || [];
+
+    if (sources.length > 0) {
+        // ⚡ PERFORMANCE: Cache harvest target ID and use closest by range
+        let target = Game.getObjectById(creep.memory.harvestTargetId);
+
+        if (!target || target.energy === 0) {
+            target = creep.pos.findClosestByRange(sources);
+            if (target) {
+                creep.memory.harvestTargetId = target.id;
+            } else {
+                delete creep.memory.harvestTargetId;
+            }
+        }
+
+        if (target) {
+            if (creep.harvest(target) === ERR_NOT_IN_RANGE) {
+                creep.moveTo(target, PATH_STYLE_HARVEST);
+            }
+        }
+    }
+}
+
+const roleRepairer = {
+    run: function (creep) {
+        _updateState(creep);
+
+        if (creep.memory.repairing) {
+            _performRepair(creep);
         } else {
-            // エネルギーを採取
-            // ⚡ PERFORMANCE: Use pre-warmed room cache for active sources.
-            const sources = creep.room._activeSources || [];
-
-            if (sources.length > 0) {
-                // ⚡ PERFORMANCE: Cache harvest target ID and use closest by range
-                let target = Game.getObjectById(creep.memory.harvestTargetId);
-
-                if (!target || target.energy === 0) {
-                    target = creep.pos.findClosestByRange(sources);
-                    if (target) {
-                        creep.memory.harvestTargetId = target.id;
-                    } else {
-                        delete creep.memory.harvestTargetId;
-                    }
-                }
-
-                if (target) {
-                    if (creep.harvest(target) === ERR_NOT_IN_RANGE) {
-                        creep.moveTo(target, PATH_STYLE_HARVEST);
-                    }
-                }
-            }
+            _performHarvest(creep);
         }
     },
 };


### PR DESCRIPTION
🎯 **What:** Extracted the core logic inside the `roleRepairer.run` function into three focused helper methods: `_updateState`, `_performRepair`, and `_performHarvest`.

💡 **Why:** The original `run` function was overly long, combining state management, target discovery, pathfinding, and actual action execution. Extracting these into separate, named helper functions vastly improves readability and maintainability, allowing future developers to understand the creep's behavior flow at a glance.

✅ **Verification:** Ran isolated unit tests (`npx jest tests/role.repairer.test.js --reporters="default"`) which successfully passed. The behavior of the creep remains exactly the same.

✨ **Result:** A much cleaner, self-documenting `roleRepairer` module that adheres to the single responsibility principle for its methods.

---
*PR created automatically by Jules for task [7142399137521015922](https://jules.google.com/task/7142399137521015922) started by @tadanobutubutu*