### PR TITLE
Restore secure console logging output

### DIFF
--- a/utils.logging.js
+++ b/utils.logging.js
@@ -139,7 +139,8 @@ function log(arg1, arg2) {
         ? LOG_EMOJIS[level]
         : DEFAULT_EMOJI;
     const escaped = _escapeHTML(redacted);
-    }
+    console.log(`${emoji} [${level}] ${escaped}`);
+}
 
 function error(msg) {
     log(msg, 'error');


### PR DESCRIPTION
This PR fixes a critical bug in the logging utility where console output was being suppressed due to a misplaced closing brace.

**Changes:**
- Restored the `console.log()` statement that was accidentally removed or commented out in the `log()` function
- Fixed syntax error caused by an orphaned closing brace that was preventing proper function execution
- The logging function now correctly outputs formatted messages with emoji, log level, and escaped HTML content

**Impact:**
This fix restores the ability to output secure, formatted log messages to the console, which is essential for debugging and monitoring application behavior.

## Summary by Sourcery

Bug Fixes:
- Fix suppression of console output in the log() function by reinstating the console.log call and correcting a misplaced closing brace.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores secure console logging by fixing an orphaned brace and re-adding the `console.log` call in `log()`. Messages now print with emoji, level, and escaped HTML as intended.

<sup>Written for commit ba9bff5ce8b7b0711a1fe8ce0456b4e0c6f1e6a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tadanobutubutu/screeps/pull/5364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

