### PR TITLE
Add error path testing for pre-commit script

### DIFF
--- a/tests/pre_commit_script.test.js
+++ b/tests/pre_commit_script.test.js
@@ -1,0 +1,45 @@
+describe('pre_commit_script.js', () => {
+    let originalConsoleError;
+    let originalProcessExit;
+    let execFileSyncMock;
+
+    beforeEach(() => {
+        jest.resetModules();
+        originalConsoleError = console.error;
+        originalProcessExit = process.exit;
+
+        console.error = jest.fn();
+        process.exit = jest.fn();
+        execFileSyncMock = jest.fn();
+
+        jest.doMock('child_process', () => ({
+            execFileSync: execFileSyncMock,
+        }));
+    });
+
+    afterEach(() => {
+        console.error = originalConsoleError;
+        process.exit = originalProcessExit;
+        jest.dontMock('child_process');
+    });
+
+    it('should successfully execute lint and test commands', () => {
+        require('../pre_commit_script.js');
+
+        expect(execFileSyncMock).toHaveBeenCalledWith('npm', ['run', 'lint'], { stdio: 'inherit' });
+        expect(execFileSyncMock).toHaveBeenCalledWith('npm', ['test'], { stdio: 'inherit' });
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+    });
+
+    it('should handle execution errors and exit with code 1', () => {
+        execFileSyncMock.mockImplementationOnce(() => {
+            throw new Error('Command failed');
+        });
+
+        require('../pre_commit_script.js');
+
+        expect(console.error).toHaveBeenCalledWith('Pre-commit checks failed:', 'Command failed');
+        expect(process.exit).toHaveBeenCalledWith(1);
+    });
+});


### PR DESCRIPTION
This PR adds comprehensive test coverage for the pre-commit script, including both success and error scenarios.

**Changes:**
- Created new test suite (`tests/pre_commit_script.test.js`) with 45 lines of test code
- Added test for successful execution of lint and test commands
- Added test for error handling when commands fail, verifying proper error logging and exit code (1)
- Implemented proper mocking of `child_process.execFileSync`, `console.error`, and `process.exit` to isolate the script under test

**Key Details:**
- Tests verify that the pre-commit script correctly executes both `npm run lint` and `npm test` with inherited stdio
- Error path testing ensures failures are logged and the process exits with code 1
- Uses Jest's module mocking to control dependencies and verify behavior in isolation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for `pre_commit_script.js` to verify that `npm run lint` and `npm test` execute and that failures log an error and exit with code 1. Improves coverage of the pre-commit flow by asserting the `child_process.execFileSync` happy path and error path.

<sup>Written for commit fd9cd3567cf3144f21808d2692851c5b327827f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

