### PR TITLE
Refactor fix_eslint.js into reusable function and add tests

### DIFF
--- a/fix_eslint.js
+++ b/fix_eslint.js
@@ -1,11 +1,19 @@
 const fs = require('fs');
 
-const file = 'main.js';
-let content = fs.readFileSync(file, 'utf8');
+function fixEslintGlobals(filePath) {
+    let content = fs.readFileSync(filePath, 'utf8');
 
-content = content.replace(
-    '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, _ */',
-    '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, STRUCTURE_RAMPART, _ */'
-);
+    content = content.replace(
+        '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, _ */',
+        '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, STRUCTURE_RAMPART, _ */'
+    );
 
-fs.writeFileSync(file, content, 'utf8');
+    fs.writeFileSync(filePath, content, 'utf8');
+}
+
+if (require.main === module) {
+    const file = 'main.js';
+    fixEslintGlobals(file);
+}
+
+module.exports = { fixEslintGlobals };

--- a/tests/fix_eslint.test.js
+++ b/tests/fix_eslint.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const { fixEslintGlobals } = require('../fix_eslint');
+
+jest.mock('fs');
+
+describe('fix_eslint.js', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should replace the target global comment with STRUCTURE_RAMPART included', () => {
+        const filePath = 'dummy.js';
+        const originalContent = '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, _ */\nconst foo = 1;';
+        const expectedContent = '/* global Game, Memory, Room, FIND_HOSTILE_CREEPS, FIND_SOURCES_ACTIVE, STRUCTURE_WALL, STRUCTURE_EXTENSION, STRUCTURE_SPAWN, STRUCTURE_TOWER, STRUCTURE_LAB, RESOURCE_ENERGY, STRUCTURE_CONTAINER, STRUCTURE_RAMPART, _ */\nconst foo = 1;';
+
+        fs.readFileSync.mockReturnValue(originalContent);
+
+        fixEslintGlobals(filePath);
+
+        expect(fs.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
+        expect(fs.writeFileSync).toHaveBeenCalledWith(filePath, expectedContent, 'utf8');
+    });
+
+    it('should not modify the content if the target global comment is not found', () => {
+        const filePath = 'dummy.js';
+        const originalContent = '/* global Game, Memory, Room */\nconst foo = 1;';
+
+        fs.readFileSync.mockReturnValue(originalContent);
+
+        fixEslintGlobals(filePath);
+
+        expect(fs.readFileSync).toHaveBeenCalledWith(filePath, 'utf8');
+        expect(fs.writeFileSync).toHaveBeenCalledWith(filePath, originalContent, 'utf8');
+    });
+});


### PR DESCRIPTION
This PR refactors the `fix_eslint.js` script to improve testability and reusability while adding comprehensive test coverage.

**Key Changes:**

- **Extracted core logic into a function**: Wrapped the ESLint global comment replacement logic into a `fixEslintGlobals(filePath)` function that accepts a file path parameter, making it reusable and testable
- **Added module exports**: Exported the `fixEslintGlobals` function for use in other modules
- **Preserved CLI functionality**: Maintained the original behavior by keeping the direct file processing logic in a `require.main === module` block, allowing the script to work both as a module and as a standalone CLI tool
- **Added comprehensive tests**: Created `tests/fix_eslint.test.js` with Jest tests covering:
  - Successful replacement of the ESLint global comment with `STRUCTURE_RAMPART` added
  - Edge case where the target comment is not found (content remains unchanged)
  - Proper mocking of the `fs` module to isolate the function logic

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored fix_eslint.js by extracting the ESLint globals replacement into fixEslintGlobals(filePath) and exporting it for reuse. Kept CLI mode intact and added Jest tests that mock `fs`, verify the STRUCTURE_RAMPART insertion, and confirm no-op when the target comment is missing.

<sup>Written for commit faf66c82af2b83a10b60cab8ef25b9a6688453a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/2814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

