### PR TITLE
Cache road network planning to reduce CPU overhead

### DIFF
--- a/tests/utils.planning.test.js
+++ b/tests/utils.planning.test.js
@@ -26,6 +26,7 @@ global.RoomPosition = class {
 const mockCache = {
     getSources: jest.fn(),
     getSpawns: jest.fn(),
+    get: jest.fn((key, fn) => fn()),
 };
 
 jest.mock('../src/utils/cache', () => mockCache, { virtual: true });

--- a/utils.planning.js
+++ b/utils.planning.js
@@ -121,34 +121,36 @@ module.exports = {
             return [];
         }
         const spawn = spawns[0];
-        const sources = cache.getSources(room);
         const controller = room.controller;
 
         if (controller === undefined || controller === null) {
             return [];
         }
 
-        const roadPositions = [];
+        return cache.get(`road_network_${room.name}`, () => {
+            const sources = cache.getSources(room);
+            const roadPositions = [];
 
-        // Roads to sources
-        sources.forEach((source) => {
-            if (spawn && spawn.pos) {
-                const path = spawn.pos.findPathTo(source, { ignoreCreeps: true });
+            // Roads to sources
+            sources.forEach((source) => {
+                if (spawn && spawn.pos) {
+                    const path = spawn.pos.findPathTo(source, { ignoreCreeps: true });
+                    path.forEach((step) => {
+                        roadPositions.push(new RoomPosition(step.x, step.y, room.name));
+                    });
+                }
+            });
+
+            // Road to controller
+            if (controller && spawn && spawn.pos) {
+                const path = spawn.pos.findPathTo(controller, { ignoreCreeps: true });
                 path.forEach((step) => {
                     roadPositions.push(new RoomPosition(step.x, step.y, room.name));
                 });
             }
-        });
 
-        // Road to controller
-        if (controller && spawn && spawn.pos) {
-            const path = spawn.pos.findPathTo(controller, { ignoreCreeps: true });
-            path.forEach((step) => {
-                roadPositions.push(new RoomPosition(step.x, step.y, room.name));
-            });
-        }
-
-        return roadPositions;
+            return roadPositions;
+        }, 1000); // Cache the road network for 1000 ticks
     },
 
     // Display planning info


### PR DESCRIPTION
This PR optimizes the road network planning calculation by implementing caching to avoid redundant pathfinding computations.

**Changes:**
- Wrapped the road network planning logic with a cache layer using `cache.get()` with a 1000-tick TTL
- Moved `getSources()` call inside the cached function to ensure it's only computed when the cache misses
- Updated test mocks to support the new `cache.get()` method

**Benefits:**
- Reduces CPU overhead by caching road network calculations per room
- Pathfinding operations (which are computationally expensive) are now reused across multiple ticks instead of recalculating every time
- Cache automatically invalidates after 1000 ticks, allowing the system to adapt to room changes

## Summary by Sourcery

Cache road network planning per room to reuse pathfinding results across ticks and reduce CPU usage.

New Features:
- Introduce a cached road network computation keyed by room name with a defined TTL.

Enhancements:
- Compute source positions only on cache misses to avoid redundant work.
- Return cached road position arrays directly from the planning function.

Tests:
- Extend cache test mocks to support the new generic cache.get interface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache road network planning per room to reuse pathfinding results and reduce CPU usage across ticks. The cache invalidates after 1000 ticks so plans update when rooms change.

- **Refactors**
  - Wrapped road planning with `cache.get()` to memoize path results
  - Moved `getSources()` inside the cached function to run only on cache miss
  - Updated tests to mock `cache.get()`

<sup>Written for commit 047631cca75ae2997aa5a251d9fe09a754f8e84b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/4057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

