### PR TITLE
chore(scripts): 🧹 [code health] rephrase comment to prevent false positive TODO

### DIFF
--- a/scripts/auto-pr-generator.js
+++ b/scripts/auto-pr-generator.js
@@ -236,7 +236,7 @@ async function main() {
         const analysis = await analyzeIssueWithClaude(issue);
         console.log(`✅ Analysis complete: ${analysis.severity} severity`);
 
-        // Fix ブランチを作成してコミット
+        // 修正ブランチを作成してコミット
         const branch = await createFixBranch(issue, analysis);
         console.log(`✅ Branch and commit created: ${branch.branchName}`);
 


### PR DESCRIPTION
🎯 What: Rephrased a comment in `scripts/auto-pr-generator.js` from `// Fix ブランチを作成してコミット` to `// 修正ブランチを作成してコミット`.
💡 Why: The automated script that generates GitHub issues from `TODO` and `FIXME` comments was falsely triggering on the word "Fix" at the start of the comment, creating unnecessary issues.
✅ Verification: Ran a syntax check on the modified file to ensure it's valid javascript. Used `npx jest` to ensure no test suites are broken.
✨ Result: The false positive issue generation will no longer happen for this comment while preserving its intended meaning.

---
*PR created automatically by Jules for task [169793478101155488](https://jules.google.com/task/169793478101155488) started by @tadanobutubutu*