### PR TITLE
Add interactive room search filter with synchronized copy action

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,10 @@
 # Palette's Journal - Screeps Dashboard UX/Accessibility
 
+## 2026-08-07 - [Dynamic Search Filtering & Bulk Actions Coordination]
+
+**Learning:** When adding client-side search or filter inputs to groups of dynamic telemetry items (such as a list of active Screeps rooms), any adjacent bulk actions (such as "Copy All") must be contextually updated to reflect the filter state. Dynamically changing the action's behavior to copy only the filtered subset, and synchronizing its labels, tooltips, ARIA descriptors, and completion toasts, prevents user confusion and satisfies WCAG 2.1.1 (Keyboard Accessibility) and 2.4.4 (Link Purpose/Context).
+**Action:** When implementing any search or filter component, always review and dynamically coordinate adjacent bulk actions to operate strictly on the filtered subset of visible data, updating all accessibility labels in sync.
+
 ## 2026-08-05 - [Accessible Dashboard Polling with User Control]
 
 **Learning:** For monitoring-heavy screens like game status dashboards, polling or auto-refresh capabilities should be paired with explicit user controls. Implementing a clearly labeled checkbox with specific accessible markup (`aria-label="自動更新 (60秒ごと)"`) allows users to pause the refresh cycles at will. Furthermore, matching the refresh cycle to the API's caching layer avoids redundant server queries while maintaining the most up-to-date telemetry.
@@ -37,7 +42,7 @@
 **Action:**
 
 - エラーやログなどの一時的な技術データには「コピー」ボタンを含める。
-- 「コピー完了」のフィードバックには成功を示す緑色（`#1e7e34`）を使用する。
+- 「コピー完了」のフィードバックには成功を示す緑色（`#1e7e34`）使用する。
 - ボタンには明確なARIAラベル（例：`aria-label={copied ? "コピー済み" : "エラーをコピー"}`）を付与する。
 
 ## 2025-05-23 - [Accessible Progress Indicators]

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -138,9 +138,10 @@ export default function Dashboard() {
         });
     };
 
-    const filteredRooms = stats?.rooms?.filter((room: string) =>
-        room.toLowerCase().includes(roomQuery.toLowerCase())
-    ) || [];
+    const filteredRooms =
+        stats?.rooms?.filter((room: string) =>
+            room.toLowerCase().includes(roomQuery.toLowerCase())
+        ) || [];
 
     const copyAllRooms = () => {
         if (filteredRooms.length === 0) return;
@@ -148,7 +149,11 @@ export default function Dashboard() {
         navigator.clipboard.writeText(roomsStr).then(() => {
             setCopiedAllRooms(true);
             setTimeout(() => setCopiedAllRooms(false), 2000);
-            showToast(roomQuery ? 'フィルター結果の部屋名をコピーしました' : 'すべての部屋名をコピーしました');
+            showToast(
+                roomQuery
+                    ? 'フィルター結果の部屋名をコピーしました'
+                    : 'すべての部屋名をコピーしました'
+            );
         });
     };
 
@@ -575,13 +580,21 @@ export default function Dashboard() {
                             onBlur={() => setCopyAllHover(false)}
                             aria-label={
                                 copiedAllRooms
-                                    ? (roomQuery ? 'フィルター結果をコピーしました' : 'すべての部屋名をコピーしました')
-                                    : (roomQuery ? 'フィルター結果をコピー' : 'すべての部屋名をコピー')
+                                    ? roomQuery
+                                        ? 'フィルター結果をコピーしました'
+                                        : 'すべての部屋名をコピーしました'
+                                    : roomQuery
+                                      ? 'フィルター結果をコピー'
+                                      : 'すべての部屋名をコピー'
                             }
                             title={
                                 copiedAllRooms
-                                    ? (roomQuery ? 'フィルター結果をコピーしました' : 'すべての部屋名をコピーしました')
-                                    : (roomQuery ? 'フィルター結果をコピー' : 'すべての部屋名をコピー')
+                                    ? roomQuery
+                                        ? 'フィルター結果をコピーしました'
+                                        : 'すべての部屋名をコピーしました'
+                                    : roomQuery
+                                      ? 'フィルター結果をコピー'
+                                      : 'すべての部屋名をコピー'
                             }
                             style={{
                                 fontSize: '0.75rem',
@@ -602,7 +615,11 @@ export default function Dashboard() {
                                 transform: copyAllHover ? 'scale(1.05)' : 'scale(1)',
                             }}
                         >
-                            {copiedAllRooms ? '✅ コピーしました' : (roomQuery ? '📋 結果をコピー' : '📋 すべてコピー')}
+                            {copiedAllRooms
+                                ? '✅ コピーしました'
+                                : roomQuery
+                                  ? '📋 結果をコピー'
+                                  : '📋 すべてコピー'}
                         </button>
                     )}
                     {stats?.rooms?.length > 3 && (
@@ -637,7 +654,14 @@ export default function Dashboard() {
                         />
                     )}
                     {roomQuery && filteredRooms.length === 0 && (
-                        <span style={{ fontSize: '0.75rem', color: '#e53e3e', display: 'inline-flex', alignItems: 'center' }}>
+                        <span
+                            style={{
+                                fontSize: '0.75rem',
+                                color: '#e53e3e',
+                                display: 'inline-flex',
+                                alignItems: 'center',
+                            }}
+                        >
                             一致なし
                             <button
                                 onClick={() => setRoomQuery('')}
@@ -656,46 +680,48 @@ export default function Dashboard() {
                             </button>
                         </span>
                     )}
-                    {filteredRooms.length > 0 ? (
-                        filteredRooms.map((room: string) => (
-                            <button
-                                key={room}
-                                onClick={() => copyRoom(room)}
-                                onMouseEnter={() => setHoveredRoom(room)}
-                                onMouseLeave={() => setHoveredRoom(null)}
-                                onFocus={() => setHoveredRoom(room)}
-                                onBlur={() => setHoveredRoom(null)}
-                                aria-label={
-                                    copiedRoom === room ? 'コピー済み' : `部屋名 ${room} をコピー`
-                                }
-                                title={
-                                    copiedRoom === room ? 'コピー済み' : `部屋名 ${room} をコピー`
-                                }
-                                style={{
-                                    fontSize: '0.75rem',
-                                    backgroundColor:
-                                        copiedRoom === room
-                                            ? '#c6f6d5'
-                                            : hoveredRoom === room
-                                              ? '#e2e8f0'
-                                              : '#edf2f7',
-                                    padding: '0.1rem 0.4rem',
-                                    borderRadius: '4px',
-                                    border: '1px solid #cbd5e0',
-                                    color: copiedRoom === room ? '#22543d' : '#2d3748',
-                                    cursor: 'pointer',
-                                    transition: 'all 0.2s ease-in-out',
-                                    transform: hoveredRoom === room ? 'scale(1.06)' : 'scale(1)',
-                                    boxShadow:
-                                        hoveredRoom === room ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
-                                }}
-                            >
-                                {copiedRoom === room ? `✅ ${room}` : room}
-                            </button>
-                        ))
-                    ) : (
-                        !roomQuery && <span style={{ color: '#a0aec0', fontStyle: 'italic' }}>なし</span>
-                    )}
+                    {filteredRooms.length > 0
+                        ? filteredRooms.map((room: string) => (
+                              <button
+                                  key={room}
+                                  onClick={() => copyRoom(room)}
+                                  onMouseEnter={() => setHoveredRoom(room)}
+                                  onMouseLeave={() => setHoveredRoom(null)}
+                                  onFocus={() => setHoveredRoom(room)}
+                                  onBlur={() => setHoveredRoom(null)}
+                                  aria-label={
+                                      copiedRoom === room ? 'コピー済み' : `部屋名 ${room} をコピー`
+                                  }
+                                  title={
+                                      copiedRoom === room ? 'コピー済み' : `部屋名 ${room} をコピー`
+                                  }
+                                  style={{
+                                      fontSize: '0.75rem',
+                                      backgroundColor:
+                                          copiedRoom === room
+                                              ? '#c6f6d5'
+                                              : hoveredRoom === room
+                                                ? '#e2e8f0'
+                                                : '#edf2f7',
+                                      padding: '0.1rem 0.4rem',
+                                      borderRadius: '4px',
+                                      border: '1px solid #cbd5e0',
+                                      color: copiedRoom === room ? '#22543d' : '#2d3748',
+                                      cursor: 'pointer',
+                                      transition: 'all 0.2s ease-in-out',
+                                      transform: hoveredRoom === room ? 'scale(1.06)' : 'scale(1)',
+                                      boxShadow:
+                                          hoveredRoom === room
+                                              ? '0 2px 4px rgba(0,0,0,0.1)'
+                                              : 'none',
+                                  }}
+                              >
+                                  {copiedRoom === room ? `✅ ${room}` : room}
+                              </button>
+                          ))
+                        : !roomQuery && (
+                              <span style={{ color: '#a0aec0', fontStyle: 'italic' }}>なし</span>
+                          )}
                 </div>
             </div>
             <details

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -23,6 +23,7 @@ export default function Dashboard() {
     const [toastCloseFocused, setToastCloseFocused] = useState(false);
     const [copiedAllRooms, setCopiedAllRooms] = useState(false);
     const [copyAllHover, setCopyAllHover] = useState(false);
+    const [roomQuery, setRoomQuery] = useState('');
 
     const toastTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -137,13 +138,17 @@ export default function Dashboard() {
         });
     };
 
+    const filteredRooms = stats?.rooms?.filter((room: string) =>
+        room.toLowerCase().includes(roomQuery.toLowerCase())
+    ) || [];
+
     const copyAllRooms = () => {
-        if (!stats?.rooms) return;
-        const roomsStr = stats.rooms.join(', ');
+        if (filteredRooms.length === 0) return;
+        const roomsStr = filteredRooms.join(', ');
         navigator.clipboard.writeText(roomsStr).then(() => {
             setCopiedAllRooms(true);
             setTimeout(() => setCopiedAllRooms(false), 2000);
-            showToast('すべての部屋名をクリップボードにコピーしました');
+            showToast(roomQuery ? 'フィルター結果の部屋名をコピーしました' : 'すべての部屋名をコピーしました');
         });
     };
 
@@ -570,13 +575,13 @@ export default function Dashboard() {
                             onBlur={() => setCopyAllHover(false)}
                             aria-label={
                                 copiedAllRooms
-                                    ? 'すべての部屋名をコピーしました'
-                                    : 'すべての部屋名をコピー'
+                                    ? (roomQuery ? 'フィルター結果をコピーしました' : 'すべての部屋名をコピーしました')
+                                    : (roomQuery ? 'フィルター結果をコピー' : 'すべての部屋名をコピー')
                             }
                             title={
                                 copiedAllRooms
-                                    ? 'すべての部屋名をコピーしました'
-                                    : 'すべての部屋名をコピー'
+                                    ? (roomQuery ? 'フィルター結果をコピーしました' : 'すべての部屋名をコピーしました')
+                                    : (roomQuery ? 'フィルター結果をコピー' : 'すべての部屋名をコピー')
                             }
                             style={{
                                 fontSize: '0.75rem',
@@ -597,11 +602,62 @@ export default function Dashboard() {
                                 transform: copyAllHover ? 'scale(1.05)' : 'scale(1)',
                             }}
                         >
-                            {copiedAllRooms ? '✅ すべてコピーしました' : '📋 すべてコピー'}
+                            {copiedAllRooms ? '✅ コピーしました' : (roomQuery ? '📋 結果をコピー' : '📋 すべてコピー')}
                         </button>
                     )}
-                    {stats?.rooms?.length > 0 ? (
-                        stats.rooms.map((room: string) => (
+                    {stats?.rooms?.length > 3 && (
+                        <input
+                            type="text"
+                            value={roomQuery}
+                            onChange={(e) => setRoomQuery(e.target.value)}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Escape') {
+                                    setRoomQuery('');
+                                }
+                            }}
+                            placeholder="部屋を検索..."
+                            aria-label="部屋名で検索"
+                            style={{
+                                fontSize: '0.75rem',
+                                padding: '0.15rem 0.4rem',
+                                border: '1px solid #cbd5e0',
+                                borderRadius: '4px',
+                                outline: 'none',
+                                transition: 'all 0.2s ease-in-out',
+                                width: '100px',
+                            }}
+                            onFocus={(e) => {
+                                e.currentTarget.style.borderColor = '#004b73';
+                                e.currentTarget.style.boxShadow = '0 0 0 2px rgba(0, 75, 115, 0.2)';
+                            }}
+                            onBlur={(e) => {
+                                e.currentTarget.style.borderColor = '#cbd5e0';
+                                e.currentTarget.style.boxShadow = 'none';
+                            }}
+                        />
+                    )}
+                    {roomQuery && filteredRooms.length === 0 && (
+                        <span style={{ fontSize: '0.75rem', color: '#e53e3e', display: 'inline-flex', alignItems: 'center' }}>
+                            一致なし
+                            <button
+                                onClick={() => setRoomQuery('')}
+                                style={{
+                                    marginLeft: '0.25rem',
+                                    fontSize: '0.75rem',
+                                    color: '#004b73',
+                                    background: 'none',
+                                    border: 'none',
+                                    cursor: 'pointer',
+                                    textDecoration: 'underline',
+                                    padding: 0,
+                                }}
+                            >
+                                クリア
+                            </button>
+                        </span>
+                    )}
+                    {filteredRooms.length > 0 ? (
+                        filteredRooms.map((room: string) => (
                             <button
                                 key={room}
                                 onClick={() => copyRoom(room)}
@@ -638,7 +694,7 @@ export default function Dashboard() {
                             </button>
                         ))
                     ) : (
-                        <span style={{ color: '#a0aec0', fontStyle: 'italic' }}>なし</span>
+                        !roomQuery && <span style={{ color: '#a0aec0', fontStyle: 'italic' }}>なし</span>
                     )}
                 </div>
             </div>

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 What: Adds an interactive room search filter input to the active rooms section, with dynamic "Copy Results" button coordination, Escape key to clear, and clear empty feedback.
🎯 Why: Users with many Screeps rooms can quickly search/filter them and copy only the subset of rooms they care about.
♿ Accessibility: Leverages fully accessible search input markup, responsive outline transitions on focus, dynamic ARIA labels/titles synchronizing with the filter state, and keyboard support (Escape key).

---
*PR created automatically by Jules for task [12531344491947603984](https://jules.google.com/task/12531344491947603984) started by @tadanobutubutu*

## Summary by Sourcery

Add an interactive room search filter to the dashboard and coordinate bulk copy behavior and accessibility feedback with the filtered results.

New Features:
- Introduce a room search input for active rooms with Escape-to-clear behavior and empty-result feedback.
- Enable copying only the filtered subset of rooms via the existing bulk copy button.

Enhancements:
- Update copy-all button labels, titles, and toast messages to reflect whether all rooms or filtered results are being copied, improving clarity and accessibility.

Build:
- Normalize import style in Next.js TypeScript environment configuration.

Documentation:
- Document the pattern of coordinating search filters with bulk actions and accessibility labels in Palette's UX journal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a room search filter to the dashboard and updates "Copy All" to copy only the visible (filtered) rooms. Speeds up room management and reduces confusion, with clear labels and keyboard support.

- **New Features**
  - Search input appears when there are 3+ rooms; filters names in real time (case-insensitive) and clears on Escape.
  - "Copy All" now copies only filtered rooms; button text, tooltips, ARIA labels, and toasts reflect all vs. filtered state.
  - "No results" message with a quick clear action when the filter has no matches.
  - Copy action is disabled when nothing matches; empty state remains unchanged when no filter is applied.

<sup>Written for commit 942754eb7551b4817b850303259daaa1b028a58c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/4239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

