### PR TITLE
🧪 [testing improvement] Add error path test for generatePersonality fallback

### DIFF
--- a/tests/utils.emotions.test.js
+++ b/tests/utils.emotions.test.js
@@ -43,6 +43,22 @@ describe('utils.emotions', () => {
         expect(mockCreep.memory.emotions.personalityTraits).toBeDefined();
     });
 
+    test('generatePersonality falls back to Math.random when crypto throws', () => {
+        const crypto = require('crypto');
+        const cryptoSpy = jest.spyOn(crypto, 'randomInt').mockImplementation(() => {
+            throw new Error('mock error');
+        });
+        const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
+
+        const trait = EmotionSystem.generatePersonality();
+
+        expect(trait).toBeDefined();
+        expect(mathRandomSpy).toHaveBeenCalled();
+
+        cryptoSpy.mockRestore();
+        mathRandomSpy.mockRestore();
+    });
+
     test('initializeが既存のemotionsを上書きしない', () => {
         mockCreep.memory.emotions = { mood: 5, test: 'value' };
         EmotionSystem.initialize(mockCreep);


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for `EmotionSystem.generatePersonality` in `utils.emotions.js`.
📊 **Coverage:** Now tests the catch block fallback where `crypto.randomInt` throws, verifying it correctly falls back to `Math.random()`.
✨ **Result:** Improved test coverage and reliability of the personality generation logic.

---
*PR created automatically by Jules for task [13358145504036843401](https://jules.google.com/task/13358145504036843401) started by @tadanobutubutu*