### PR TITLE
🎨 Palette: Improve discoverability and ARIA accessibility of interactive components

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,5 +1,9 @@
 # Palette's Journal - Screeps Dashboard UX/Accessibility
 
+## 2026-08-09 - [Dynamic Attribute Synchronization & Keyboard Hints]
+**Learning:** When using components that display interactive info/tooltips via a `title` attribute, duplicating the description in an explicit `aria-label` attribute guarantees that screen readers vocalize the dynamic metadata. Additionally, indicating keyboard controls (e.g. 'Esc' to clear a search input) directly inside the `placeholder` text greatly improves feature discoverability.
+**Action:** Always provide matching `aria-label` tags for hover-only tooltips on non-standard interactive structures, and explicitly hint at keyboard shortcuts inside placeholder text.
+
 ## 2026-08-08 - [Keyboard Shortcut Hint & Focus for Input Navigation]
 
 **Learning:** When introducing keyboard shortcuts for interactive form controls (such as using `Alt + S` to focus a search input), we must display a corresponding, accessible `<kbd>` badge adjacent to the element. Equipping the badge with explicit `tabIndex={0}`, descriptive `title`, and highly clear ARIA descriptors (e.g., `aria-label="キーボードショートカット Alt + S キーで部屋の検索入力にフォーカスできます"`) makes keyboard shortcuts easily discoverable for both visual and screen-reader users, fully satisfying WCAG 2.1.1 (Keyboard Accessibility).

--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -308,6 +308,7 @@ export default function Dashboard() {
                             className="interactive-hint"
                             tabIndex={0}
                             title="最後にデータが更新された時間です"
+                            aria-label="最後にデータが更新された時間です"
                             style={{ fontSize: '0.8rem', color: '#718096' }}
                         >
                             🕒 {lastUpdated.toLocaleTimeString()}
@@ -440,6 +441,7 @@ export default function Dashboard() {
                     className="interactive-hint"
                     tabIndex={0}
                     title={`GCL ${stats?.gcl?.level || 0} 進捗: ${stats?.gcl?.progress || 0} / ${stats?.gcl?.progressTotal || 0}`}
+                    aria-label={`GCL ${stats?.gcl?.level || 0} 進捗: ${stats?.gcl?.progress || 0} / ${stats?.gcl?.progressTotal || 0}`}
                 >
                     <div
                         style={{
@@ -501,6 +503,7 @@ export default function Dashboard() {
                     className="interactive-hint"
                     tabIndex={0}
                     title={`CPU 使用率: ${stats?.cpuUsed?.toFixed(2) || '0.00'} / 100 (Screeps の基本制限: 100)`}
+                    aria-label={`CPU 使用率: ${stats?.cpuUsed?.toFixed(2) || '0.00'} / 100 (Screeps の基本制限: 100)`}
                 >
                     <div
                         style={{
@@ -551,6 +554,7 @@ export default function Dashboard() {
                         <p
                             className="interactive-hint"
                             title="グローバルパワーレベル (GPL) です"
+                            aria-label="グローバルパワーレベル (GPL) です"
                             tabIndex={0}
                             style={{ margin: 0 }}
                         >
@@ -570,6 +574,7 @@ export default function Dashboard() {
                         className="interactive-hint"
                         tabIndex={0}
                         title="AI が現在活動している部屋のリストです"
+                        aria-label="AI が現在活動している部屋のリストです"
                     >
                         🏘️ {stats?.rooms?.length === 1 ? '部屋' : '部屋数'} (
                         {stats?.rooms?.length || 0}):
@@ -662,7 +667,7 @@ export default function Dashboard() {
                                         setRoomQuery('');
                                     }
                                 }}
-                                placeholder="部屋を検索..."
+                                placeholder="部屋を検索... (Escでクリア)"
                                 aria-label="部屋名で検索"
                                 style={{
                                     fontSize: '0.75rem',
@@ -811,6 +816,7 @@ export default function Dashboard() {
                 <summary
                     className="interactive-hint"
                     title="生データを JSON 形式で表示/非表示にします"
+                    aria-label="生データを JSON 形式で表示/非表示にします"
                     style={{
                         color: '#4a5568',
                         padding: '0.2rem 0',


### PR DESCRIPTION
💡 What: Improved keyboard/discoverability cue and added ARIA labels to .interactive-hint elements
🎯 Why: Tooltip titles were not announced to screen readers and Escape clear shortcut was not discoverable
♿ Accessibility: Added explicit ARIA labels mirroring tooltip title metadata

---
*PR created automatically by Jules for task [2322694854847861650](https://jules.google.com/task/2322694854847861650) started by @tadanobutubutu*