### PR TITLE
Add clear button to room search input

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -643,7 +643,9 @@ export default function Dashboard() {
                                 aria-label="部屋名で検索"
                                 style={{
                                     fontSize: '0.75rem',
-                                    padding: roomQuery ? '0.15rem 1.4rem 0.15rem 0.4rem' : '0.15rem 0.4rem',
+                                    padding: roomQuery
+                                        ? '0.15rem 1.4rem 0.15rem 0.4rem'
+                                        : '0.15rem 0.4rem',
                                     border: '1px solid #cbd5e0',
                                     borderRadius: '4px',
                                     outline: 'none',
@@ -652,7 +654,8 @@ export default function Dashboard() {
                                 }}
                                 onFocus={(e) => {
                                     e.currentTarget.style.borderColor = '#004b73';
-                                    e.currentTarget.style.boxShadow = '0 0 0 2px rgba(0, 75, 115, 0.2)';
+                                    e.currentTarget.style.boxShadow =
+                                        '0 0 0 2px rgba(0, 75, 115, 0.2)';
                                 }}
                                 onBlur={(e) => {
                                     e.currentTarget.style.borderColor = '#cbd5e0';

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -623,35 +623,89 @@ export default function Dashboard() {
                         </button>
                     )}
                     {stats?.rooms?.length > 3 && (
-                        <input
-                            type="text"
-                            value={roomQuery}
-                            onChange={(e) => setRoomQuery(e.target.value)}
-                            onKeyDown={(e) => {
-                                if (e.key === 'Escape') {
-                                    setRoomQuery('');
-                                }
-                            }}
-                            placeholder="部屋を検索..."
-                            aria-label="部屋名で検索"
+                        <div
                             style={{
-                                fontSize: '0.75rem',
-                                padding: '0.15rem 0.4rem',
-                                border: '1px solid #cbd5e0',
-                                borderRadius: '4px',
-                                outline: 'none',
-                                transition: 'all 0.2s ease-in-out',
-                                width: '100px',
+                                position: 'relative',
+                                display: 'inline-flex',
+                                alignItems: 'center',
                             }}
-                            onFocus={(e) => {
-                                e.currentTarget.style.borderColor = '#004b73';
-                                e.currentTarget.style.boxShadow = '0 0 0 2px rgba(0, 75, 115, 0.2)';
-                            }}
-                            onBlur={(e) => {
-                                e.currentTarget.style.borderColor = '#cbd5e0';
-                                e.currentTarget.style.boxShadow = 'none';
-                            }}
-                        />
+                        >
+                            <input
+                                type="text"
+                                value={roomQuery}
+                                onChange={(e) => setRoomQuery(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key === 'Escape') {
+                                        setRoomQuery('');
+                                    }
+                                }}
+                                placeholder="部屋を検索..."
+                                aria-label="部屋名で検索"
+                                style={{
+                                    fontSize: '0.75rem',
+                                    padding: roomQuery ? '0.15rem 1.4rem 0.15rem 0.4rem' : '0.15rem 0.4rem',
+                                    border: '1px solid #cbd5e0',
+                                    borderRadius: '4px',
+                                    outline: 'none',
+                                    transition: 'all 0.2s ease-in-out',
+                                    width: '100px',
+                                }}
+                                onFocus={(e) => {
+                                    e.currentTarget.style.borderColor = '#004b73';
+                                    e.currentTarget.style.boxShadow = '0 0 0 2px rgba(0, 75, 115, 0.2)';
+                                }}
+                                onBlur={(e) => {
+                                    e.currentTarget.style.borderColor = '#cbd5e0';
+                                    e.currentTarget.style.boxShadow = 'none';
+                                }}
+                            />
+                            {roomQuery && (
+                                <button
+                                    onClick={() => setRoomQuery('')}
+                                    aria-label="検索キーワードをクリア"
+                                    title="検索をクリア"
+                                    style={{
+                                        position: 'absolute',
+                                        right: '4px',
+                                        background: 'none',
+                                        border: 'none',
+                                        color: '#718096',
+                                        cursor: 'pointer',
+                                        padding: '0.1rem',
+                                        display: 'inline-flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        fontSize: '0.7rem',
+                                        lineHeight: 1,
+                                        borderRadius: '50%',
+                                        width: '14px',
+                                        height: '14px',
+                                        transition: 'background-color 0.1s, color 0.1s',
+                                        outline: 'none',
+                                    }}
+                                    onMouseEnter={(e) => {
+                                        e.currentTarget.style.backgroundColor = '#cbd5e0';
+                                        e.currentTarget.style.color = '#2d3748';
+                                    }}
+                                    onMouseLeave={(e) => {
+                                        e.currentTarget.style.backgroundColor = 'transparent';
+                                        e.currentTarget.style.color = '#718096';
+                                    }}
+                                    onFocus={(e) => {
+                                        e.currentTarget.style.backgroundColor = '#cbd5e0';
+                                        e.currentTarget.style.color = '#2d3748';
+                                        e.currentTarget.style.outline = '1px solid #004b73';
+                                    }}
+                                    onBlur={(e) => {
+                                        e.currentTarget.style.backgroundColor = 'transparent';
+                                        e.currentTarget.style.color = '#718096';
+                                        e.currentTarget.style.outline = 'none';
+                                    }}
+                                >
+                                    ✕
+                                </button>
+                            )}
+                        </div>
                     )}
                     {roomQuery && filteredRooms.length === 0 && (
                         <span

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
🎨 Palette: Add Clear Button to Room Search Input
💡 What: Added an accessible clear button to the room search input on the Screeps dashboard.
🎯 Why: Solves the issue where visual or keyboard-only users would have to manually backspace or select all text to clear the room search filter.
♿ Accessibility: Provided with aria-label="検索キーワードをクリア" and explicit keyboard focus indicators (outline on focus).

---
*PR created automatically by Jules for task [4337783371500799234](https://jules.google.com/task/4337783371500799234) started by @tadanobutubutu*

## Summary by Sourcery

Add an accessible clear button to the room search input on the dashboard and make a minor TypeScript config style adjustment.

New Features:
- Provide a clear button for the room search input that resets the query and improves accessibility for keyboard and screen-reader users.

Enhancements:
- Wrap the room search input in a container to accommodate the clear button and adjust input padding when a query is present.

Chores:
- Normalize import string quotes in the Next.js TypeScript environment definition file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a clear (✕) button to the Dashboard room search input so users can quickly reset their query. The button appears only when there’s text and keeps the Escape-to-clear behavior.

- **New Features**
  - Inline clear button inside the input with hover/focus styles and smooth transitions.
  - Adjusted input padding and layout using a relative container.
  - Accessible with `aria-label` and `title`; click clears the query.

<sup>Written for commit bc294f9f8032018332fc0c9a2a01eb67855df4f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/4445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

