### PR TITLE
Optimize getTotalBuildProgress with direct for loop

### DIFF
--- a/src/roles/builder.js
+++ b/src/roles/builder.js
@@ -354,12 +354,19 @@ function hasBuildSites(room) {
 
 /**
  * ルーム内のすべての建設サイトの合計建設量を返す
+ * ⚡ PERFORMANCE OPTIMIZATION: Use a standard for-loop instead of Array.prototype.reduce
+ * to avoid closure allocations and callback overhead in hot-path room evaluation.
  * @param {Room} room
  * @returns {number}
  */
 function getTotalBuildProgress(room) {
     const sites = cache.getConstructionSites(room);
-    return sites.reduce((acc, s) => acc + (s.progressTotal - s.progress), 0);
+    let total = 0;
+    for (let i = 0; i < sites.length; i++) {
+        const s = sites[i];
+        total += (s.progressTotal - s.progress);
+    }
+    return total;
 }
 
 module.exports = { run, getBody, hasBuildSites, getTotalBuildProgress, BUILD_PRIORITY };


### PR DESCRIPTION
This PR improves the performance of the `getTotalBuildProgress` function by replacing `Array.prototype.reduce` with a standard for-loop implementation.

**Changes:**
- Replaced the `reduce()` callback pattern with a direct for-loop in `getTotalBuildProgress()`
- Eliminates closure allocations and callback overhead in this hot-path room evaluation function
- Maintains identical functionality while reducing memory pressure and execution time

**Rationale:**
The `getTotalBuildProgress` function is called frequently during room evaluation. By using a simple for-loop instead of reduce, we avoid the overhead of callback function creation and closure allocation, resulting in better performance for this performance-critical code path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimized getTotalBuildProgress by replacing Array.reduce with a simple for-loop to speed up a hot path. This reduces CPU time and memory use during room evaluation.

- **Refactors**
  - Cuts callback/closure allocation in this path for better performance.
  - No behavior change; output remains identical.

<sup>Written for commit e205c5ab5245a996649ac96c1230664072d77ca4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/3129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

