### PR TITLE
Cache static terrain mining spots by source ID in miner role

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -87,3 +87,8 @@
 - 🧪 **Testing Improvement:** When creating test suites for script files that run logic in the global scope directly on load (e.g., `patch_main.js`), refactoring the main execution logic into a named function and exporting it (e.g., `module.exports = runPatch;`) prevents unintended automatic execution when required by the test framework (e.g., Jest). The script can still support direct execution by checking `if (require.main === module)`.
 
 - **Tower Target Optimization:** In `findTowerTargets` (`utils.defense.js`), iterating over all structures to filter for damaged ones can be expensive. Replacing multiple `.filter()` calls with a single `for` loop eliminates intermediate array allocations and reduces loop iterations by half.
+
+## 2026-08-04 - Caching Static Terrain Mining Spots in Miner Roles
+
+**Learning:** Periodically scanning the surrounding terrain coordinates of a source to determine the available mining spots (or terrain wall tiles) on every miner assignment loop introduces redundant CPU and lookup overhead. Since the map terrain and source coordinates are completely static, caching this calculated count per source ID avoids redundant `getTerrain()` calls.
+**Action:** Implemented a persistent module-level dictionary (`_miningSpotsCache`) inside `src/roles/miner.js` to cache the mining spot counts.

--- a/src/roles/miner.js
+++ b/src/roles/miner.js
@@ -143,12 +143,18 @@ function _findBestSource(sources, minerCounts) {
     return bestSource;
 }
 
+// Persistent module-level cache for mining spot counts by source ID to avoid redundant terrain scanning
+const _miningSpotsCache = Object.create(null);
+
 /**
  * ソース周囲の採掘可能スポット数を計算する
  * @param {Source} source
  * @returns {number} 1〜3
  */
 function _countMiningSpots(source) {
+    if (_miningSpotsCache[source.id] !== undefined) {
+        return _miningSpotsCache[source.id];
+    }
     const room = source.room;
     const terrain = room.getTerrain();
     let count = 0;
@@ -169,7 +175,9 @@ function _countMiningSpots(source) {
         }
     }
 
-    return Math.min(count, 3);
+    const result = Math.min(count, 3);
+    _miningSpotsCache[source.id] = result;
+    return result;
 }
 
 // ============================================================

--- a/tests/src.roles.miner.test.js
+++ b/tests/src.roles.miner.test.js
@@ -1003,5 +1003,44 @@ describe('src/roles/miner', () => {
             miner.run(creep);
             expect(creep.repair).toHaveBeenCalledWith(container);
         });
+
+        test('_countMiningSpots caches terrain results by source ID to avoid redundant getTerrain calls', () => {
+            const source1 = { id: 'cache_test_s1', room: roomMock, pos: new RoomPosition(5, 5, 'W0N0') };
+            cache.getSources.mockReturnValue([source1]);
+            cache.getMyCreeps.mockReturnValue([]);
+            cache.isSafeKey.mockReturnValue(true);
+
+            const mockTerrain = {
+                get: jest.fn().mockReturnValue(0),
+            };
+            roomMock.getTerrain.mockReturnValue(mockTerrain);
+
+            const creep1 = {
+                name: 'c1',
+                memory: {},
+                room: roomMock,
+                pos: new RoomPosition(0, 0, 'W0N0'),
+                harvest: jest.fn(),
+                store: { getFreeCapacity: jest.fn().mockReturnValue(50) },
+            };
+            global.Game.getObjectById.mockReturnValue(null);
+            cache.getContainers.mockReturnValue([]);
+
+            miner.run(creep1);
+            expect(roomMock.getTerrain).toHaveBeenCalledTimes(1);
+
+            // Run assignment again with a second creep
+            const creep2 = {
+                name: 'c2',
+                memory: {},
+                room: roomMock,
+                pos: new RoomPosition(0, 0, 'W0N0'),
+                harvest: jest.fn(),
+                store: { getFreeCapacity: jest.fn().mockReturnValue(50) },
+            };
+            miner.run(creep2);
+            // getTerrain should not have been called a second time because of the cache!
+            expect(roomMock.getTerrain).toHaveBeenCalledTimes(1);
+        });
     });
 });


### PR DESCRIPTION
💡 What: Cached the static terrain mining spots per source in a persistent module-level dictionary inside the miner role.
🎯 Why: Terrain is static and never changes. Redundant calls to `room.getTerrain` on every tick inside assignment loops cause high CPU overhead.
📊 Impact: Bypasses redundant terrain lookups, reducing assignment loop overhead to O(1) after first computation.
🔬 Measurement: Covered by a dedicated unit test verifying terrain is queried exactly once.

---
*PR created automatically by Jules for task [16214009028278611404](https://jules.google.com/task/16214009028278611404) started by @tadanobutubutu*

## Summary by Sourcery

Cache computed mining spot counts per source in the miner role to avoid repeated terrain lookups.

Enhancements:
- Introduce a module-level dictionary to persist mining spot counts per source ID and reuse them across miner assignments.

Documentation:
- Document the terrain caching approach and rationale in the Bolt performance notes.

Tests:
- Add a unit test ensuring miner terrain is queried only once per source and reused across multiple creeps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache mining spot counts per source in the miner role to avoid repeated `room.getTerrain()` calls. This reduces CPU in assignment loops and makes lookups O(1) after the first scan.

- **Refactors**
  - Added a module-level cache `'_miningSpotsCache'` keyed by source ID.
  - `_countMiningSpots` returns cached values and stores results after first computation.
  - Added a unit test to ensure `room.getTerrain` runs only once per source.

<sup>Written for commit 118de7183250285f7a1945874eefde152fd2804c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/4690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved miner assignment performance by avoiding repeated terrain calculations for the same mining source.
  * Preserved consistent mining-spot counts when multiple miners use the same source.

* **Tests**
  * Added regression coverage to verify that terrain data is calculated only once per mining source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->