### PR TITLE
Refactor transporter role to extract helper methods

### DIFF
--- a/role.transporter.js
+++ b/role.transporter.js
@@ -6,65 +6,77 @@ const roleTransporter = {
     run: function (creep) {
         creep.say('🚚');
 
+        this._updateState(creep);
+
+        if (creep.memory.transporting) {
+            this._deliverEnergy(creep);
+        } else {
+            this._withdrawEnergy(creep);
+        }
+    },
+
+    _updateState: function (creep) {
         if (creep.memory.transporting && creep.store[RESOURCE_ENERGY] === 0) {
             creep.memory.transporting = false;
         }
         if (!creep.memory.transporting && creep.store.getFreeCapacity() === 0) {
             creep.memory.transporting = true;
         }
+    },
 
-        if (creep.memory.transporting) {
-            // ⚡ PERFORMANCE: Use pre-filtered room-level delivery targets.
-            const targets = creep.room._deliveryTargets || [];
+    _deliverEnergy: function (creep) {
+        // ⚡ PERFORMANCE: Use pre-filtered room-level delivery targets.
+        const targets = creep.room._deliveryTargets || [];
 
-            if (targets && targets.length > 0) {
-                // ⚡ PERFORMANCE: ターゲットIDをキャッシュして毎ティックの再探索を回避
-                let target = Game.getObjectById(creep.memory.deliveryTargetId);
+        if (targets && targets.length > 0) {
+            // ⚡ PERFORMANCE: ターゲットIDをキャッシュして毎ティックの再探索を回避
+            let target = Game.getObjectById(creep.memory.deliveryTargetId);
 
-                // ⚡ PERFORMANCE: O(1) check for delivery target validity instead of O(N) .some()
-                if (!target || target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
-                    target = creep.pos.findClosestByRange(targets);
-                    if (target) {
-                        creep.memory.deliveryTargetId = target.id;
-                    } else {
-                        delete creep.memory.deliveryTargetId;
-                    }
-                }
-
+            // ⚡ PERFORMANCE: O(1) check for delivery target validity instead of O(N) .some()
+            if (!target || target.store.getFreeCapacity(RESOURCE_ENERGY) === 0) {
+                target = creep.pos.findClosestByRange(targets);
                 if (target) {
-                    if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-                        creep.moveTo(target, PATH_STYLE_DELIVER);
-                    }
+                    creep.memory.deliveryTargetId = target.id;
+                } else {
+                    delete creep.memory.deliveryTargetId;
                 }
-            } else {
-                delete creep.memory.deliveryTargetId;
+            }
+
+            if (target) {
+                if (creep.transfer(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+                    creep.moveTo(target, PATH_STYLE_DELIVER);
+                }
             }
         } else {
-            // ⚡ PERFORMANCE: Use pre-calculated withdrawal sources cache from main.js
-            const sources = creep.room._withdrawalSources || [];
+            delete creep.memory.deliveryTargetId;
+        }
+    },
 
-            if (sources.length > 0) {
-                // ⚡ PERFORMANCE: ターゲットIDをキャッシュ
-                let target = Game.getObjectById(creep.memory.withdrawalTargetId);
+    _withdrawEnergy: function (creep) {
+        // ⚡ PERFORMANCE: Use pre-calculated withdrawal sources cache from main.js
+        const sources = creep.room._withdrawalSources || [];
 
-                // ⚡ PERFORMANCE: O(1) check for withdrawal target validity instead of O(N) .some()
-                if (!target || target.store[RESOURCE_ENERGY] === 0) {
-                    target = creep.pos.findClosestByRange(sources);
-                    if (target) {
-                        creep.memory.withdrawalTargetId = target.id;
-                    } else {
-                        delete creep.memory.withdrawalTargetId;
-                    }
-                }
+        if (sources.length > 0) {
+            // ⚡ PERFORMANCE: ターゲットIDをキャッシュ
+            let target = Game.getObjectById(creep.memory.withdrawalTargetId);
 
+            // ⚡ PERFORMANCE: O(1) check for withdrawal target validity instead of O(N) .some()
+            if (!target || target.store[RESOURCE_ENERGY] === 0) {
+                target = creep.pos.findClosestByRange(sources);
                 if (target) {
-                    if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
-                        creep.moveTo(target, PATH_STYLE_WITHDRAW);
-                    }
+                    creep.memory.withdrawalTargetId = target.id;
+                } else {
+                    delete creep.memory.withdrawalTargetId;
                 }
-            } else {
-                delete creep.memory.withdrawalTargetId;
             }
+
+            if (target) {
+                if (creep.withdraw(target, RESOURCE_ENERGY) === ERR_NOT_IN_RANGE) {
+                    creep.moveTo(target, PATH_STYLE_WITHDRAW);
+                }
+            }
+        } else {
+            delete creep.memory.withdrawalTargetId;
         }
     },
 };


### PR DESCRIPTION
This PR refactors the `role.transporter.js` module to improve code maintainability and readability by extracting the main logic into focused helper methods.

**Key Changes:**

- **Extracted `_updateState()`** - Isolates state management logic that tracks whether a creep is transporting or withdrawing energy
- **Extracted `_deliverEnergy()`** - Separates delivery logic including target caching, validation, and energy transfer operations
- **Extracted `_withdrawEnergy()`** - Separates withdrawal logic including source caching, validation, and energy withdrawal operations
- **Simplified main `run()` method** - Now serves as a clear orchestrator that calls the helper methods in sequence

**Benefits:**

- Reduces cognitive load by breaking a 60+ line function into smaller, single-responsibility methods
- Improves testability and reusability of individual behaviors
- Maintains all existing performance optimizations (target caching, O(1) validity checks, pre-filtered room-level caches)
- No functional changes - behavior remains identical

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `role.transporter.js` by extracting state, delivery, and withdrawal logic into focused helper methods for clearer, testable code. Behavior and performance are unchanged.

- **Refactors**
  - Added `_updateState()` to manage transporting/withdrawing flags.
  - Added `_deliverEnergy()` and `_withdrawEnergy()` with target/source caching, O(1) validity checks, and move/transfer steps.
  - Simplified `run()` to orchestrate helpers while keeping existing optimizations.

<sup>Written for commit d1a35294e56f1d3bd14e2ec6e313b80add03856e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

