### PR TITLE
Add Alt+D keyboard shortcut to toggle raw JSON data display

### DIFF
--- a/dashboard/components/Dashboard.tsx
+++ b/dashboard/components/Dashboard.tsx
@@ -111,6 +111,9 @@ export default function Dashboard() {
                 } else if (e.key.toLowerCase() === 's') {
                     e.preventDefault();
                     searchInputRef.current?.focus();
+                } else if (e.key.toLowerCase() === 'd') {
+                    e.preventDefault();
+                    setDetailsOpen((prev) => !prev);
                 }
             }
         };
@@ -812,89 +815,117 @@ export default function Dashboard() {
                           )}
                 </div>
             </div>
-            <details
-                onToggle={(e) => setDetailsOpen((e.target as HTMLDetailsElement).open)}
-                style={{ border: 'none' }}
+            <div
+                style={{
+                    display: 'flex',
+                    alignItems: 'flex-start',
+                    gap: '0.5rem',
+                }}
             >
-                <summary
+                <kbd
                     className="interactive-hint"
-                    title="生データを JSON 形式で表示/非表示にします"
-                    aria-label="生データを JSON 形式で表示/非表示にします"
+                    tabIndex={0}
+                    aria-label="キーボードショートカット Alt + D キーで生データの表示・非表示を切り替えられます"
+                    title="Alt + D キーで表示・非表示を切り替えられます"
                     style={{
+                        backgroundColor: '#f7fafc',
+                        border: '1px solid #cbd5e0',
+                        borderRadius: '4px',
+                        padding: '0.1rem 0.4rem',
+                        fontSize: '0.7rem',
                         color: '#4a5568',
-                        padding: '0.2rem 0',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '0.4rem',
+                        boxShadow: '0 1px 1px rgba(0,0,0,0.1)',
+                        cursor: 'help',
+                        marginTop: '0.15rem',
                     }}
                 >
-                    <span
+                    Alt + D
+                </kbd>
+                <details
+                    open={detailsOpen}
+                    onToggle={(e) => setDetailsOpen((e.target as HTMLDetailsElement).open)}
+                    style={{ border: 'none' }}
+                >
+                    <summary
+                        className="interactive-hint"
+                        title="生データを JSON 形式で表示/非表示にします"
+                        aria-label="生データを JSON 形式で表示/非表示にします"
                         style={{
-                            display: 'inline-block',
-                            transition: 'transform 0.2s ease-in-out',
-                            transform: detailsOpen ? 'rotate(90deg)' : 'rotate(0deg)',
-                            fontSize: '0.75rem',
+                            color: '#4a5568',
+                            padding: '0.2rem 0',
+                            cursor: 'pointer',
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: '0.4rem',
                         }}
                     >
-                        ▶
-                    </span>
-                    <span>生データを確認</span>
-                </summary>
-                <div
-                    style={{
-                        marginTop: '0.5rem',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '0.5rem',
-                    }}
-                >
-                    <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
-                        <button
-                            onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                copyRawData();
-                            }}
-                            onMouseEnter={() => setJsonHover(true)}
-                            onMouseLeave={() => setJsonHover(false)}
-                            onFocus={() => setJsonHover(true)}
-                            onBlur={() => setJsonHover(false)}
-                            aria-label={copiedJson ? 'コピー済み' : '生データをJSONとしてコピー'}
-                            title={copiedJson ? 'コピー済み' : 'JSONをコピー'}
+                        <span
                             style={{
+                                display: 'inline-block',
+                                transition: 'transform 0.2s ease-in-out',
+                                transform: detailsOpen ? 'rotate(90deg)' : 'rotate(0deg)',
                                 fontSize: '0.75rem',
-                                padding: '0.3rem 0.6rem',
-                                backgroundColor: copiedJson
-                                    ? '#155d27'
-                                    : jsonHover
-                                      ? '#e2e8f0'
-                                      : '#edf2f7',
-                                border: '1px solid #cbd5e0',
-                                borderRadius: '4px',
-                                color: copiedJson ? 'white' : '#4a5568',
-                                cursor: 'pointer',
-                                transition: 'all 0.2s ease-in-out',
-                                transform: jsonHover ? 'scale(1.05)' : 'scale(1)',
-                                boxShadow: jsonHover ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
                             }}
                         >
-                            {copiedJson ? '✅ コピー済み' : '📋 JSONをコピー'}
-                        </button>
-                    </div>
-                    <pre
+                            ▶
+                        </span>
+                        <span>生データを確認</span>
+                    </summary>
+                    <div
                         style={{
-                            backgroundColor: '#f7fafc',
-                            padding: '1rem',
-                            borderRadius: '4px',
-                            margin: 0,
-                            overflow: 'auto',
+                            marginTop: '0.5rem',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '0.5rem',
                         }}
                     >
-                        {JSON.stringify(stats, null, 2)}
-                    </pre>
-                </div>
-            </details>
+                        <div style={{ display: 'flex', justifyContent: 'flex-start' }}>
+                            <button
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    copyRawData();
+                                }}
+                                onMouseEnter={() => setJsonHover(true)}
+                                onMouseLeave={() => setJsonHover(false)}
+                                onFocus={() => setJsonHover(true)}
+                                onBlur={() => setJsonHover(false)}
+                                aria-label={copiedJson ? 'コピー済み' : '生データをJSONとしてコピー'}
+                                title={copiedJson ? 'コピー済み' : 'JSONをコピー'}
+                                style={{
+                                    fontSize: '0.75rem',
+                                    padding: '0.3rem 0.6rem',
+                                    backgroundColor: copiedJson
+                                        ? '#155d27'
+                                        : jsonHover
+                                          ? '#e2e8f0'
+                                          : '#edf2f7',
+                                    border: '1px solid #cbd5e0',
+                                    borderRadius: '4px',
+                                    color: copiedJson ? 'white' : '#4a5568',
+                                    cursor: 'pointer',
+                                    transition: 'all 0.2s ease-in-out',
+                                    transform: jsonHover ? 'scale(1.05)' : 'scale(1)',
+                                    boxShadow: jsonHover ? '0 2px 4px rgba(0,0,0,0.1)' : 'none',
+                                }}
+                            >
+                                {copiedJson ? '✅ コピー済み' : '📋 JSONをコピー'}
+                            </button>
+                        </div>
+                        <pre
+                            style={{
+                                backgroundColor: '#f7fafc',
+                                padding: '1rem',
+                                borderRadius: '4px',
+                                margin: 0,
+                                overflow: 'auto',
+                            }}
+                        >
+                            {JSON.stringify(stats, null, 2)}
+                        </pre>
+                    </div>
+                </details>
+            </div>
             {toastMsg && (
                 <div
                     key={toastMsg}


### PR DESCRIPTION
💡 What: Added Alt + D keyboard shortcut to toggle raw JSON data details.
🎯 Why: Enhances accessibility and usability for keyboard-only users.
♿ Accessibility: Added focusable kbd indicator with descriptive aria-label.

---
*PR created automatically by Jules for task [12400170346589496127](https://jules.google.com/task/12400170346589496127) started by @tadanobutubutu*

## Summary by Sourcery

Add a keyboard-accessible way to toggle display of raw JSON data details on the dashboard.

New Features:
- Introduce Alt+D keyboard shortcut to open and close the raw JSON details section.
- Display a focusable kbd hint describing the Alt+D shortcut near the raw JSON details toggle.

Enhancements:
- Bind the raw JSON details <details> component to the existing detailsOpen state for consistent programmatic control.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Alt+D keyboard shortcut to toggle the raw JSON details panel in the Dashboard. Improves keyboard navigation and shows a small “Alt + D” hint next to the panel.

- **New Features**
  - Alt+D toggles the JSON details by updating `detailsOpen`.
  - Added a visible “Alt + D” <kbd> hint with aria-label and tooltip.
  - Wrapped the details section in a small flex layout to place the hint alongside the summary.

<sup>Written for commit 9e3fb2f83d369d9bfe3688721f82ac4bd7f6da48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/5214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

