### PR TITLE
test(logging): 🧪 [add tests for setLevel]

### DIFF
--- a/tests/utils.logging.test.js
+++ b/tests/utils.logging.test.js
@@ -203,4 +203,31 @@ describe('utils.logging', () => {
         expect(lastLog.level).toBe('error');
         expect(lastLog.message).toBe('test message');
     });
+
+    describe('setLevel', () => {
+        test('sets valid numeric level', () => {
+            utilsLogging.setLevel(1);
+            expect(utilsLogging.getLevel()).toBe(1);
+        });
+
+        test('sets valid string level', () => {
+            utilsLogging.setLevel('error');
+            expect(utilsLogging.getLevel()).toBe(0);
+        });
+
+        test('falls back to info for invalid type', () => {
+            utilsLogging.setLevel({});
+            expect(utilsLogging.getLevel()).toBe(2);
+        });
+
+        test('falls back to info for invalid numeric value', () => {
+            utilsLogging.setLevel(99);
+            expect(utilsLogging.getLevel()).toBe(2);
+        });
+
+        test('falls back to info for invalid string value', () => {
+            utilsLogging.setLevel('invalid');
+            expect(utilsLogging.getLevel()).toBe(2);
+        });
+    });
 });


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `setLevel` function in `utils.logging.js`.
📊 **Coverage:** Now tests setting valid numeric levels, valid string levels, and fallback behaviors for invalid types/values.
✨ **Result:** Improved test coverage and reliability for logging level mutation.

---
*PR created automatically by Jules for task [8613865546302169149](https://jules.google.com/task/8613865546302169149) started by @tadanobutubutu*