### PR TITLE
Add comprehensive tests for defender role exports

### DIFF
--- a/tests/role.defender.test.js
+++ b/tests/role.defender.test.js
@@ -11,6 +11,12 @@ global.FIND_MY_STRUCTURES = 8;
 global.ATTACK = 'attack';
 global.RANGED_ATTACK = 'ranged_attack';
 global.HEAL = 'heal';
+
+global.MOVE = 'move';
+global.TOUGH = 'tough';
+global.CLAIM = 'claim';
+global.ROOM_BOUNDS = { MIN: 0, MAX: 49 };
+
 global.STRUCTURE_RAMPART = 'rampart';
 global.STRUCTURE_CONTROLLER = 'controller';
 global.RoomPosition = class {
@@ -27,15 +33,39 @@ global.RoomPosition = class {
     }
 };
 
+
 jest.mock(
-    '../utils/cache',
+    '../src/utils/pathfinder',
     () => ({
-        getEnemies: jest.fn(),
+        moveTo: jest.fn(),
     }),
     { virtual: true }
 );
 
-const cache = require('../utils/cache');
+
+jest.mock(
+    '../src/utils/logger',
+    () => ({
+        error: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+    }),
+    { virtual: true }
+);
+
+
+jest.mock(
+    '../src/utils/cache',
+    () => ({
+        getEnemies: jest.fn(),
+        getMyCreeps: jest.fn(),
+        getMyStructures: jest.fn(),
+    }),
+    { virtual: true }
+);
+
+const cache = require('../src/utils/cache');
 const roleDefender = require('../src/roles/defender');
 
 describe('role.defender', () => {
@@ -114,5 +144,156 @@ describe('role.defender', () => {
         });
 
         expect(() => roleDefender.run(mockCreep)).not.toThrow();
+    });
+});
+
+
+describe('getBody', () => {
+    test('ranged = true の場合、エネルギー量に応じた遠距離ボディを返す', () => {
+        expect(roleDefender.getBody(900, true)).toContain(global.RANGED_ATTACK);
+        expect(roleDefender.getBody(450, true)).toContain(global.RANGED_ATTACK);
+        expect(roleDefender.getBody(200, true)).toContain(global.RANGED_ATTACK);
+    });
+
+    test('ranged = false の場合、エネルギー量に応じた近接ボディを返す', () => {
+        expect(roleDefender.getBody(800, false)).toContain(global.ATTACK);
+        expect(roleDefender.getBody(400, false)).toContain(global.ATTACK);
+        expect(roleDefender.getBody(200, false)).toContain(global.ATTACK);
+        expect(roleDefender.getBody(100, false)).toContain(global.ATTACK);
+    });
+});
+
+describe('detectInvasion', () => {
+    test('敵がいない場合は detected: false を返す', () => {
+        cache.getEnemies.mockReturnValue([]);
+        const result = roleDefender.detectInvasion({});
+        expect(result.detected).toBe(false);
+        expect(result.count).toBe(0);
+    });
+
+    test('攻撃パーツを持つ敵がいる場合は detected: true を返す', () => {
+        const mockEnemy = {
+            getActiveBodyparts: jest.fn((part) => part === global.ATTACK ? 1 : 0),
+            hitsMax: 100
+        };
+        cache.getEnemies.mockReturnValue([mockEnemy]);
+        const result = roleDefender.detectInvasion({});
+        expect(result.detected).toBe(true);
+        expect(result.count).toBe(1);
+        expect(result.strongestHp).toBe(100);
+    });
+});
+
+describe('shouldActivateSafeMode', () => {
+    let room;
+
+    beforeEach(() => {
+        room = {
+            controller: {
+                my: true,
+                safeMode: undefined,
+                safeModeAvailable: 1
+            }
+        };
+        // Ensure getMyCreeps is mockable
+        if (!cache.getMyCreeps) {
+            cache.getMyCreeps = jest.fn();
+        }
+    });
+
+    test('コントローラーがない場合は false を返す', () => {
+        expect(roleDefender.shouldActivateSafeMode({})).toBe(false);
+    });
+
+    test('コントローラーが自分のものじゃない場合は false を返す', () => {
+        room.controller.my = false;
+        expect(roleDefender.shouldActivateSafeMode(room)).toBe(false);
+    });
+
+    test('すでにセーフモードが発動している場合は false を返す', () => {
+        room.controller.safeMode = 1000;
+        expect(roleDefender.shouldActivateSafeMode(room)).toBe(false);
+    });
+
+    test('セーフモードのストックがない場合は false を返す', () => {
+        room.controller.safeModeAvailable = 0;
+        expect(roleDefender.shouldActivateSafeMode(room)).toBe(false);
+    });
+
+    test('敵が3体以上いて、ディフェンダーが足りない場合は true を返す', () => {
+        const mockEnemy = {
+            getActiveBodyparts: jest.fn((part) => part === global.ATTACK ? 1 : 0),
+            hitsMax: 100
+        };
+        cache.getEnemies.mockReturnValue([mockEnemy, mockEnemy, mockEnemy]);
+
+        cache.getMyCreeps.mockReturnValue([]);
+
+        expect(roleDefender.shouldActivateSafeMode(room)).toBe(true);
+    });
+
+    test('敵が3体以上いても、ディフェンダーが十分な場合は false を返す', () => {
+        const mockEnemy = {
+            getActiveBodyparts: jest.fn((part) => part === global.ATTACK ? 1 : 0),
+            hitsMax: 100
+        };
+        cache.getEnemies.mockReturnValue([mockEnemy, mockEnemy, mockEnemy]);
+
+        const mockDefender = {
+            memory: { role: 'defender' },
+            getActiveBodyparts: jest.fn((part) => part === global.ATTACK ? 1 : 0)
+        };
+        cache.getMyCreeps.mockReturnValue([mockDefender, mockDefender, mockDefender]);
+
+        expect(roleDefender.shouldActivateSafeMode(room)).toBe(false);
+    });
+});
+
+
+describe('Patrol & Combat Logics', () => {
+    let mockCreep;
+    beforeEach(() => {
+        mockCreep = {
+            memory: {},
+            say: jest.fn(),
+            attack: jest.fn().mockReturnValue(OK),
+            rangedAttack: jest.fn().mockReturnValue(OK),
+            moveTo: jest.fn().mockReturnValue(OK),
+            pos: { x: 25, y: 25, getRangeTo: jest.fn().mockReturnValue(5) },
+            room: {
+                name: 'W1N1',
+                controller: {
+                    pos: { x: 30, y: 30 },
+                },
+                visual: { line: jest.fn() }
+            },
+            getActiveBodyparts: jest.fn((part) => {
+                if (part === ATTACK) return 2;
+                if (part === RANGED_ATTACK) return 1;
+                return 0;
+            }),
+            hits: 100,
+            hitsMax: 100,
+            heal: jest.fn(),
+        };
+    });
+
+    test('敵がいない、かつランパートがある場合はランパートを巡回する', () => {
+        cache.getEnemies.mockReturnValue([]);
+        cache.getMyStructures.mockReturnValue([{ pos: { x: 10, y: 10 } }, { pos: { x: 20, y: 20 } }]);
+
+        roleDefender.run(mockCreep);
+
+        expect(mockCreep.memory.patrolIndex).toBeDefined();
+    });
+
+    test('自己修復', () => {
+        cache.getEnemies.mockReturnValue([]);
+        mockCreep.hits = 50;
+        mockCreep.getActiveBodyparts = jest.fn((part) => part === HEAL ? 1 : 0);
+
+        roleDefender.run(mockCreep);
+
+        expect(mockCreep.heal).toHaveBeenCalledWith(mockCreep);
     });
 });


### PR DESCRIPTION
This PR expands test coverage for the defender role by adding test suites for exported functions and core game logic.

**Key Changes:**

- **Added global mocks**: Introduced missing game constants (`MOVE`, `TOUGH`, `CLAIM`, `ROOM_BOUNDS`) and mocked utility modules (`pathfinder`, `logger`)
- **Fixed import paths**: Corrected cache import paths from `../utils/cache` to `../src/utils/cache` for consistency
- **Extended cache mocks**: Added `getMyCreeps` and `getMyStructures` mock functions to support new test scenarios
- **New test suites**:
  - `getBody()`: Tests body composition for both ranged and melee defenders based on energy levels
  - `detectInvasion()`: Tests enemy detection logic and invasion metrics
  - `shouldActivateSafeMode()`: Tests safe mode activation conditions including controller ownership, existing safe mode status, and defender availability
  - `Patrol & Combat Logics`: Tests patrol behavior, self-healing, and combat scenarios

These tests ensure the defender role correctly exports and executes its core functions for invasion detection, safe mode management, and combat operations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds comprehensive tests for the defender role exports, covering body creation, invasion detection, safe mode decisions, and patrol/combat behavior. Also adds missing mocks and fixes import paths to improve test reliability.

- **New Features**
  - Added test suites for `getBody()`, `detectInvasion()`, `shouldActivateSafeMode()`, and patrol/combat flows.
  - Added global mocks for `MOVE`, `TOUGH`, `CLAIM`, `ROOM_BOUNDS`; mocked `../src/utils/pathfinder` and `../src/utils/logger`.
  - Extended cache mocks with `getMyCreeps` and `getMyStructures`.

- **Bug Fixes**
  - Corrected cache import path in tests to `../src/utils/cache`.

<sup>Written for commit 9beaa0ca2f09d386c80b633093ff50cd1a600efc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

