### PR TITLE
Optimize spawnManager target counts computation

### DIFF
--- a/src/managers/spawnManager.js
+++ b/src/managers/spawnManager.js
@@ -158,8 +158,16 @@ function _getTargetCounts(room, rcl) {
     }
 
     // 緊急モード: クリープが0の場合は最低限のハーベスターを確保
-    const totalCreeps = Object.values(result).reduce((s, v) => s + v, 0);
-    if (Object.keys(Game.creeps).length === 0) {
+    // ⚡ PERFORMANCE OPTIMIZATION: Removed unused totalCreeps variable and its O(N) reduce allocation.
+    // ⚡ PERFORMANCE OPTIMIZATION: Use O(1) loop-based early-exit instead of Object.keys(Game.creeps).length to check if empty, avoiding array allocation.
+    let hasCreeps = false;
+    for (let name in Game.creeps) {
+        if (Object.prototype.hasOwnProperty.call(Game.creeps, name)) {
+            hasCreeps = true;
+            break;
+        }
+    }
+    if (!hasCreeps) {
         result[ROLES.HARVESTER] = Math.max(result[ROLES.HARVESTER] || 0, 1);
     }
 


### PR DESCRIPTION
💡 What: Removed unused `totalCreeps` variable (which computed an expensive `Object.values().reduce()` allocation/reduction) and replaced the O(N) array allocation check of `Object.keys(Game.creeps).length === 0` with an O(1) early-exit `for...in` loop.
🎯 Why: In Screeps, every millisecond and CPU cycle counts. Computing unused variables and allocating arrays just to check for empty collections puts unnecessary pressure on V8 and garbage collection.
📊 Impact: Prevents O(N) array allocations and traversal per spawn tick, reducing memory usage and CPU cycles.
🔬 Measurement: Verified with `npx jest tests/spawnManager.test.js --reporters="default"`.

---
*PR created automatically by Jules for task [4720854416298211691](https://jules.google.com/task/4720854416298211691) started by @tadanobutubutu*

## Summary by Sourcery

Enhancements:
- Replace Object.keys-based empty creeps check with an early-exit loop to avoid array allocation and reduce CPU usage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up emergency spawn logic by optimizing `_getTargetCounts` in `spawnManager` to avoid unnecessary allocations. Reduces memory churn and improves tick time in rooms with many creeps.

- **Refactors**
  - Removed unused `totalCreeps` reduce.
  - Replaced `Object.keys(Game.creeps).length` check with early-exit loop to avoid array allocation.
  - Added `Object.prototype.hasOwnProperty.call` when iterating `Game.creeps` for safety.

<sup>Written for commit 678bc4ab62dc0c8afb9b262f4a4cd2ed4d8c83ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/3672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

