### PR TITLE
Add Alt+S keyboard shortcut to focus search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,10 @@
 # Palette's Journal - Screeps Dashboard UX/Accessibility
 
+## 2026-08-08 - [Keyboard Shortcut Hint & Focus for Input Navigation]
+
+**Learning:** When introducing keyboard shortcuts for interactive form controls (such as using `Alt + S` to focus a search input), we must display a corresponding, accessible `<kbd>` badge adjacent to the element. Equipping the badge with explicit `tabIndex={0}`, descriptive `title`, and highly clear ARIA descriptors (e.g., `aria-label="キーボードショートカット Alt + S キーで部屋の検索入力にフォーカスできます"`) makes keyboard shortcuts easily discoverable for both visual and screen-reader users, fully satisfying WCAG 2.1.1 (Keyboard Accessibility).
+**Action:** Always document keyboard shortcuts with a highly visible `<kbd>` component next to the targeted control, pairing it with consistent focusable hints and comprehensive screen-reader metadata.
+
 ## 2026-08-07 - [Dynamic Search Filtering & Bulk Actions Coordination]
 
 **Learning:** When adding client-side search or filter inputs to groups of dynamic telemetry items (such as a list of active Screeps rooms), any adjacent bulk actions (such as "Copy All") must be contextually updated to reflect the filter state. Dynamically changing the action's behavior to copy only the filtered subset, and synchronizing its labels, tooltips, ARIA descriptors, and completion toasts, prevents user confusion and satisfies WCAG 2.1.1 (Keyboard Accessibility) and 2.4.4 (Link Purpose/Context).

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -26,6 +26,7 @@ export default function Dashboard() {
     const [roomQuery, setRoomQuery] = useState('');
 
     const toastTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const searchInputRef = useRef<HTMLInputElement>(null);
 
     const showToast = (msg: string) => {
         if (toastTimeoutRef.current) {
@@ -94,20 +95,22 @@ export default function Dashboard() {
 
     useEffect(() => {
         const handleKeyDown = (e: KeyboardEvent) => {
-            // Only trigger if no input/textarea is focused and Alt+R is pressed
-            // Using Alt+R to comply with WCAG 2.1.4 (avoiding single-key shortcuts)
+            // Using Alt key combinations to comply with WCAG 2.1.4 (avoiding single-key shortcuts)
             if (
                 e.altKey &&
-                e.key.toLowerCase() === 'r' &&
-                !refreshing &&
                 !(
                     e.target instanceof HTMLInputElement ||
                     e.target instanceof HTMLTextAreaElement ||
                     (e.target as HTMLElement).isContentEditable
                 )
             ) {
-                e.preventDefault();
-                fetchStats(true);
+                if (e.key.toLowerCase() === 'r' && !refreshing) {
+                    e.preventDefault();
+                    fetchStats(true);
+                } else if (e.key.toLowerCase() === 's') {
+                    e.preventDefault();
+                    searchInputRef.current?.focus();
+                }
             }
         };
         window.addEventListener('keydown', handleKeyDown);
@@ -628,9 +631,29 @@ export default function Dashboard() {
                                 position: 'relative',
                                 display: 'inline-flex',
                                 alignItems: 'center',
+                                gap: '0.35rem',
                             }}
                         >
+                            <kbd
+                                className="interactive-hint"
+                                tabIndex={0}
+                                aria-label="キーボードショートカット Alt + S キーで部屋の検索入力にフォーカスできます"
+                                title="Alt + S キーで検索入力にフォーカスできます"
+                                style={{
+                                    backgroundColor: '#f7fafc',
+                                    border: '1px solid #cbd5e0',
+                                    borderRadius: '4px',
+                                    padding: '0.1rem 0.4rem',
+                                    fontSize: '0.7rem',
+                                    color: '#4a5568',
+                                    boxShadow: '0 1px 1px rgba(0,0,0,0.1)',
+                                    cursor: 'help',
+                                }}
+                            >
+                                Alt + S
+                            </kbd>
                             <input
+                                ref={searchInputRef}
                                 type="text"
                                 value={roomQuery}
                                 onChange={(e) => setRoomQuery(e.target.value)}

--- a/dashboard/next-env.d.ts
+++ b/dashboard/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
💡 **What:** Added an accessible keyboard shortcut (`Alt + S`) to quickly focus the Screeps Room Search input field when the list of active rooms is large. Introduced a styled, interactive `<kbd>` keyboard badge next to the input to inform users of the shortcut.

🎯 **Why:** Highly populated dashboards can be tedious to navigate with a mouse. Providing a fast, keyboard-first mechanism to focus the search input enhances visual control, speeds up filtering, and makes the dashboard highly responsive and pleasant for power users.

♿ **Accessibility:**
- Followed WCAG 2.1.4 (Character Key Shortcuts) by using a multi-key combo (`Alt + S`) rather than single-key letters to prevent accidental activation and conflicts with assistive technologies.
- Equipped the keyboard shortcut badge with explicit `tabIndex={0}`, a clear hover tooltip, and detailed screen-reader metadata (`aria-label="キーボードショートカット Alt + S キーで部屋の検索入力にフォーカスできます"`) to ensure full discoverability and accessibility for keyboard and screen-reader users.

---
*PR created automatically by Jules for task [13247923224204168963](https://jules.google.com/task/13247923224204168963) started by @tadanobutubutu*

## Summary by Sourcery

Add an Alt+S keyboard shortcut to focus the Screeps room search input and surface an accessible visual hint for the shortcut adjacent to the search field.

New Features:
- Introduce an Alt+S keyboard shortcut that focuses the room search input when no text field is currently active.
- Display an accessible, styled <kbd> badge next to the search input to advertise the Alt+S shortcut.

Enhancements:
- Generalize the Alt-key keyboard handler to support multiple shortcuts while respecting WCAG guidance.
- Document the keyboard shortcut and associated accessibility practices in Palette's UX/accessibility journal.

Chores:
- Normalize import quoting in the Next.js TypeScript env configuration file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Alt+S shortcut to focus the room search input in the Dashboard, improving keyboard navigation and discoverability. Also consolidates Alt-key shortcuts while keeping Alt+R refresh behavior.

- **New Features**
  - `Alt+S` focuses the search input (via `searchInputRef`) when not typing in a field.
  - Visible <kbd>Alt + S</kbd> hint with `tabIndex={0}`, Japanese `aria-label`, and `title`.
  - Consolidated Alt key handling; `Alt+R` refresh remains supported.
  - Complies with WCAG 2.1.4 (no single-key shortcuts) and strengthens 2.1.1 keyboard access.

<sup>Written for commit 74a9f81704dbc7da18f133eded57d3c7ab51ccd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/4689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

